### PR TITLE
Refactor asdf and zsh_setup roles for macOS support

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -1,3 +1,4 @@
+---
 name: Molecule Test
 on:
   pull_request:

--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -81,7 +81,7 @@ jobs:
 
       - name: ${{ matrix.name }}
         run: molecule test
-        working-directory: ${{ matrix.path }}/molecule/default
+        working-directory: ${{ matrix.path }}
         env:
           PY_COLORS: "1"
           ANSIBLE_FORCE_COLOR: "1"

--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -1,4 +1,3 @@
----
 name: Molecule Test
 on:
   pull_request:
@@ -52,6 +51,13 @@ jobs:
 
   playbook_test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: "Playbook Test - attack-box"
+            path: "playbooks/attack-box"
+          - name: "Playbook Test - workstation"
+            path: "playbooks/workstation"
     steps:
       - name: Checkout code
         uses: actions/checkout@v3.6.0
@@ -73,9 +79,9 @@ jobs:
           mkdir -p ~/.ansible/collections/ansible_collections/cowdogmoo
           ln -s $PWD ~/.ansible/collections/ansible_collections/cowdogmoo/workstation
 
-      - name: Playbooks Tests
+      - name: ${{ matrix.name }}
         run: molecule test
-        working-directory: playbooks
+        working-directory: ${{ matrix.path }}/molecule/default
         env:
           PY_COLORS: "1"
           ANSIBLE_FORCE_COLOR: "1"

--- a/playbooks/workstation/group_vars/all.yml
+++ b/playbooks/workstation/group_vars/all.yml
@@ -1,0 +1,8 @@
+---
+home_path: >-
+  {{
+    '/Users' if ansible_os_family == 'Darwin' and ansible_user_id != 'root'
+    else '/var/root' if ansible_os_family == 'Darwin' and ansible_user_id == 'root'
+    else '/root' if ansible_user_id == 'root'
+    else '/home'
+  }}

--- a/playbooks/workstation/group_vars/all.yml
+++ b/playbooks/workstation/group_vars/all.yml
@@ -1,8 +1,0 @@
----
-home_path: >-
-  {{
-    '/Users' if ansible_os_family == 'Darwin' and ansible_user_id != 'root'
-    else '/var/root' if ansible_os_family == 'Darwin' and ansible_user_id == 'root'
-    else '/root' if ansible_user_id == 'root'
-    else '/home'
-  }}

--- a/playbooks/workstation/inventory
+++ b/playbooks/workstation/inventory
@@ -1,0 +1,2 @@
+[local]
+localhost ansible_connection=local

--- a/playbooks/workstation/inventory
+++ b/playbooks/workstation/inventory
@@ -1,2 +1,2 @@
-[local]
+[all]
 localhost ansible_connection=local

--- a/playbooks/workstation/molecule/default/converge.yml
+++ b/playbooks/workstation/molecule/default/converge.yml
@@ -2,7 +2,6 @@
 - name: Converge
   hosts: all
   gather_facts: true
-
   roles:
     - role: cowdogmoo.workstation.user_setup
 

--- a/playbooks/workstation/molecule/default/converge.yml
+++ b/playbooks/workstation/molecule/default/converge.yml
@@ -3,5 +3,8 @@
   hosts: all
   gather_facts: true
 
+  roles:
+    - role: cowdogmoo.workstation.user_setup
+
 - name: Import playbook for testing
   ansible.builtin.import_playbook: ../../workstation.yml

--- a/playbooks/workstation/molecule/default/converge.yml
+++ b/playbooks/workstation/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: true
+
+- name: Import playbook for testing
+  ansible.builtin.import_playbook: ../../workstation.yml

--- a/playbooks/workstation/molecule/default/converge.yml
+++ b/playbooks/workstation/molecule/default/converge.yml
@@ -2,8 +2,6 @@
 - name: Converge
   hosts: all
   gather_facts: true
-  roles:
-    - role: cowdogmoo.workstation.user_setup
 
 - name: Import playbook for testing
   ansible.builtin.import_playbook: ../../workstation.yml

--- a/playbooks/workstation/molecule/default/converge.yml
+++ b/playbooks/workstation/molecule/default/converge.yml
@@ -2,6 +2,11 @@
 - name: Converge
   hosts: all
   gather_facts: true
+  pre_tasks:
+    - name: Set ansible_user_id based on OS
+      ansible.builtin.set_fact:
+        ansible_user_id: "{{ 'ubuntu' if ansible_distribution == 'Ubuntu' else 'rocky' }}"
+      when: ansible_distribution in ['Ubuntu', 'RedHat', 'Rocky']
 
 - name: Import playbook for testing
   ansible.builtin.import_playbook: ../../workstation.yml

--- a/playbooks/workstation/molecule/default/inventory
+++ b/playbooks/workstation/molecule/default/inventory
@@ -1,0 +1,2 @@
+[local]
+localhost ansible_connection=local

--- a/playbooks/workstation/molecule/default/molecule.yml
+++ b/playbooks/workstation/molecule/default/molecule.yml
@@ -1,0 +1,38 @@
+---
+# Use Ansible Galaxy to install dependencies
+dependency:
+  name: galaxy
+  options:
+    # Install required galaxy roles
+    role-file: ../../requirements.yml
+    # Install required collections
+    requirements-file: ../../requirements.yml
+
+# Run molecule inside of a docker container
+driver:
+  name: docker
+
+platforms:
+  - name: ubuntu-workstation
+    image: geerlingguy/docker-ubuntu2204-ansible:latest
+    command: "" # necessary for systemd
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+
+  - name: redhat-workstation
+    image: "geerlingguy/docker-rockylinux9-ansible:latest"
+    command: "" # necessary for systemd
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+
+verifier:
+  name: ansible

--- a/playbooks/workstation/workstation.yml
+++ b/playbooks/workstation/workstation.yml
@@ -6,46 +6,10 @@
       ansible.builtin.command: id -gn "{{ ansible_user_id }}"
       changed_when: false
       register: primary_group_name
-
-    - name: Determine path for zsh
-      ansible.builtin.command: "which zsh"
-      changed_when: false
-      register: zsh_path
-
-    # - name: Set asdf_users
-    #   ansible.builtin.set_fact:
-    #     asdf_users:
-    #       - username: "{{ ansible_user_id }}"
-    #         usergroup: "{{ primary_group_name.stdout }}"
-    #         shell: "{{ zsh_path.stdout }}"
-    #         shell_profile_lines:
-    #           - 'export ASDF_PATH="{{ home_path }}/{{ ansible_user_id }}/.asdf"'
-    #           - 'export PATH="$ASDF_PATH/bin:$ASDF_PATH/shims:$PATH"'
-    #           - '. "$ASDF_PATH/asdf.sh"'
-    #         plugins:
-    #           - name: golang
-    #             version: "1.21.4"
-    #             scope: "global"
-    #           - name: python
-    #             version: "3.12.0"
-    #             scope: "global"
-    #           - name: ruby
-    #             version: "3.2.2"
-    #             scope: "global"
-    #           - name: kubectl
-    #             version: "1.28.2"
-    #             scope: "global"
-    #           - name: helm
-    #             version: "3.13.1"
-    #             scope: "global"
-    #           - name: packer
-    #             version: "1.9.4"
-    #             scope: "global"
-
   roles:
-    # - role: 'roles/package_management'
     # - role: cowdogmoo.workstation.user_setup
     - role: "roles/user_setup"
+    - role: "roles/package_management"
     # - role: cowdogmoo.workstation.package_management
     # - role: cowdogmoo.workstation.zsh_setup
     - role: "roles/zsh_setup"
@@ -54,5 +18,28 @@
           - username: "{{ ansible_user_id }}"
             usergroup: "{{ primary_group_name.stdout }}"
     # - role: cowdogmoo.workstation.asdf
-    #   vars:
-    #     asdf_users: "{{ asdf_users }}"
+    - role: "roles/asdf"
+      vars:
+        asdf_users:
+          - username: "{{ ansible_env.USER if ansible_distribution == 'mac' else asdf_default_username }}"
+            usergroup: "{{ 'staff' if ansible_distribution == 'mac' else asdf_default_group }}"
+            shell: "/bin/zsh"
+            plugins:
+              - name: golang
+                version: "1.21.4"
+                scope: "global"
+              - name: python
+                version: "3.12.0"
+                scope: "global"
+              - name: ruby
+                version: "3.2.2"
+                scope: "global"
+              - name: kubectl
+                version: "1.28.2"
+                scope: "global"
+              - name: helm
+                version: "3.13.1"
+                scope: "global"
+              - name: packer
+                version: "1.9.4"
+                scope: "global"

--- a/playbooks/workstation/workstation.yml
+++ b/playbooks/workstation/workstation.yml
@@ -12,40 +12,47 @@
       changed_when: false
       register: zsh_path
 
-    - name: Set setup_users with correct group name and OS-specific shell profile lines
-      ansible.builtin.set_fact:
-        setup_users:
-          - username: "{{ ansible_user_id }}"
-            usergroup: "{{ primary_group_name.stdout }}"
-            shell: "{{ zsh_path.stdout }}"
-            shell_profile_lines:
-              - 'export ASDF_PATH="{{ (ansible_os_family == ''Darwin'') | ternary(''/Users'', ''/home'') }}/{{ ansible_user_id }}/.asdf"'
-              - 'export PATH="$ASDF_PATH/bin:$ASDF_PATH/shims:$PATH"'
-              - '. "$ASDF_PATH/asdf.sh"'
-            plugins:
-              - name: golang
-                version: "1.21.4"
-                scope: "global"
-              - name: python
-                version: "3.12.0"
-                scope: "global"
-              - name: ruby
-                version: "3.2.2"
-                scope: "global"
-              - name: kubectl
-                version: "1.28.2"
-                scope: "global"
-              - name: helm
-                version: "3.13.1"
-                scope: "global"
-              - name: packer
-                version: "1.9.4"
-                scope: "global"
+    # - name: Set asdf_users
+    #   ansible.builtin.set_fact:
+    #     asdf_users:
+    #       - username: "{{ ansible_user_id }}"
+    #         usergroup: "{{ primary_group_name.stdout }}"
+    #         shell: "{{ zsh_path.stdout }}"
+    #         shell_profile_lines:
+    #           - 'export ASDF_PATH="{{ home_path }}/{{ ansible_user_id }}/.asdf"'
+    #           - 'export PATH="$ASDF_PATH/bin:$ASDF_PATH/shims:$PATH"'
+    #           - '. "$ASDF_PATH/asdf.sh"'
+    #         plugins:
+    #           - name: golang
+    #             version: "1.21.4"
+    #             scope: "global"
+    #           - name: python
+    #             version: "3.12.0"
+    #             scope: "global"
+    #           - name: ruby
+    #             version: "3.2.2"
+    #             scope: "global"
+    #           - name: kubectl
+    #             version: "1.28.2"
+    #             scope: "global"
+    #           - name: helm
+    #             version: "3.13.1"
+    #             scope: "global"
+    #           - name: packer
+    #             version: "1.9.4"
+    #             scope: "global"
 
   roles:
-    - role: cowdogmoo.workstation.zsh_setup
+    # - role: 'roles/package_management'
+    # - role: cowdogmoo.workstation.user_setup
+    - role: "roles/user_setup"
+    # - role: cowdogmoo.workstation.package_management
+    # - role: cowdogmoo.workstation.zsh_setup
+    - role: "roles/zsh_setup"
       vars:
-        zsh_setup_users: "{{ setup_users }}"
-    - role: cowdogmoo.workstation.asdf
-      vars:
-        asdf_users: "{{ setup_users }}"
+        zsh_setup_users:
+          - username: "{{ ansible_user_id }}"
+            usergroup: "{{ primary_group_name.stdout }}"
+    # - role: cowdogmoo.workstation.asdf
+    #   vars:
+    #     asdf_users: "{{ asdf_users }}"

--- a/playbooks/workstation/workstation.yml
+++ b/playbooks/workstation/workstation.yml
@@ -7,18 +7,14 @@
       changed_when: false
       register: primary_group_name
   roles:
-    # - role: cowdogmoo.workstation.user_setup
-    - role: "roles/user_setup"
-    - role: "roles/package_management"
-    # - role: cowdogmoo.workstation.package_management
-    # - role: cowdogmoo.workstation.zsh_setup
-    - role: "roles/zsh_setup"
+    - role: cowdogmoo.workstation.user_setup
+    - role: cowdogmoo.workstation.package_management
+    - role: cowdogmoo.workstation.zsh_setup
       vars:
         zsh_setup_users:
           - username: "{{ ansible_user_id }}"
             usergroup: "{{ primary_group_name.stdout }}"
-    # - role: cowdogmoo.workstation.asdf
-    - role: "roles/asdf"
+    - role: cowdogmoo.workstation.asdf
       vars:
         asdf_users:
           - username: "{{ ansible_env.USER if ansible_distribution == 'mac' else asdf_default_username }}"

--- a/playbooks/workstation/workstation.yml
+++ b/playbooks/workstation/workstation.yml
@@ -1,6 +1,51 @@
 ---
 - name: Workstation
   hosts: all
+  pre_tasks:
+    - name: Get primary group name of the user
+      ansible.builtin.command: id -gn "{{ ansible_user_id }}"
+      changed_when: false
+      register: primary_group_name
+
+    - name: Determine path for zsh
+      ansible.builtin.command: "which zsh"
+      changed_when: false
+      register: zsh_path
+
+    - name: Set setup_users with correct group name and OS-specific shell profile lines
+      ansible.builtin.set_fact:
+        setup_users:
+          - username: "{{ ansible_user_id }}"
+            usergroup: "{{ primary_group_name.stdout }}"
+            shell: "{{ zsh_path.stdout }}"
+            shell_profile_lines:
+              - 'export ASDF_PATH="{{ (ansible_os_family == ''Darwin'') | ternary(''/Users'', ''/home'') }}/{{ ansible_user_id }}/.asdf"'
+              - 'export PATH="$ASDF_PATH/bin:$ASDF_PATH/shims:$PATH"'
+              - '. "$ASDF_PATH/asdf.sh"'
+            plugins:
+              - name: golang
+                version: "1.21.4"
+                scope: "global"
+              - name: python
+                version: "3.12.0"
+                scope: "global"
+              - name: ruby
+                version: "3.2.2"
+                scope: "global"
+              - name: kubectl
+                version: "1.28.2"
+                scope: "global"
+              - name: helm
+                version: "3.13.1"
+                scope: "global"
+              - name: packer
+                version: "1.9.4"
+                scope: "global"
+
   roles:
     - role: cowdogmoo.workstation.zsh_setup
+      vars:
+        zsh_setup_users: "{{ setup_users }}"
     - role: cowdogmoo.workstation.asdf
+      vars:
+        asdf_users: "{{ setup_users }}"

--- a/playbooks/workstation/workstation.yml
+++ b/playbooks/workstation/workstation.yml
@@ -1,25 +1,33 @@
 ---
 - name: Workstation
   hosts: all
-  pre_tasks:
+
+  roles:
+    - role: cowdogmoo.workstation.user_setup
+    - role: cowdogmoo.workstation.package_management
+
+  tasks:
     - name: Get primary group name of the user
       ansible.builtin.command: id -gn "{{ ansible_user_id }}"
       changed_when: false
       register: primary_group_name
-  roles:
-    - role: cowdogmoo.workstation.user_setup
-    - role: cowdogmoo.workstation.package_management
-    - role: cowdogmoo.workstation.zsh_setup
+
+    - name: Setup ZSH Configuration
+      ansible.builtin.include_role:
+        name: cowdogmoo.workstation.zsh_setup
       vars:
         zsh_setup_users:
           - username: "{{ ansible_user_id }}"
             usergroup: "{{ primary_group_name.stdout }}"
-    - role: cowdogmoo.workstation.asdf
+
+    - name: Setup ASDF Configuration
+      ansible.builtin.include_role:
+        name: cowdogmoo.workstation.asdf
       vars:
         asdf_users:
-          - username: "{{ ansible_env.USER if ansible_distribution == 'mac' else asdf_default_username }}"
-            usergroup: "{{ 'staff' if ansible_distribution == 'mac' else asdf_default_group }}"
-            shell: "/bin/zsh"
+          - username: "{{ ansible_user_id }}"
+            usergroup: "{{ primary_group_name.stdout }}"
+            shell: "{{ '/bin/zsh' if ansible_distribution == 'mac' else '/usr/bin/zsh' }}"
             plugins:
               - name: golang
                 version: "1.21.4"

--- a/playbooks/workstation/workstation.yml
+++ b/playbooks/workstation/workstation.yml
@@ -27,7 +27,7 @@
         asdf_users:
           - username: "{{ ansible_user_id }}"
             usergroup: "{{ primary_group_name.stdout }}"
-            shell: "{{ '/bin/zsh' if ansible_distribution == 'mac' else '/usr/bin/zsh' }}"
+            shell: "{{ '/bin/zsh' if ansible_distribution == 'MacOSX' else '/usr/bin/zsh' }}"
             plugins:
               - name: golang
                 version: "1.21.4"

--- a/playbooks/workstation/workstation.yml
+++ b/playbooks/workstation/workstation.yml
@@ -1,0 +1,6 @@
+---
+- name: Workstation
+  hosts: all
+  roles:
+    - role: cowdogmoo.workstation.zsh_setup
+    - role: cowdogmoo.workstation.asdf

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,5 @@
 ---
 roles:
-  - name: l50.sliver
   - name: cowdogmoo.firefox
 
 collections:

--- a/roles/asdf/README.md
+++ b/roles/asdf/README.md
@@ -1,7 +1,7 @@
 # Ansible Role: asdf
 
-This role installs and configures asdf, a version manager for multiple
-programming languages.
+This role installs and configures the asdf version manager for multiple
+programming languages on Unix-like systems.
 
 ---
 
@@ -20,56 +20,44 @@ programming languages.
 
 ## Role Variables
 
-| Variable              | Default Value                         | Description                                |
-| --------------------- | ------------------------------------- | ------------------------------------------ |
-| asdf_git_repo         | "https://github.com/asdf-vm/asdf.git" | Git repository URL for asdf                |
-| asdf_os_family        | "{{ ansible_os_family \| lower }}"    | OS family for loading OS-specific tasks    |
-| asdf_default_username | "{{ ansible_distribution \| lower }}" | Default username for setup                 |
-| asdf_users            | Configurable                          | Users to setup with asdf and their plugins |
+| Variable              | Default Value                                                                                | Description                                         |
+| --------------------- | -------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| asdf_git_repo         | "https://github.com/asdf-vm/asdf.git"                                                        | Git repository of ASDF.                             |
+| asdf_os_family        | "{{ ansible_os_family \| lower }}"                                                           | Operating system family.                            |
+| asdf_default_username | "{{ ansible_env.USER if ansible_os_family == 'Darwin' else ansible_distribution \| lower }}" | Default username based on OS.                       |
+| asdf_default_group    | "{{ 'staff' if ansible_os_family == 'Darwin' else ansible_distribution \| lower }}"          | Default group based on OS.                          |
+| asdf_users            | See below                                                                                    | List of users to set up with ASDF and their plugins |
 
-### Configuration for `asdf_users`
+### Default Configuration for `asdf_users`
 
-`asdf_users` is a list of dictionaries, each with:
+- `username`: The username for ASDF setup.
+- `usergroup`: The group of the user.
+- `shell`: The shell used by the user.
+- `plugins`: List of ASDF plugins to install.
 
-- `username`: User's name
-- `usergroup`: User's group
-- `shell`: User's shell (default is "/usr/bin/zsh")
-- `shell_profile_lines`: Shell profile settings
-- `plugins`: List of asdf plugins to install (name, version, scope)
+Example `asdf_users` configuration:
+
+```yaml
+- username: "{{ asdf_default_username }}"
+  usergroup: "{{ asdf_default_group }}"
+  shell: "/usr/bin/zsh"
+  plugins:
+    - name: golang
+      version: "1.21.4"
+      scope: "global"
+    # ... other plugins ...
+```
 
 ---
 
-## Local Development
-
-To develop locally, run the following from the repository root:
-
-```bash
-ansible-galaxy install -r requirements.yml
-PATH_TO_ROLE="${PWD}"
-ln -s "${PATH_TO_ROLE}" "${HOME}/.ansible/roles/cowdogmoo.asdf"
-```
-
 ## Testing
 
-For local testing:
-
-- Use [act](https://github.com/nektos/act) for local GitHub Actions testing.
-
-- Run Molecule tests:
-
-  ```bash
-  ACTION="molecule"
-  if [[ $(uname) == "Darwin" ]]; then
-    act -j $ACTION --container-architecture linux/amd64
-  fi
-  ```
-
-To test changes made to this role locally:
+To test the role, use Molecule:
 
 ```bash
-molecule create
 molecule converge
 molecule idempotence
+molecule verify
 molecule destroy
 ```
 
@@ -77,26 +65,25 @@ molecule destroy
 
 Key tasks in this role:
 
-1. Set default username for Kali systems.
-2. Clone asdf for each user.
-3. Deploy `.tool-versions` file and set correct permissions.
-4. Set permissions for each user's ASDF directory.
-5. Update shell profiles for each user.
-6. Gather installed ASDF plugins and versions for each user.
-7. Copy `setup_asdf_env.sh` to a common location for all users.
-8. Install and configure asdf packages for each user.
+- Check and install libyaml.
+- Update shell profiles for users.
+- Clone ASDF repository.
+- Deploy `.tool-versions` file.
+- Set permissions for ASDF directories.
+- Gather installed ASDF plugins and versions.
 
 ## Platforms
 
 This role is tested on the following platforms:
 
 - Ubuntu
+- macOS
 - Kali
 - EL (Enterprise Linux)
 
 ## Dependencies
 
-- role: cowdogmoo.workstation.user_setup
+- `cowdogmoo.workstation.package_management`
 
 ## Author Information
 

--- a/roles/asdf/defaults/main.yml
+++ b/roles/asdf/defaults/main.yml
@@ -5,7 +5,7 @@ asdf_default_username: "{{ ansible_distribution | lower }}"
 # Default home path is /home for Linux and /Users for macOS
 asdf_home_path: "{{ (ansible_os_family == 'Darwin') | ternary('/Users', '/home') }}"
 
-# Users to setup with asdf, each with their specific setup scripts
+# Users to setup with asdf
 asdf_users:
   - username: "{{ asdf_default_username }}"
     usergroup: "{{ asdf_default_username }}"

--- a/roles/asdf/defaults/main.yml
+++ b/roles/asdf/defaults/main.yml
@@ -2,6 +2,9 @@
 # Default username is the distribution name
 asdf_default_username: "{{ ansible_distribution | lower }}"
 
+# Default home path is /home for Linux and /Users for macOS
+asdf_home_path: "{{ (ansible_os_family == 'Darwin') | ternary('/Users', '/home') }}"
+
 # Users to setup with asdf, each with their specific setup scripts
 asdf_users:
   - username: "{{ asdf_default_username }}"

--- a/roles/asdf/defaults/main.yml
+++ b/roles/asdf/defaults/main.yml
@@ -1,19 +1,13 @@
 ---
-# Default username is the distribution name
-asdf_default_username: "{{ ansible_distribution | lower }}"
-
-# Default home path is /home for Linux and /Users for macOS
-asdf_home_path: "{{ (ansible_os_family == 'Darwin') | ternary('/Users', '/home') }}"
+# Default username and group are set based on the operating system
+asdf_default_username: "{{ ansible_env.USER if ansible_os_family == 'Darwin' else ansible_distribution | lower }}"
+asdf_default_group: "{{ 'staff' if ansible_os_family == 'Darwin' else ansible_distribution | lower }}"
 
 # Users to setup with asdf
 asdf_users:
   - username: "{{ asdf_default_username }}"
-    usergroup: "{{ asdf_default_username }}"
+    usergroup: "{{ asdf_default_group }}"
     shell: "/usr/bin/zsh"
-    shell_profile_lines:
-      - 'export ASDF_PATH="/home/{{ asdf_default_username }}/.asdf"'
-      - 'export PATH="$ASDF_PATH/bin:$ASDF_PATH/shims:$PATH"'
-      - '. "$ASDF_PATH/asdf.sh"'
     plugins:
       - name: golang
         version: "1.21.4"

--- a/roles/asdf/files/setup_asdf_env.sh
+++ b/roles/asdf/files/setup_asdf_env.sh
@@ -6,10 +6,14 @@ if [ -z "$1" ]; then
 	exit 1
 fi
 
-export ASDF_PATH="/home/$1/.asdf"
+if [ -z "$2" ]; then
+	echo "No home directory provided"
+	exit 1
+fi
+
+export ASDF_PATH="$2/$1/.asdf"
 export PATH="$ASDF_PATH/bin:$ASDF_PATH/shims:$PATH"
 
-# Check if ASDF_PATH is correctly set
 if [[ ! -d "$ASDF_PATH" ]]; then
 	echo "ASDF_PATH '$ASDF_PATH' does not exist"
 	exit 1

--- a/roles/asdf/files/setup_asdf_env.sh
+++ b/roles/asdf/files/setup_asdf_env.sh
@@ -1,20 +1,17 @@
 #!/bin/bash
-set -ex
+echo "Running setup_asdf_env.sh with user home path: $1"
 
 if [ -z "$1" ]; then
-	echo "No username provided"
+	echo "No user home path provided" >&2
 	exit 1
 fi
 
-if [ -z "$2" ]; then
-	echo "No home directory provided"
-	exit 1
-fi
-
-export ASDF_PATH="$2/$1/.asdf"
+export ASDF_PATH="$1/.asdf"
 export PATH="$ASDF_PATH/bin:$ASDF_PATH/shims:$PATH"
 
+echo "Set ASDF_PATH to: $ASDF_PATH"
+
 if [[ ! -d "$ASDF_PATH" ]]; then
-	echo "ASDF_PATH '$ASDF_PATH' does not exist"
+	echo "ASDF_PATH '$ASDF_PATH' does not exist" >&2
 	exit 1
 fi

--- a/roles/asdf/meta/main.yml
+++ b/roles/asdf/meta/main.yml
@@ -19,3 +19,5 @@ galaxy_info:
         - all
   galaxy_tags:
     - asdf
+dependencies:
+  - role: cowdogmoo.workstation.package_management

--- a/roles/asdf/meta/main.yml
+++ b/roles/asdf/meta/main.yml
@@ -19,5 +19,3 @@ galaxy_info:
         - all
   galaxy_tags:
     - asdf
-dependencies:
-  - role: cowdogmoo.workstation.user_setup

--- a/roles/asdf/tasks/get_enriched_users.yml
+++ b/roles/asdf/tasks/get_enriched_users.yml
@@ -1,13 +1,22 @@
 ---
 - name: Get home directory for each user
-  ansible.builtin.shell: "eval echo ~{{ item.username }}" # noqa command-instead-of-shell
+  ansible.builtin.shell: 'python -c ''import pwd; print(pwd.getpwnam("{{ item.username }}").pw_dir)'''
   loop: "{{ asdf_users }}"
   register: home_dirs
-  become: true
-  become_user: "{{ item.username }}"
   changed_when: false
 
-- name: Update home_path and shell for each user in asdf_users
+- name: Update home_path, shell, and plugins for each user in asdf_users
   ansible.builtin.set_fact:
-    enriched_setup_users: "{{ (enriched_setup_users | default([])) | rejectattr('username', 'equalto', item.0.username) | list + [item.0 | combine({'home_path': item.1.stdout, 'shell': item.0.shell})] }}"
+    enriched_setup_users: >-
+      {{ (enriched_setup_users | default([])) | rejectattr('username', 'equalto', item.0.username) | list +
+      [item.0 | combine({
+        'home_path': item.1.stdout,
+        'shell': (item.0.shell | default('/bin/bash')),
+        'plugins': item.0.plugins,
+        'shell_profile_lines': [
+          'export ASDF_PATH="' + item.1.stdout + '/.asdf"',
+          'export PATH="$ASDF_PATH/bin:$ASDF_PATH/shims:$PATH"',
+          '. "$ASDF_PATH/asdf.sh"'
+        ]
+      })] }}
   loop: "{{ asdf_users | zip(home_dirs.results) }}"

--- a/roles/asdf/tasks/get_enriched_users.yml
+++ b/roles/asdf/tasks/get_enriched_users.yml
@@ -1,0 +1,13 @@
+---
+- name: Get home directory for each user
+  ansible.builtin.shell: "eval echo ~{{ item.username }}" # noqa command-instead-of-shell
+  loop: "{{ asdf_users }}"
+  register: home_dirs
+  become: true
+  become_user: "{{ item.username }}"
+  changed_when: false
+
+- name: Update home_path and shell for each user in asdf_users
+  ansible.builtin.set_fact:
+    enriched_setup_users: "{{ (enriched_setup_users | default([])) | rejectattr('username', 'equalto', item.0.username) | list + [item.0 | combine({'home_path': item.1.stdout, 'shell': item.0.shell})] }}"
+  loop: "{{ asdf_users | zip(home_dirs.results) }}"

--- a/roles/asdf/tasks/get_enriched_users.yml
+++ b/roles/asdf/tasks/get_enriched_users.yml
@@ -1,6 +1,6 @@
 ---
 - name: Get home directory for each user
-  ansible.builtin.shell: 'python -c ''import pwd; print(pwd.getpwnam("{{ item.username }}").pw_dir)'''
+  ansible.builtin.shell: 'python3 -c ''import pwd; print(pwd.getpwnam("{{ item.username }}").pw_dir)'''
   loop: "{{ asdf_users }}"
   register: home_dirs
   changed_when: false

--- a/roles/asdf/tasks/install_libyaml.yml
+++ b/roles/asdf/tasks/install_libyaml.yml
@@ -1,3 +1,4 @@
+---
 - name: Check if libyaml is installed
   ansible.builtin.command: ldconfig -p | grep libyaml
   register: libyaml_installed

--- a/roles/asdf/tasks/main.yml
+++ b/roles/asdf/tasks/main.yml
@@ -68,23 +68,18 @@
   loop_control:
     loop_var: user
 
-- name: Update shell profiles to source setup_asdf_env
-  ansible.builtin.lineinfile:
-    path: "{{ home_path }}/{{ user_line.0.username }}/{{ (user_line.0.shell | default('/bin/bash') == '/bin/zsh') | ternary('.zshrc', '.bashrc') }}"
-    line: "source /usr/local/bin/setup_asdf_env"
-    insertafter: EOF
-    create: false
-    state: present
-  loop: "{{ asdf_users | subelements('shell_profile_lines') }}"
-  loop_control:
-    loop_var: user_line
-  when: user_line.0.username != 'root'
+- name: Include task to update shell profiles for each user
+  ansible.builtin.include_tasks: update_shell_profiles.yml
+  vars:
+    user: "{{ item }}"
+  loop: "{{ asdf_users }}"
+  when: item.username != 'root'
 
 - name: Gather installed ASDF plugins and versions for each user
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      . /usr/local/bin/setup_asdf_env "{{ user.username }}"
+      . /usr/local/bin/setup_asdf_env "{{ user.username }}" "{{ (ansible_os_family == 'Darwin') | ternary('/Users', '/home') }}"
       {% for plugin in user.plugins %}
       if ! asdf plugin list | grep -q {{ plugin.name }}; then
         asdf plugin add {{ plugin.name }};

--- a/roles/asdf/tasks/main.yml
+++ b/roles/asdf/tasks/main.yml
@@ -4,10 +4,14 @@
     asdf_default_username: "kali"
   when: ansible_distribution_release == "kali-rolling"
 
+- name: Set home directory path
+  ansible.builtin.set_fact:
+    home_path: "{{ (ansible_os_family == 'Darwin') | ternary('/Users', '/home') }}"
+
 - name: Clone asdf for each user
   ansible.builtin.git:
     repo: "{{ asdf_git_repo }}"
-    dest: "/home/{{ user.username }}/.asdf"
+    dest: "{{ home_path }}/{{ user.username }}/.asdf"
     clone: true
     update: false
   loop: "{{ asdf_users }}"
@@ -20,7 +24,7 @@
 - name: Deploy .tool-versions file
   ansible.builtin.template:
     src: tool-versions.j2
-    dest: "/home/{{ user.username }}/.tool-versions"
+    dest: "{{ home_path }}/{{ user.username }}/.tool-versions"
     owner: "{{ user.username }}"
     group: "{{ user.usergroup | default(user.username) }}"
     mode: "0644"
@@ -33,7 +37,7 @@
 
 - name: Ensure correct permissions for .tool-versions
   ansible.builtin.file:
-    path: "/home/{{ item.username }}/.tool-versions"
+    path: "{{ home_path }}/{{ item.username }}/.tool-versions"
     owner: "{{ item.username }}"
     group: "{{ item.usergroup | default(item.username) }}"
     mode: "0644"
@@ -45,7 +49,7 @@
 
 - name: Set permissions for each user's ASDF directory
   ansible.builtin.file:
-    path: "/home/{{ user.username }}/.asdf"
+    path: "{{ home_path }}/{{ user.username }}/.asdf"
     owner: "{{ user.username }}"
     group: "{{ user.usergroup | default(user.username) }}"
     recurse: true
@@ -58,16 +62,18 @@
 
 - name: Check if .asdf directory exists for each user
   ansible.builtin.stat:
-    path: "/home/{{ user.username }}/.asdf"
+    path: "{{ home_path }}/{{ user.username }}/.asdf"
   register: asdf_dir_check
   loop: "{{ asdf_users }}"
   loop_control:
     loop_var: user
 
-- name: Update shell profiles for each user
+- name: Update shell profiles to source setup_asdf_env.sh
   ansible.builtin.lineinfile:
-    path: "/home/{{ user_line.0.username }}/{{ (ansible_user_shell == '/bin/zsh') | ternary('.zshrc', '.bashrc') }}"
-    line: "{{ user_line.1 }}"
+    path: "{{ home_path }}/{{ user_line.0.username }}/{{ (user_line.0.shell | default('/bin/bash') == '/bin/zsh') | ternary('.zshrc', '.bashrc') }}"
+    line: "source /usr/local/bin/setup_asdf_env.sh"
+    insertafter: EOF
+    create: false
     state: present
   loop: "{{ asdf_users | subelements('shell_profile_lines') }}"
   loop_control:
@@ -75,17 +81,16 @@
   when: user_line.0.username != 'root'
 
 - name: Gather installed ASDF plugins and versions for each user
-  ansible.builtin.shell: set -o pipefail
-    . /usr/local/bin/setup_asdf_env "{{ user.username }}"
-
-    {% for plugin in user.plugins %}
-    if ! asdf plugin list | grep -q {{ plugin.name }}; then
-    asdf plugin add {{ plugin.name }};
-    fi;
-    {% endfor %}
-
-    echo "plugins:$(asdf plugin list),versions:$(asdf list all | tr '\n' ',')"
-  args:
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      . /usr/local/bin/setup_asdf_env "{{ user.username }}"
+      {% for plugin in user.plugins %}
+      if ! asdf plugin list | grep -q {{ plugin.name }}; then
+        asdf plugin add {{ plugin.name }};
+      fi;
+      {% endfor %}
+      echo "plugins:$(asdf plugin list),versions:$(asdf list all | tr '\n' ',')"
     executable: "{{ user.shell }}"
   register: asdf_info
   changed_when: false
@@ -98,12 +103,12 @@
 - name: Copy setup_asdf_env.sh to a common location for all users
   ansible.builtin.copy:
     src: setup_asdf_env.sh
-    dest: /usr/local/bin/setup_asdf_env
+    dest: /usr/local/bin/setup_asdf_env.sh
     mode: "0755"
-  become: true
 
 - name: Install and configure asdf packages for each user
   ansible.builtin.include_tasks: package_setup.yml
   loop: "{{ asdf_users }}"
   loop_control:
     loop_var: asdf_user
+  when: asdf_user.username != 'root'

--- a/roles/asdf/tasks/main.yml
+++ b/roles/asdf/tasks/main.yml
@@ -68,10 +68,10 @@
   loop_control:
     loop_var: user
 
-- name: Update shell profiles to source setup_asdf_env.sh
+- name: Update shell profiles to source setup_asdf_env
   ansible.builtin.lineinfile:
     path: "{{ home_path }}/{{ user_line.0.username }}/{{ (user_line.0.shell | default('/bin/bash') == '/bin/zsh') | ternary('.zshrc', '.bashrc') }}"
-    line: "source /usr/local/bin/setup_asdf_env.sh"
+    line: "source /usr/local/bin/setup_asdf_env"
     insertafter: EOF
     create: false
     state: present
@@ -103,7 +103,7 @@
 - name: Copy setup_asdf_env.sh to a common location for all users
   ansible.builtin.copy:
     src: setup_asdf_env.sh
-    dest: /usr/local/bin/setup_asdf_env.sh
+    dest: /usr/local/bin/setup_asdf_env
     mode: "0755"
 
 - name: Install and configure asdf packages for each user

--- a/roles/asdf/tasks/main.yml
+++ b/roles/asdf/tasks/main.yml
@@ -6,12 +6,13 @@
 
 - name: Set home directory path
   ansible.builtin.set_fact:
-    asdf_home_path: "{{ (ansible_os_family == 'Darwin') | ternary('/Users', '/home') }}"
+    asdf_home_path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var/root' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}"
+  loop: "{{ zsh_setup_users }}"
 
 - name: Clone asdf for each user
   ansible.builtin.git:
     repo: "{{ asdf_git_repo }}"
-    dest: "{{ asdf_home_path }}/{{ user.username }}/.asdf"
+    dest: "{{ asdf_home_path }}/.asdf"
     clone: true
     update: false
   loop: "{{ asdf_users }}"
@@ -24,7 +25,7 @@
 - name: Deploy .tool-versions file
   ansible.builtin.template:
     src: tool-versions.j2
-    dest: "{{ asdf_home_path }}/{{ user.username }}/.tool-versions"
+    dest: "{{ asdf_home_path }}/.tool-versions"
     owner: "{{ user.username }}"
     group: "{{ user.usergroup | default(user.username) }}"
     mode: "0644"
@@ -37,7 +38,7 @@
 
 - name: Ensure correct permissions for .tool-versions
   ansible.builtin.file:
-    path: "{{ asdf_home_path }}/{{ item.username }}/.tool-versions"
+    path: "{{ asdf_home_path }}/.tool-versions"
     owner: "{{ item.username }}"
     group: "{{ item.usergroup | default(item.username) }}"
     mode: "0644"
@@ -49,7 +50,7 @@
 
 - name: Set permissions for each user's ASDF directory
   ansible.builtin.file:
-    path: "{{ asdf_home_path }}/{{ user.username }}/.asdf"
+    path: "{{ asdf_home_path }}/.asdf"
     owner: "{{ user.username }}"
     group: "{{ user.usergroup | default(user.username) }}"
     recurse: true
@@ -62,7 +63,7 @@
 
 - name: Check if .asdf directory exists for each user
   ansible.builtin.stat:
-    path: "{{ asdf_home_path }}/{{ user.username }}/.asdf"
+    path: "{{ asdf_home_path }}/.asdf"
   register: asdf_dir_check
   loop: "{{ asdf_users }}"
   loop_control:
@@ -79,7 +80,7 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      . /usr/local/bin/setup_asdf_env "{{ asdf_home_path }}/{{ user.username }}"
+      . /usr/local/bin/setup_asdf_env "{{ asdf_home_path }}"
       {% for plugin in user.plugins %}
       if ! asdf plugin list | grep -q {{ plugin.name }}; then
         asdf plugin add {{ plugin.name }};

--- a/roles/asdf/tasks/main.yml
+++ b/roles/asdf/tasks/main.yml
@@ -87,7 +87,11 @@
     dest: /usr/local/bin/setup_asdf_env
     mode: "0755"
 
-- name: Install and configure asdf packages for each user
-  ansible.builtin.include_tasks: package_setup.yml
+- name: Install libyaml from source
+  ansible.builtin.include_tasks: install_libyaml.yml
+  when: ansible_distribution == 'Rocky'
+
+- name: Install asdf plugins and set versions for each user
+  ansible.builtin.include_tasks: package_individual_setup.yml
   loop: "{{ enriched_setup_users }}"
   when: item.username != 'root'

--- a/roles/asdf/tasks/main.yml
+++ b/roles/asdf/tasks/main.yml
@@ -6,12 +6,12 @@
 
 - name: Set home directory path
   ansible.builtin.set_fact:
-    home_path: "{{ (ansible_os_family == 'Darwin') | ternary('/Users', '/home') }}"
+    asdf_home_path: "{{ (ansible_os_family == 'Darwin') | ternary('/Users', '/home') }}"
 
 - name: Clone asdf for each user
   ansible.builtin.git:
     repo: "{{ asdf_git_repo }}"
-    dest: "{{ home_path }}/{{ user.username }}/.asdf"
+    dest: "{{ asdf_home_path }}/{{ user.username }}/.asdf"
     clone: true
     update: false
   loop: "{{ asdf_users }}"
@@ -24,7 +24,7 @@
 - name: Deploy .tool-versions file
   ansible.builtin.template:
     src: tool-versions.j2
-    dest: "{{ home_path }}/{{ user.username }}/.tool-versions"
+    dest: "{{ asdf_home_path }}/{{ user.username }}/.tool-versions"
     owner: "{{ user.username }}"
     group: "{{ user.usergroup | default(user.username) }}"
     mode: "0644"
@@ -37,7 +37,7 @@
 
 - name: Ensure correct permissions for .tool-versions
   ansible.builtin.file:
-    path: "{{ home_path }}/{{ item.username }}/.tool-versions"
+    path: "{{ asdf_home_path }}/{{ item.username }}/.tool-versions"
     owner: "{{ item.username }}"
     group: "{{ item.usergroup | default(item.username) }}"
     mode: "0644"
@@ -49,7 +49,7 @@
 
 - name: Set permissions for each user's ASDF directory
   ansible.builtin.file:
-    path: "{{ home_path }}/{{ user.username }}/.asdf"
+    path: "{{ asdf_home_path }}/{{ user.username }}/.asdf"
     owner: "{{ user.username }}"
     group: "{{ user.usergroup | default(user.username) }}"
     recurse: true
@@ -62,7 +62,7 @@
 
 - name: Check if .asdf directory exists for each user
   ansible.builtin.stat:
-    path: "{{ home_path }}/{{ user.username }}/.asdf"
+    path: "{{ asdf_home_path }}/{{ user.username }}/.asdf"
   register: asdf_dir_check
   loop: "{{ asdf_users }}"
   loop_control:
@@ -79,7 +79,7 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      . /usr/local/bin/setup_asdf_env "{{ user.username }}" "{{ (ansible_os_family == 'Darwin') | ternary('/Users', '/home') }}"
+      . /usr/local/bin/setup_asdf_env "{{ asdf_home_path }}/{{ user.username }}"
       {% for plugin in user.plugins %}
       if ! asdf plugin list | grep -q {{ plugin.name }}; then
         asdf plugin add {{ plugin.name }};

--- a/roles/asdf/tasks/main.yml
+++ b/roles/asdf/tasks/main.yml
@@ -4,97 +4,82 @@
     asdf_default_username: "kali"
   when: ansible_distribution_release == "kali-rolling"
 
-- name: Set home directory path
-  ansible.builtin.set_fact:
-    asdf_home_path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var/root' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}"
-  loop: "{{ zsh_setup_users }}"
+- name: Include get_enriched_users tasks
+  ansible.builtin.include_tasks: get_enriched_users.yml
 
 - name: Clone asdf for each user
   ansible.builtin.git:
     repo: "{{ asdf_git_repo }}"
-    dest: "{{ asdf_home_path }}/.asdf"
+    dest: "{{ item.home_path }}/.asdf"
     clone: true
     update: false
-  loop: "{{ asdf_users }}"
-  loop_control:
-    loop_var: user
+  loop: "{{ enriched_setup_users }}"
   when:
-    - asdf_users is defined
-    - user.username != 'root'
+    - item.username != 'root'
 
 - name: Deploy .tool-versions file
   ansible.builtin.template:
     src: tool-versions.j2
-    dest: "{{ asdf_home_path }}/.tool-versions"
-    owner: "{{ user.username }}"
-    group: "{{ user.usergroup | default(user.username) }}"
-    mode: "0644"
-  loop: "{{ asdf_users }}"
-  loop_control:
-    loop_var: user
-  when:
-    - asdf_users is defined
-    - user.username != 'root'
-
-- name: Ensure correct permissions for .tool-versions
-  ansible.builtin.file:
-    path: "{{ asdf_home_path }}/.tool-versions"
+    dest: "{{ item.home_path }}/.tool-versions"
     owner: "{{ item.username }}"
     group: "{{ item.usergroup | default(item.username) }}"
     mode: "0644"
-  loop: "{{ asdf_users }}"
-  loop_control:
-    loop_var: item
+  loop: "{{ enriched_setup_users }}"
+  when:
+    - item.username != 'root'
+
+- name: Ensure correct permissions for .tool-versions
+  ansible.builtin.file:
+    path: "{{ item.home_path }}/.tool-versions"
+    owner: "{{ item.username }}"
+    group: "{{ item.usergroup | default(item.username) }}"
+    mode: "0644"
+  loop: "{{ enriched_setup_users }}"
   when:
     - item.username != 'root'
 
 - name: Set permissions for each user's ASDF directory
   ansible.builtin.file:
-    path: "{{ asdf_home_path }}/.asdf"
-    owner: "{{ user.username }}"
-    group: "{{ user.usergroup | default(user.username) }}"
+    path: "{{ item.home_path }}/.asdf"
+    owner: "{{ item.username }}"
+    group: "{{ item.usergroup | default(item.username) }}"
     recurse: true
-  loop: "{{ asdf_users }}"
-  loop_control:
-    loop_var: user
+  loop: "{{ enriched_setup_users }}"
   when:
-    - asdf_users is defined
-    - user.username != 'root'
+    - item.username != 'root'
 
 - name: Check if .asdf directory exists for each user
   ansible.builtin.stat:
-    path: "{{ asdf_home_path }}/.asdf"
+    path: "{{ item.home_path }}/.asdf"
   register: asdf_dir_check
-  loop: "{{ asdf_users }}"
-  loop_control:
-    loop_var: user
+  loop: "{{ enriched_setup_users }}"
 
 - name: Include task to update shell profiles for each user
   ansible.builtin.include_tasks: update_shell_profiles.yml
+  loop: "{{ enriched_setup_users }}"
+  loop_control:
+    loop_var: user
   vars:
-    user: "{{ item }}"
-  loop: "{{ asdf_users }}"
-  when: item.username != 'root'
+    line: "{{ user.shell_profile_lines }}"
+  when: user.username != 'root'
 
 - name: Gather installed ASDF plugins and versions for each user
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      . /usr/local/bin/setup_asdf_env "{{ asdf_home_path }}"
-      {% for plugin in user.plugins %}
+      . /usr/local/bin/setup_asdf_env "{{ item.home_path }}"
+      {% for plugin in item.plugins %}
       if ! asdf plugin list | grep -q {{ plugin.name }}; then
         asdf plugin add {{ plugin.name }};
       fi;
       {% endfor %}
       echo "plugins:$(asdf plugin list),versions:$(asdf list all | tr '\n' ',')"
-    executable: "{{ user.shell }}"
+    executable: "{{ item.shell }}"
   register: asdf_info
   changed_when: false
   become: true
-  become_user: "{{ user.username }}"
-  loop: "{{ asdf_users }}"
-  loop_control:
-    loop_var: user
+  become_user: "{{ item.username }}"
+  loop: "{{ enriched_setup_users }}"
 
 - name: Copy setup_asdf_env.sh to a common location for all users
   ansible.builtin.copy:
@@ -104,7 +89,5 @@
 
 - name: Install and configure asdf packages for each user
   ansible.builtin.include_tasks: package_setup.yml
-  loop: "{{ asdf_users }}"
-  loop_control:
-    loop_var: asdf_user
-  when: asdf_user.username != 'root'
+  loop: "{{ enriched_setup_users }}"
+  when: item.username != 'root'

--- a/roles/asdf/tasks/package_individual_setup.yml
+++ b/roles/asdf/tasks/package_individual_setup.yml
@@ -3,7 +3,7 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      . /usr/local/bin/setup_asdf_env "{{ asdf_home_path }}/{{ user.username }}"
+      . /usr/local/bin/setup_asdf_env "{{ asdf_home_path }}"
       asdf plugin list
     executable: "{{ user.shell }}"
   register: asdf_plugins
@@ -19,7 +19,7 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      . /usr/local/bin/setup_asdf_env "{{ asdf_home_path }}/{{ user_plugin.0.username }}"
+      . /usr/local/bin/setup_asdf_env "{{ asdf_home_path }}"
       if ! asdf plugin list | grep -q "{{ user_plugin.1.name }}"; then
         asdf plugin add "{{ user_plugin.1.name }}"
       fi
@@ -38,7 +38,7 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      user_home_path="{{ asdf_home_path }}/{{ user.0.username }}"
+      user_home_path="{{ asdf_home_path }}"
       echo "Running setup_asdf_env.sh with user home path: $user_home_path"
       . /usr/local/bin/setup_asdf_env "$user_home_path"
       if ! asdf list "{{ user.1.name }}" | grep -q "{{ user.1.version }}"; then

--- a/roles/asdf/tasks/package_individual_setup.yml
+++ b/roles/asdf/tasks/package_individual_setup.yml
@@ -10,26 +10,20 @@
   changed_when: false
   become: true
   become_user: "{{ item.username }}"
-  loop: "{{ enriched_setup_users }}"
-  when: item.username != 'root'
 
 - name: Install asdf plugins for each user
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
       . /usr/local/bin/setup_asdf_env "{{ item.home_path }}"
-      if ! asdf plugin list | grep -q "{{ user_plugin.1.name }}"; then
-        asdf plugin add "{{ user_plugin.1.name }}"
+      {% for plugin in item.plugins %}
+      if ! asdf plugin list | grep -q "{{ plugin.name }}"; then
+        asdf plugin add "{{ plugin.name }}"
       fi
+      {% endfor %}
     executable: "{{ item.shell }}"
   become: true
   become_user: "{{ item.username }}"
-  loop: "{{ query('subelements', enriched_setup_users, 'plugins', {'skip_missing': true}) }}"
-  loop_control:
-    loop_var: user_plugin
-  when:
-    - user_plugin.1.name is defined
-    - user_plugin.0.username != 'root'
   changed_when: false
 
 - name: Install specific version of asdf plugins for each user
@@ -37,6 +31,7 @@
     cmd: |
       set -o pipefail
       . /usr/local/bin/setup_asdf_env "{{ item.home_path }}"
+      {% for plugin in item.plugins %}
       asdf install "{{ plugin.name }}" "{{ plugin.version }}"
       if [ "{{ plugin.scope }}" = "global" ]; then
         asdf global "{{ plugin.name }}" "{{ plugin.version }}"
@@ -46,15 +41,8 @@
         echo "Invalid scope: {{ plugin.scope }}"
         exit 1
       fi
+      {% endfor %}
     executable: "{{ item.shell }}"
   become: true
   become_user: "{{ item.username }}"
-  loop: "{{ query('subelements', enriched_setup_users, 'plugins', {'skip_missing': true}) }}"
-  loop_control:
-    loop_var: plugin
-  when:
-    - plugin.name is defined
-    - plugin.version is defined
-    - plugin.scope is defined
-    - item.username != 'root'
   changed_when: false

--- a/roles/asdf/tasks/package_individual_setup.yml
+++ b/roles/asdf/tasks/package_individual_setup.yml
@@ -3,7 +3,7 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      . /usr/local/bin/setup_asdf_env "{{ user.username }}" "{{ (ansible_os_family == 'Darwin') | ternary('/Users', '/home') }}/{{ user.username }}"
+      . /usr/local/bin/setup_asdf_env "{{ asdf_home_path }}/{{ user.username }}"
       asdf plugin list
     executable: "{{ user.shell }}"
   register: asdf_plugins
@@ -19,7 +19,7 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      . /usr/local/bin/setup_asdf_env "{{ user_plugin.0.username }}" "{{ (ansible_os_family == 'Darwin') | ternary('/Users', '/home') }}/{{ user_plugin.0.username }}"
+      . /usr/local/bin/setup_asdf_env "{{ asdf_home_path }}/{{ user_plugin.0.username }}"
       if ! asdf plugin list | grep -q "{{ user_plugin.1.name }}"; then
         asdf plugin add "{{ user_plugin.1.name }}"
       fi
@@ -29,22 +29,38 @@
   loop: "{{ query('subelements', asdf_users, 'plugins', {'skip_missing': true}) }}"
   loop_control:
     loop_var: user_plugin
-  when: user_plugin.1.name is defined
+  when:
+    - user_plugin.1.name is defined
+    - user_plugin.0.username != 'root'
   changed_when: false
 
 - name: Install specific version of asdf plugins for each user
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      . /usr/local/bin/setup_asdf_env "{{ user_plugin.0.username }}" "{{ (ansible_os_family == 'Darwin') | ternary('/Users', '/home') }}/{{ user_plugin.0.username }}"
-      if ! asdf list "{{ user_plugin.1.name }}" | grep -q "{{ user_plugin.1.version }}"; then
-        asdf install "{{ user_plugin.1.name }}" "{{ user_plugin.1.version }}"
+      user_home_path="{{ asdf_home_path }}/{{ user.0.username }}"
+      echo "Running setup_asdf_env.sh with user home path: $user_home_path"
+      . /usr/local/bin/setup_asdf_env "$user_home_path"
+      if ! asdf list "{{ user.1.name }}" | grep -q "{{ user.1.version }}"; then
+        asdf install "{{ user.1.name }}" "{{ user.1.version }}"
       fi
-    executable: "{{ user_plugin.0.shell }}"
+      if [ "{{ user.1.scope }}" = "global" ]; then
+        asdf global "{{ user.1.name }}" "{{ user.1.version }}"
+      elif [ "{{ user.1.scope }}" = "local" ]; then
+        asdf local "{{ user.1.name }}" "{{ user.1.version }}"
+      else
+        echo "Invalid scope: {{ user.1.scope }}"
+        exit 1
+      fi
+    executable: "{{ user.0.shell }}"
   become: true
-  become_user: "{{ user_plugin.0.username }}"
+  become_user: "{{ user.0.username }}"
   loop: "{{ query('subelements', asdf_users, 'plugins', {'skip_missing': true}) }}"
   loop_control:
-    loop_var: user_plugin
-  when: user_plugin.1.name is defined and user_plugin.1.version is defined
+    loop_var: user
+  when:
+    - user.1.name is defined
+    - user.1.version is defined
+    - user.1.scope is defined
+    - user.0.username != 'root'
   changed_when: false

--- a/roles/asdf/tasks/package_individual_setup.yml
+++ b/roles/asdf/tasks/package_individual_setup.yml
@@ -3,30 +3,28 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      . /usr/local/bin/setup_asdf_env "{{ asdf_home_path }}"
+      . /usr/local/bin/setup_asdf_env "{{ item.home_path }}"
       asdf plugin list
-    executable: "{{ user.shell }}"
+    executable: "{{ item.shell }}"
   register: asdf_plugins
   changed_when: false
   become: true
-  become_user: "{{ user.username }}"
-  loop: "{{ asdf_users }}"
-  loop_control:
-    loop_var: user
-  when: user.username != 'root'
+  become_user: "{{ item.username }}"
+  loop: "{{ enriched_setup_users }}"
+  when: item.username != 'root'
 
 - name: Install asdf plugins for each user
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      . /usr/local/bin/setup_asdf_env "{{ asdf_home_path }}"
+      . /usr/local/bin/setup_asdf_env "{{ item.home_path }}"
       if ! asdf plugin list | grep -q "{{ user_plugin.1.name }}"; then
         asdf plugin add "{{ user_plugin.1.name }}"
       fi
-    executable: "{{ user_plugin.0.shell }}"
+    executable: "{{ item.shell }}"
   become: true
-  become_user: "{{ user_plugin.0.username }}"
-  loop: "{{ query('subelements', asdf_users, 'plugins', {'skip_missing': true}) }}"
+  become_user: "{{ item.username }}"
+  loop: "{{ query('subelements', enriched_setup_users, 'plugins', {'skip_missing': true}) }}"
   loop_control:
     loop_var: user_plugin
   when:
@@ -38,29 +36,25 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      user_home_path="{{ asdf_home_path }}"
-      echo "Running setup_asdf_env.sh with user home path: $user_home_path"
-      . /usr/local/bin/setup_asdf_env "$user_home_path"
-      if ! asdf list "{{ user.1.name }}" | grep -q "{{ user.1.version }}"; then
-        asdf install "{{ user.1.name }}" "{{ user.1.version }}"
-      fi
-      if [ "{{ user.1.scope }}" = "global" ]; then
-        asdf global "{{ user.1.name }}" "{{ user.1.version }}"
-      elif [ "{{ user.1.scope }}" = "local" ]; then
-        asdf local "{{ user.1.name }}" "{{ user.1.version }}"
+      . /usr/local/bin/setup_asdf_env "{{ item.home_path }}"
+      asdf install "{{ plugin.name }}" "{{ plugin.version }}"
+      if [ "{{ plugin.scope }}" = "global" ]; then
+        asdf global "{{ plugin.name }}" "{{ plugin.version }}"
+      elif [ "{{ plugin.scope }}" = "local" ]; then
+        asdf local "{{ plugin.name }}" "{{ plugin.version }}"
       else
-        echo "Invalid scope: {{ user.1.scope }}"
+        echo "Invalid scope: {{ plugin.scope }}"
         exit 1
       fi
-    executable: "{{ user.0.shell }}"
+    executable: "{{ item.shell }}"
   become: true
-  become_user: "{{ user.0.username }}"
-  loop: "{{ query('subelements', asdf_users, 'plugins', {'skip_missing': true}) }}"
+  become_user: "{{ item.username }}"
+  loop: "{{ query('subelements', enriched_setup_users, 'plugins', {'skip_missing': true}) }}"
   loop_control:
-    loop_var: user
+    loop_var: plugin
   when:
-    - user.1.name is defined
-    - user.1.version is defined
-    - user.1.scope is defined
-    - user.0.username != 'root'
+    - plugin.name is defined
+    - plugin.version is defined
+    - plugin.scope is defined
+    - item.username != 'root'
   changed_when: false

--- a/roles/asdf/tasks/package_individual_setup.yml
+++ b/roles/asdf/tasks/package_individual_setup.yml
@@ -2,7 +2,8 @@
 - name: Get all plugins for each user
   ansible.builtin.shell:
     cmd: |
-      . /usr/local/bin/setup_asdf_env "{{ user.username }}"
+      set -o pipefail
+      . /usr/local/bin/setup_asdf_env "{{ user.username }}" "{{ (ansible_os_family == 'Darwin') | ternary('/Users', '/home') }}/{{ user.username }}"
       asdf plugin list
     executable: "{{ user.shell }}"
   register: asdf_plugins
@@ -18,7 +19,7 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      . /usr/local/bin/setup_asdf_env "{{ user_plugin.0.username }}"
+      . /usr/local/bin/setup_asdf_env "{{ user_plugin.0.username }}" "{{ (ansible_os_family == 'Darwin') | ternary('/Users', '/home') }}/{{ user_plugin.0.username }}"
       if ! asdf plugin list | grep -q "{{ user_plugin.1.name }}"; then
         asdf plugin add "{{ user_plugin.1.name }}"
       fi
@@ -35,7 +36,7 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      . /usr/local/bin/setup_asdf_env "{{ user_plugin.0.username }}"
+      . /usr/local/bin/setup_asdf_env "{{ user_plugin.0.username }}" "{{ (ansible_os_family == 'Darwin') | ternary('/Users', '/home') }}/{{ user_plugin.0.username }}"
       if ! asdf list "{{ user_plugin.1.name }}" | grep -q "{{ user_plugin.1.version }}"; then
         asdf install "{{ user_plugin.1.name }}" "{{ user_plugin.1.version }}"
       fi

--- a/roles/asdf/tasks/package_setup.yml
+++ b/roles/asdf/tasks/package_setup.yml
@@ -5,6 +5,3 @@
 
 - name: Install asdf plugins and set versions for each user
   ansible.builtin.include_tasks: package_individual_setup.yml
-  loop: "{{ asdf_users }}"
-  loop_control:
-    loop_var: asdf_setup_user

--- a/roles/asdf/tasks/package_setup.yml
+++ b/roles/asdf/tasks/package_setup.yml
@@ -1,7 +1,0 @@
----
-- name: Install libyaml from source
-  ansible.builtin.include_tasks: install_libyaml.yml
-  when: ansible_distribution == 'Rocky'
-
-- name: Install asdf plugins and set versions for each user
-  ansible.builtin.include_tasks: package_individual_setup.yml

--- a/roles/asdf/tasks/update_shell_profiles.yml
+++ b/roles/asdf/tasks/update_shell_profiles.yml
@@ -1,7 +1,7 @@
 ---
 - name: Update shell profile for user
   ansible.builtin.lineinfile:
-    path: "{{ asdf_home_path }}/{{ user.username }}/{{ (user.shell | default('/bin/bash') == '/bin/zsh') | ternary('.zshrc', '.bashrc') }}"
+    path: "{{ asdf_home_path }}/{{ (user.shell | default('/bin/bash') == '/bin/zsh') | ternary('.zshrc', '.bashrc') }}"
     line: "{{ line }}"
     insertafter: EOF
     create: true

--- a/roles/asdf/tasks/update_shell_profiles.yml
+++ b/roles/asdf/tasks/update_shell_profiles.yml
@@ -1,7 +1,7 @@
 ---
 - name: Update shell profile for user
   ansible.builtin.lineinfile:
-    path: "{{ home_path }}/{{ user.username }}/{{ (user.shell | default('/bin/bash') == '/bin/zsh') | ternary('.zshrc', '.bashrc') }}"
+    path: "{{ asdf_home_path }}/{{ user.username }}/{{ (user.shell | default('/bin/bash') == '/bin/zsh') | ternary('.zshrc', '.bashrc') }}"
     line: "{{ line }}"
     insertafter: EOF
     create: true

--- a/roles/asdf/tasks/update_shell_profiles.yml
+++ b/roles/asdf/tasks/update_shell_profiles.yml
@@ -1,0 +1,11 @@
+---
+- name: Update shell profile for user
+  ansible.builtin.lineinfile:
+    path: "{{ home_path }}/{{ user.username }}/{{ (user.shell | default('/bin/bash') == '/bin/zsh') | ternary('.zshrc', '.bashrc') }}"
+    line: "{{ line }}"
+    insertafter: EOF
+    create: true
+    mode: "0644"
+  loop: "{{ user.shell_profile_lines }}"
+  loop_control:
+    loop_var: line

--- a/roles/asdf/tasks/update_shell_profiles.yml
+++ b/roles/asdf/tasks/update_shell_profiles.yml
@@ -1,11 +1,11 @@
 ---
 - name: Update shell profile for user
   ansible.builtin.lineinfile:
-    path: "{{ asdf_home_path }}/{{ (user.shell | default('/bin/bash') == '/bin/zsh') | ternary('.zshrc', '.bashrc') }}"
+    path: "{{ user.home_path }}/{{ (user.shell | default('/bin/bash') == '/bin/zsh') | ternary('.zshrc', '.bashrc') }}"
     line: "{{ line }}"
     insertafter: EOF
     create: true
     mode: "0644"
-  loop: "{{ user.shell_profile_lines }}"
-  loop_control:
-    loop_var: line
+  loop: "{{ line }}"
+  when:
+    - user.username != 'root'

--- a/roles/logging/README.md
+++ b/roles/logging/README.md
@@ -1,7 +1,7 @@
 # Ansible Role: Logging
 
-This role creates logging directories and configures
-log rotation for a provided path.
+This role provides logging directories and log rotation for other roles,
+ensuring proper logging infrastructure on Unix-like systems.
 
 ---
 
@@ -18,79 +18,38 @@ log rotation for a provided path.
     "molecule-plugins[docker]"
   ```
 
+---
+
 ## Role Variables
 
-| Variable                    | Default Value | Description                    |
-| --------------------------- | ------------- | ------------------------------ |
-| logging_directories         | [See Below]   | Directories for logging        |
-| logging_log_rotation_config | [See Below]   | Configuration for log rotation |
+| Variable                    | Default Value | Description                            |
+| --------------------------- | ------------- | -------------------------------------- |
+| logging_directories         | [See below]   | Directories to be created for logging. |
+| logging_log_rotation_config | Configurable  | Configuration for log rotation.        |
 
 ### Default Configuration for `logging_directories`
 
-The `logging_directories` variable is a list of dictionaries, each containing:
-
-- `path`: Path of the logging directory, default is `"/var/log/ansible"`
-- `owner`: Owner of the directory, default is `"root"`
-- `group`: Group of the directory, default is `"root"`
-- `mode`: File mode, default is `"0755"`
-
-### Default Configuration for `logging_log_rotation_config`
-
-Default settings for log rotation:
-
-- `path`: Log file path, default is `"/var/log/ansible/*.log"`
-- `rotate`: Number of rotations, default is `4`
-- `frequency`: Rotation frequency, default is `"weekly"`
-- `compress`: Compress old versions, default is `true`
-- `missingok`: Ignore missing log files, default is `true`
-- `notifempty`: Don't rotate if empty, default is `true`
-- `create`: Create new log file, default is `true`
-- `dateext`: Use date extension, default is `true`
-- `owner`: Owner of the log files, default is `"root"`
-- `group`: Group of the log files, default is `"root"`
+- `path`: The path of the directory to be created for logging, e.g., "/var/log/ansible"
 
 ---
 
-## Local Development
-
-To develop locally, run the following from the repository root:
-
-```bash
-ansible-galaxy install -r requirements.yml
-PATH_TO_ROLE="${PWD}"
-ln -s "${PATH_TO_ROLE}" "${HOME}/.ansible/roles/cowdogmoo.logging"
-```
-
 ## Testing
 
-For local testing:
-
-- Use [act](https://github.com/nektos/act) for local GitHub Actions testing.
-
-- Run Molecule tests:
-
-  ```bash
-  ACTION="molecule"
-  if [[ $(uname) == "Darwin" ]]; then
-    act -j $ACTION --container-architecture linux/amd64
-  fi
-  ```
-
-To test changes made to this role locally:
+To test the role, use Molecule:
 
 ```bash
-molecule create
 molecule converge
 molecule idempotence
+molecule verify
 molecule destroy
 ```
 
 ## Role Tasks
 
-The role includes the following main tasks:
+Key tasks in this role:
 
-1. Ensure logging directories exist.
-2. Set up log rotation.
+- Ensure logging directories exist.
+- Setup log rotation.
 
 ## Platforms
 

--- a/roles/package_management/README.md
+++ b/roles/package_management/README.md
@@ -1,7 +1,7 @@
 # Ansible Role: Package Management
 
-This role manages package installations and cleanups on Debian-based
-and Red Hat-based systems.
+This role manages package installations and cleanups on Debian and Red
+Hat-based systems.
 
 ---
 
@@ -18,51 +18,43 @@ and Red Hat-based systems.
     "molecule-plugins[docker]"
   ```
 
+---
+
 ## Role Variables
 
-| Variable                                    | Default Value                                                                                                                                                     | Description                     |
-| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| package_management_common_install_packages  | bash, ca-certificates, colordiff, dbus-x11, file, gcc, git, less, make, net-tools, procps, rsync, sudo, terminator, tree, wget, vim, zsh                          | Common packages for all systems |
-| package_management_debian_specific_packages | curl, fonts-powerline, inetutils-ping, locales, software-properties-common, tigervnc-standalone-server, tigervnc-tools, xfce4-goodies, xfce4, zsh-autosuggestions | Debian-specific packages        |
-| package_management_redhat_specific_packages | epel-release, tigervnc, tigervnc-server                                                                                                                           | Red Hat-specific packages       |
+| Variable                                    | Default Value                                        |
+| ------------------------------------------- | ---------------------------------------------------- |
+| package_management_common_install_packages  | autoconf, bash, bison, ... (list of common packages) |
+| package_management_install_packages         | Conditional selection based on OS family             |
+| package_management_debian_specific_packages | build-essential, curl, fonts-powerline, ...          |
+| package_management_redhat_specific_packages | bzip2-devel, epel-release, gcc, gcc-c++, ...         |
 
 ---
 
-## Local Development
-
-To develop locally, run the following from the repository root:
-
-```bash
-ansible-galaxy install -r requirements.yml
-export PATH_TO_ROLE="${PWD}"
-ln -s "${PATH_TO_ROLE}" "${HOME}/.ansible/roles/cowdogmoo.package_management"
-```
-
 ## Testing
 
-- Use [act](https://github.com/nektos/act) for local GitHub Actions testing.
+To test the role, use Molecule:
 
-- Run Molecule tests:
-
-  ```bash
-  molecule create
-  molecule converge
-  molecule idempotence
-  molecule destroy
-  ```
+```bash
+molecule converge
+molecule idempotence
+molecule verify
+molecule destroy
+```
 
 ## Role Tasks
 
-1. Include common variables.
-2. Install distribution-specific packages.
-3. Install common packages.
-4. Cleanup unnecessary packages.
-5. Configure .xinitrc for XFCE (Red Hat).
-6. Manage systemd default target (Red Hat).
+Key tasks in this role:
+
+- Include common variables.
+- Install distribution-specific packages.
+- Install common packages.
+- Configure .xinitrc for XFCE (Red Hat).
+- Check and set systemd default target (Red Hat).
 
 ## Platforms
 
-Tested on:
+This role is tested on the following platforms:
 
 - Ubuntu
 - Kali

--- a/roles/package_management/tasks/main.yml
+++ b/roles/package_management/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Include common variables
   ansible.builtin.include_vars: "main.yml"
-  tags: always
+  when: ansible_system != 'Darwin'
 
 - name: Install distribution-specific packages
   become: true
@@ -9,7 +9,9 @@
     name: "{{ package_management_install_packages }}"
     state: present
     update_cache: true
-  when: ansible_os_family in ['Debian', 'RedHat']
+  when:
+    - ansible_os_family in ['Debian', 'RedHat']
+    - ansible_system != 'Darwin'
   environment: "{{ (ansible_os_family == 'Debian') | ternary({'DEBIAN_FRONTEND': 'noninteractive'}, {}) }}"
   tags: distro-packages
 
@@ -19,6 +21,7 @@
     name: "{{ package_management_common_install_packages }}"
     state: present
     update_cache: true
+  when: ansible_system != 'Darwin'
   tags: common-packages
 
 # Red Hat specific tasks

--- a/roles/package_management/tasks/main.yml
+++ b/roles/package_management/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Include common variables
   ansible.builtin.include_vars: "main.yml"
-  when: ansible_system != 'Darwin'
+  when: ansible_os_family in ['Debian', 'RedHat']
 
 - name: Install distribution-specific packages
   become: true
@@ -11,7 +11,6 @@
     update_cache: true
   when:
     - ansible_os_family in ['Debian', 'RedHat']
-    - ansible_system != 'Darwin'
   environment: "{{ (ansible_os_family == 'Debian') | ternary({'DEBIAN_FRONTEND': 'noninteractive'}, {}) }}"
   tags: distro-packages
 
@@ -21,7 +20,7 @@
     name: "{{ package_management_common_install_packages }}"
     state: present
     update_cache: true
-  when: ansible_system != 'Darwin'
+  when: ansible_os_family in ['Debian', 'RedHat']
   tags: common-packages
 
 # Red Hat specific tasks

--- a/roles/package_management/vars/main.yml
+++ b/roles/package_management/vars/main.yml
@@ -14,6 +14,7 @@ package_management_common_install_packages:
   - make
   - net-tools
   - procps
+  - python3
   - rsync
   - sudo
   - terminator

--- a/roles/user_setup/README.md
+++ b/roles/user_setup/README.md
@@ -1,6 +1,7 @@
 # Ansible Role: User Setup
 
-This role sets up user accounts with optional sudo privileges for Unix-like systems.
+This role sets up user accounts with optional sudo privileges for Unix-like
+systems.
 
 ---
 
@@ -17,69 +18,56 @@ This role sets up user accounts with optional sudo privileges for Unix-like syst
     "molecule-plugins[docker]"
   ```
 
+---
+
 ## Role Variables
 
-| Variable                    | Default Value                       | Description                                                                                  |
-| --------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------- |
-| user_setup_install_packages | ["bash", "sudo"]                    | Base packages to install                                                                     |
-| user_setup_default_username | {{ ansible_distribution \| lower }} | Default username based on the Ansible distribution                                           |
-| user_setup_default_users    | Configurable                        | List of users with attributes: username, usergroup, sudo, shell (defaults provided in below) |
+| Variable                    | Default Value                | Description                  |
+| --------------------------- | ---------------------------- | ---------------------------- |
+| user_setup_install_packages | bash, sudo                   | Base packages for users.     |
+| user_setup_default_users    | Defined in defaults/main.yml | Default user configurations. |
 
 ### Default Configuration for `user_setup_default_users`
 
-The `user_setup_default_users` variable is a list of dictionaries, each containing:
+- `username`: Default username based on OS distribution.
+- `usergroup`: Default group based on OS distribution.
+- `sudo`: Whether the user has sudo privileges.
+- `shell`: Default shell for the user.
 
-- `username`: Default is `{{ user_setup_default_username }}`
-- `usergroup`: Group of the user, default is `{{ user_setup_default_username }}`
-- `sudo`: Whether the user has sudo access, default is `true`
-- `shell`: Default shell for the user, default is `/bin/zsh`
+Example `user_setup_default_users` configuration:
+
+```yaml
+- username: "{{ ansible_env.USER if ansible_distribution == 'MacOSX' else
+  user_setup_default_username }}"
+  usergroup: "{{ 'staff' if ansible_distribution == 'MacOSX' else
+  user_setup_default_group }}"
+  sudo: true
+  shell: /bin/zsh
+```
 
 ---
 
-## Local Development
-
-To develop locally, run the following from the repository root:
-
-```bash
-ansible-galaxy install -r requirements.yml
-PATH_TO_ROLE="${PWD}"
-ln -s "${PATH_TO_ROLE}" "${HOME}/.ansible/roles/cowdogmoo.user_setup"
-```
-
 ## Testing
 
-For local testing:
-
-- Install [act](https://github.com/nektos/act) for running GitHub Actions locally.
-
-- Run:
-
-  ```bash
-  ACTION="molecule"
-  if [[ $(uname) == "Darwin" ]]; then
-    act -j $ACTION --container-architecture linux/amd64
-  fi
-  ```
-
-To test changes made to this role locally:
+To test the role, use Molecule:
 
 ```bash
-molecule create
 molecule converge
 molecule idempotence
+molecule verify
 molecule destroy
 ```
 
 ## Role Tasks
 
-The role includes the following main tasks:
+Key tasks in this role:
 
-1. Gather the list of unique shells to install.
-2. Install base packages.
-3. Install user-specific shells.
-4. Ensure groups exist for users.
-5. Create users.
-6. Provide sudoers access for relevant users.
+- Gather list of unique shells to install.
+- Install base packages for all users.
+- Install user-specific shells.
+- Ensure groups exist for users.
+- Create users with specific attributes.
+- Provide sudoers access for relevant users.
 
 ## Platforms
 

--- a/roles/user_setup/defaults/main.yml
+++ b/roles/user_setup/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
 user_setup_default_username: "{{ ansible_distribution | lower }}"
+user_setup_default_group: "{{ ansible_distribution | lower }}"
 user_setup_default_users:
   - username: "{{ user_setup_default_username }}"
-    usergroup: "{{ user_setup_default_username }}"
+    usergroup: "{{ user_setup_default_group }}"
     sudo: true
     shell: /bin/zsh

--- a/roles/user_setup/defaults/main.yml
+++ b/roles/user_setup/defaults/main.yml
@@ -2,7 +2,7 @@
 user_setup_default_username: "{{ ansible_distribution | lower }}"
 user_setup_default_group: "{{ ansible_distribution | lower }}"
 user_setup_default_users:
-  - username: "{{ user_setup_default_username }}"
-    usergroup: "{{ user_setup_default_group }}"
+  - username: "{{ ansible_env.USER if ansible_distribution == 'mac' else user_setup_default_username }}"
+    usergroup: "{{ 'staff' if ansible_distribution == 'mac' else user_setup_default_group }}"
     sudo: true
     shell: /bin/zsh

--- a/roles/user_setup/defaults/main.yml
+++ b/roles/user_setup/defaults/main.yml
@@ -2,7 +2,7 @@
 user_setup_default_username: "{{ ansible_distribution | lower }}"
 user_setup_default_group: "{{ ansible_distribution | lower }}"
 user_setup_default_users:
-  - username: "{{ ansible_env.USER if ansible_distribution == 'mac' else user_setup_default_username }}"
-    usergroup: "{{ 'staff' if ansible_distribution == 'mac' else user_setup_default_group }}"
+  - username: "{{ ansible_env.USER if ansible_distribution == 'MacOSX' else user_setup_default_username }}"
+    usergroup: "{{ 'staff' if ansible_distribution == 'MacOSX' else user_setup_default_group }}"
     sudo: true
     shell: /bin/zsh

--- a/roles/user_setup/molecule/default/converge.yml
+++ b/roles/user_setup/molecule/default/converge.yml
@@ -3,3 +3,11 @@
   hosts: all
   roles:
     - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+      vars:
+        home_path: >-
+          {{
+            '/Users' if ansible_os_family == 'Darwin' and ansible_user_id != 'root'
+            else '/var/root' if ansible_os_family == 'Darwin' and ansible_user_id == 'root'
+            else '/root' if ansible_user_id == 'root'
+            else '/home'
+          }}

--- a/roles/user_setup/molecule/default/converge.yml
+++ b/roles/user_setup/molecule/default/converge.yml
@@ -3,11 +3,3 @@
   hosts: all
   roles:
     - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
-      vars:
-        home_path: >-
-          {{
-            '/Users' if ansible_os_family == 'Darwin' and ansible_user_id != 'root'
-            else '/var/root' if ansible_os_family == 'Darwin' and ansible_user_id == 'root'
-            else '/root' if ansible_user_id == 'root'
-            else '/home'
-          }}

--- a/roles/user_setup/molecule/default/verify.yml
+++ b/roles/user_setup/molecule/default/verify.yml
@@ -34,7 +34,7 @@
     - name: Assert user creation
       ansible.builtin.assert:
         that:
-          - "'{{ item.username }}' in (user_check.results | map(attribute='stdout') | list)"
+          - item.username in (user_check.results | map(attribute='stdout') | list)
       loop: "{{ user_setup_default_users }}"
       loop_control:
         label: "{{ item.username }}"

--- a/roles/user_setup/tasks/main.yml
+++ b/roles/user_setup/tasks/main.yml
@@ -49,11 +49,11 @@
   when: item.usergroup is defined and item.usergroup != ''
   tags: group-setup
 
-- name: Create users (modified for macOS)
+- name: Create users
   become: true
   ansible.builtin.user:
     name: "{{ item.username }}"
-    group: "{{ item.username == user_setup_default_username | ternary(user_setup_default_group, item.usergroup) }}"
+    group: "{{ (item.username == user_setup_default_username) | ternary(user_setup_default_group, item.usergroup) }}"
     shell: "{{ item.shell }}"
   loop: "{{ user_setup_default_users }}"
   when: item.username == user_setup_default_username

--- a/roles/user_setup/tasks/main.yml
+++ b/roles/user_setup/tasks/main.yml
@@ -1,4 +1,20 @@
 ---
+- name: Set default username for macOS systems
+  ansible.builtin.set_fact:
+    user_setup_default_username: "{{ ansible_env.USER }}"
+  when: ansible_os_family == 'Darwin'
+
+- name: Determine default group for macOS systems
+  ansible.builtin.command: id -gn
+  register: macos_default_group
+  when: ansible_os_family == 'Darwin'
+  changed_when: false
+
+- name: Set default group for macOS systems
+  ansible.builtin.set_fact:
+    user_setup_default_group: "{{ macos_default_group.stdout }}"
+  when: ansible_os_family == 'Darwin'
+
 - name: Gather the list of unique shells to install
   ansible.builtin.set_fact:
     unique_shells: "{{ user_setup_default_users | map(attribute='shell') | unique | map('regex_replace', '^/bin/(.*)$', '\\1') | list }}"
@@ -33,13 +49,14 @@
   when: item.usergroup is defined and item.usergroup != ''
   tags: group-setup
 
-- name: Create users
+- name: Create users (modified for macOS)
   become: true
   ansible.builtin.user:
     name: "{{ item.username }}"
-    group: "{{ item.usergroup }}"
+    group: "{{ item.username == user_setup_default_username | ternary(user_setup_default_group, item.usergroup) }}"
     shell: "{{ item.shell }}"
   loop: "{{ user_setup_default_users }}"
+  when: item.username == user_setup_default_username
   tags: user-setup
 
 - name: Provide sudoers access for relevant users in sudoers.d

--- a/roles/user_setup/tasks/main.yml
+++ b/roles/user_setup/tasks/main.yml
@@ -16,11 +16,18 @@
   when: ansible_os_family == 'Darwin'
 
 - name: Gather the list of unique shells to install
+  become: true
   ansible.builtin.set_fact:
+    # Gather the list of unique shells to install.
+    # 1. Extract 'shell' attribute from each user.
+    # 2. Filter out duplicate shell entries.
+    # 3. Strip the '/bin/' prefix from each shell name.
+    # 4. Convert the result into a list.
     unique_shells: "{{ user_setup_default_users | map(attribute='shell') | unique | map('regex_replace', '^/bin/(.*)$', '\\1') | list }}"
+
   tags: always
 
-- name: Install base packages
+- name: Install base packages for all users
   become: true
   ansible.builtin.package:
     name: "{{ user_setup_install_packages }}"
@@ -28,6 +35,7 @@
     update_cache: true
   environment: "{{ (ansible_os_family == 'Debian') | ternary({'DEBIAN_FRONTEND': 'noninteractive'}, {}) }}"
   tags: packages
+  when: ansible_os_family != 'Darwin'
 
 - name: Install user-specific shells
   become: true
@@ -35,9 +43,11 @@
     name: "{{ item }}"
     state: present
   loop: "{{ unique_shells }}"
-  when: item != '' and item != 'bash'
-  environment:
-    DEBIAN_FRONTEND: "{{ 'noninteractive' if ansible_distribution == 'Debian' else '' }}"
+  when:
+    - item != ''
+    - item != 'bash'
+    - ansible_os_family != 'Darwin'
+  environment: "{{ (ansible_os_family == 'Debian') | ternary({'DEBIAN_FRONTEND': 'noninteractive'}, {}) }}"
   tags: shells
 
 - name: Ensure groups exist for users
@@ -46,18 +56,18 @@
     name: "{{ item.usergroup }}"
     state: present
   loop: "{{ user_setup_default_users }}"
-  when: item.usergroup is defined and item.usergroup != ''
+  when: item.usergroup is defined and item.usergroup != '' and ansible_os_family != 'Darwin'
   tags: group-setup
 
 - name: Create users
   become: true
   ansible.builtin.user:
     name: "{{ item.username }}"
-    group: "{{ (item.username == user_setup_default_username) | ternary(user_setup_default_group, item.usergroup) }}"
+    group: "{{ item.usergroup }}"
     shell: "{{ item.shell }}"
   loop: "{{ user_setup_default_users }}"
-  when: item.username == user_setup_default_username
   tags: user-setup
+  when: ansible_os_family != 'Darwin'
 
 - name: Provide sudoers access for relevant users in sudoers.d
   become: true
@@ -66,6 +76,6 @@
     content: "{{ item.username }} ALL=(ALL:ALL) NOPASSWD:ALL\n"
     validate: "visudo -cf %s"
     mode: "0440"
-  when: item.sudo
+  when: item.sudo and ansible_os_family != 'Darwin'
   loop: "{{ user_setup_default_users }}"
   tags: sudo-setup

--- a/roles/user_setup/tasks/main.yml
+++ b/roles/user_setup/tasks/main.yml
@@ -1,20 +1,4 @@
 ---
-- name: Set default username for macOS systems
-  ansible.builtin.set_fact:
-    user_setup_default_username: "{{ ansible_env.USER }}"
-  when: ansible_os_family == 'Darwin'
-
-- name: Determine default group for macOS systems
-  ansible.builtin.command: id -gn
-  register: macos_default_group
-  when: ansible_os_family == 'Darwin'
-  changed_when: false
-
-- name: Set default group for macOS systems
-  ansible.builtin.set_fact:
-    user_setup_default_group: "{{ macos_default_group.stdout }}"
-  when: ansible_os_family == 'Darwin'
-
 - name: Gather the list of unique shells to install
   become: true
   ansible.builtin.set_fact:
@@ -24,7 +8,6 @@
     # 3. Strip the '/bin/' prefix from each shell name.
     # 4. Convert the result into a list.
     unique_shells: "{{ user_setup_default_users | map(attribute='shell') | unique | map('regex_replace', '^/bin/(.*)$', '\\1') | list }}"
-
   tags: always
 
 - name: Install base packages for all users

--- a/roles/vnc_setup/README.md
+++ b/roles/vnc_setup/README.md
@@ -18,65 +18,42 @@ and secure remote desktop access for each user on Unix-like systems.
     "molecule-plugins[docker]"
   ```
 
+---
+
 ## Role Variables
 
-| Variable                    | Default Value                                                     | Description                                         |
-| --------------------------- | ----------------------------------------------------------------- | --------------------------------------------------- |
-| vnc_setup_vncpwd_repo_url   | [vncpwd Git repo URL](https://github.com/jeroennijhof/vncpwd.git) | URL for cloning vncpwd repo.                        |
-| vnc_setup_client_options    | "-geometry 1920x1080"                                             | Options for VNC client configuration.               |
-| vnc_setup_systemd           | true                                                              | Determines if systemd services are set up.          |
-| vnc_setup_users             | Configurable                                                      | List of users to set up with VNC.                   |
-| vnc_setup_default_username  | "{{ ansible_distribution \| lower }}"                             | Default username derived from ansible_distribution. |
-| vnc_setup_vncpwd_clone_path | "/tmp/vncpwd"                                                     | Path to clone vncpwd repo.                          |
-| vnc_setup_vncpwd_path       | "/usr/local/bin/vncpwd"                                           | Path to install vncpwd executable.                  |
+| Variable                    | Default Value                                                                            | Description                       |
+| --------------------------- | ---------------------------------------------------------------------------------------- | --------------------------------- |
+| vnc_setup_vncpwd_repo_url   | [https://github.com/jeroennijhof/vncpwd.git](https://github.com/jeroennijhof/vncpwd.git) | URL for cloning vncpwd repo.      |
+| vnc_setup_client_options    | "-geometry 1920x1080"                                                                    | VNC client configuration options. |
+| vnc_setup_systemd           | true                                                                                     | Enable/disable systemd setup.     |
+| vnc_setup_users             | Configurable                                                                             | List of users for VNC setup.      |
+| vnc_setup_default_username  | "{{ ansible_distribution \| lower }}"                                                    | Default username.                 |
+| vnc_setup_vncpwd_clone_path | "/tmp/vncpwd"                                                                            | Clone path for vncpwd repo.       |
+| vnc_setup_vncpwd_path       | "/usr/local/bin/vncpwd"                                                                  | Path for vncpwd executable.       |
 
 ---
 
-## Local Development
-
-To develop locally, run the following from the repository root:
-
-```bash
-ansible-galaxy install -r requirements.yml
-PATH_TO_ROLE="${PWD}"
-ln -s "${PATH_TO_ROLE}" "${HOME}/.ansible/roles/cowdogmoo.vnc_setup"
-```
-
 ## Testing
 
-For local testing:
-
-- Use [act](https://github.com/nektos/act) for local GitHub Actions testing.
-
-- Run Molecule tests:
-
-  ```bash
-  ACTION="molecule"
-  if [[ $(uname) == "Darwin" ]]; then
-    act -j $ACTION --container-architecture linux/amd64
-  fi
-  ```
-
-To test changes made to this role locally:
+To test the role, use Molecule:
 
 ```bash
-molecule create
 molecule converge
 molecule idempotence
+molecule verify
 molecule destroy
 ```
 
 ## Role Tasks
 
-The role includes the following main tasks:
-
-1. Install and configure vncpwd.
-2. Set up user-specific .vnc directories.
-3. Generate random VNC passwords.
-4. Create user runtime directories.
-5. Enable lingering and systemd directories for users.
-6. Configure VNC service files and permissions.
-7. Add scripts to start VNC and set XDG_RUNTIME_DIR.
+- Install and configure vncpwd.
+- Set up .vnc directories for users.
+- Generate random VNC passwords.
+- Create user runtime directories.
+- Enable lingering and systemd directories.
+- Configure VNC service files and permissions.
+- Add scripts for starting VNC.
 
 ## Platforms
 

--- a/roles/zsh_setup/README.md
+++ b/roles/zsh_setup/README.md
@@ -18,75 +18,51 @@ Unix-like systems.
     "molecule-plugins[docker]"
   ```
 
+---
+
 ## Role Variables
 
-| Variable                         | Default Value                                                           | Description                                                                       |
-| -------------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| zsh_setup_omz_install_script_url | "https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh" | URL for oh-my-zsh install script                                                  |
-| zsh_setup_theme                  | "af-magic"                                                              | Default theme for zsh                                                             |
-| zsh_setup_default_username       | {{ ansible_distribution \| lower }}                                     | Default username based on the Ansible distribution                                |
-| zsh_setup_users                  | Configurable                                                            | List of users for zsh setup. Each user dictionary includes username and usergroup |
+| Variable                         | Default Value                                                           | Description              |
+| -------------------------------- | ----------------------------------------------------------------------- | ------------------------ |
+| zsh_setup_omz_install_script_url | "https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh" | oh-my-zsh install script |
+| zsh_setup_theme                  | "af-magic"                                                              | Default theme for zsh    |
+| zsh_setup_default_username       | {{ ansible_distribution \| lower }}                                     | Default username         |
+| zsh_setup_users                  | Configurable                                                            | Users for zsh setup      |
 
 ### Default Configuration for `zsh_setup_users`
-
-The `zsh_setup_users` variable is a list of dictionaries, each containing:
 
 - `username`: Specified user or default `{{ zsh_setup_default_username }}`
 - `usergroup`: User's group, default is `{{ zsh_setup_default_username }}`
 
 ---
 
-## Local Development
-
-To develop locally, run the following from the repository root:
-
-```bash
-ansible-galaxy install -r requirements.yml
-PATH_TO_ROLE="${PWD}"
-ln -s "${PATH_TO_ROLE}" "${HOME}/.ansible/roles/cowdogmoo.zsh_setup"
-```
-
 ## Testing
 
-For local testing:
-
-- Use [act](https://github.com/nektos/act) for local GitHub Actions testing.
-
-- Run Molecule tests:
-
-  ```bash
-  ACTION="molecule"
-  if [[ $(uname) == "Darwin" ]]; then
-    act -j $ACTION --container-architecture linux/amd64
-  fi
-  ```
-
-To test changes made to this role locally:
+To test the role, use Molecule:
 
 ```bash
-molecule create
 molecule converge
 molecule idempotence
+molecule verify
 molecule destroy
 ```
 
 ## Role Tasks
 
-The role includes the following main tasks:
-
-1. Check if .oh-my-zsh exists for users.
-2. Download oh-my-zsh install script for users.
-3. Install oh-my-zsh for users.
-4. Check and ensure zsh-installer.sh is executable.
-5. Execute zsh-installer.sh for users.
-6. Remove zsh-installer.sh after installation.
-7. Create per-user $HOME/.zshrc files.
+- Check if .oh-my-zsh exists for users.
+- Download oh-my-zsh install script.
+- Install oh-my-zsh for users.
+- Ensure zsh-installer.sh is executable.
+- Execute zsh-installer.sh for users.
+- Remove zsh-installer.sh after installation.
+- Create per-user $HOME/.zshrc files.
 
 ## Platforms
 
 This role is tested on the following platforms:
 
 - Ubuntu
+- macOS
 - Kali
 - EL (Enterprise Linux)
 

--- a/roles/zsh_setup/defaults/main.yml
+++ b/roles/zsh_setup/defaults/main.yml
@@ -1,11 +1,12 @@
 ---
-# Path to clone [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh).
+# Oh My ZSH install script URL
 zsh_setup_omz_install_script_url: "https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh"
 # ZSH theme
 zsh_setup_theme: "af-magic"
 # Default username value, derived from the ansible_distribution variable
 zsh_setup_default_username: "{{ ansible_distribution | lower }}"
+zsh_setup_default_group: "{{ ansible_distribution | lower }}"
 # List of users to configure zsh for
 zsh_setup_users:
-  - username: "{{ zsh_setup_default_username }}"
-    usergroup: "{{ zsh_setup_default_username }}"
+  - username: "{{ ansible_env.USER if ansible_distribution == 'mac' else zsh_setup_default_username }}"
+    usergroup: "{{ 'staff' if ansible_distribution == 'mac' else zsh_setup_default_group }}"

--- a/roles/zsh_setup/defaults/main.yml
+++ b/roles/zsh_setup/defaults/main.yml
@@ -9,5 +9,3 @@ zsh_setup_default_username: "{{ ansible_distribution | lower }}"
 zsh_setup_users:
   - username: "{{ zsh_setup_default_username }}"
     usergroup: "{{ zsh_setup_default_username }}"
-  - username: "root"
-    usergroup: "root"

--- a/roles/zsh_setup/molecule/default/converge.yml
+++ b/roles/zsh_setup/molecule/default/converge.yml
@@ -3,5 +3,4 @@
   hosts: all
   roles:
     - role: cowdogmoo.workstation.user_setup
-    - role: cowdogmoo.workstation.package_management
     - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/roles/zsh_setup/molecule/default/verify.yml
+++ b/roles/zsh_setup/molecule/default/verify.yml
@@ -7,64 +7,69 @@
       ansible.builtin.include_vars:
         file: "../../defaults/main.yml"
 
-    - name: Simulate failed package installation
-      block:
-        - name: Check contents of .zshrc
-          ansible.builtin.command: "cat {{ (item.username == 'root') | ternary('/root', '/home/' + item.username) }}/.zshrc"
-          register: zshrc_contents
-          changed_when: false
-          with_items: "{{ zsh_setup_users }}"
+    - name: Check contents of .zshrc
+      ansible.builtin.command: "cat {{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.zshrc"
+      register: zshrc_contents
+      changed_when: false
+      loop: "{{ zsh_setup_users }}"
 
-        - name: Confirm .oh-my-zsh is installed for all zsh_setup_users
-          ansible.builtin.stat:
-            path: "{{ (item.username == 'root') | ternary('/root', '/home/' + item.username) }}/.oh-my-zsh"
-          register: oh_my_zsh_test
-          with_items: "{{ zsh_setup_users }}"
+    - name: Confirm .oh-my-zsh is installed for all zsh_setup_users
+      ansible.builtin.stat:
+        path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.oh-my-zsh"
+      register: oh_my_zsh_test
+      loop: "{{ zsh_setup_users }}"
 
-        - name: Assert .oh-my-zsh installation
-          ansible.builtin.assert:
-            that:
-              - "oh_my_zsh_test.results[item | int].stat.exists"
-            msg: ".oh-my-zsh installation check failed for {{ item.username }}"
-          with_items: "{{ zsh_setup_users }}"
+    - name: Assert .oh-my-zsh installation
+      ansible.builtin.assert:
+        that:
+          - "oh_my_zsh_test.results[item | int].stat.exists"
+        msg: ".oh-my-zsh installation check failed for {{ item.username }}"
+      loop: "{{ zsh_setup_users }}"
 
-        - name: Confirm zsh-installer.sh is removed for all zsh_setup_users
-          ansible.builtin.stat:
-            path: "{{ (item.username == 'root') | ternary('/root', '/home/' + item.username) }}/zsh-installer.sh"
-          register: zsh_installer_test
-          with_items: "{{ zsh_setup_users }}"
+    - name: Confirm zsh-installer.sh is removed for all zsh_setup_users
+      ansible.builtin.stat:
+        path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}/zsh-installer.sh"
+      register: zsh_installer_test
+      loop: "{{ zsh_setup_users }}"
 
-        - name: Assert zsh-installer.sh removal
-          ansible.builtin.assert:
-            that:
-              - "not zsh_installer_test.results[item | int].stat.exists"
-            msg: "zsh-installer.sh removal check failed for {{ item.username }}"
-          with_items: "{{ zsh_setup_users }}"
+    - name: Assert zsh-installer.sh removal
+      ansible.builtin.assert:
+        that:
+          - "not zsh_installer_test.results[item | int].stat.exists"
+        msg: "zsh-installer.sh removal check failed for {{ item.username }}"
+      loop: "{{ zsh_setup_users }}"
 
-        - name: Confirm per-user $HOME/.zshrc files exist for all zsh_setup_users
-          ansible.builtin.stat:
-            path: "{{ (item.username == 'root') | ternary('/root', '/home/' + item.username) }}/.zshrc"
-          register: zshrc_test
-          with_items: "{{ zsh_setup_users }}"
+    - name: Confirm per-user $HOME/.zshrc files exist for all zsh_setup_users
+      ansible.builtin.stat:
+        path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.zshrc"
+      register: zshrc_test
+      loop: "{{ zsh_setup_users }}"
 
-        - name: Assert per-user $HOME/.zshrc files
-          ansible.builtin.assert:
-            that:
-              - "zshrc_test.results[item | int].stat.exists"
-              - "zshrc_test.results[item | int].stat.mode == '0644'"
-            msg: "$HOME/.zshrc file check failed for {{ item.username }}"
-          with_items: "{{ zsh_setup_users }}"
+    - name: Assert per-user $HOME/.zshrc files
+      ansible.builtin.assert:
+        that:
+          - "zshrc_test.results[item | int].stat.exists"
+          - "zshrc_test.results[item | int].stat.mode == '0644'"
+        msg: "$HOME/.zshrc file check failed for {{ item.username }}"
+      loop: "{{ zsh_setup_users }}"
 
-        - name: Confirm per-user $HOME/.oh-my-zsh directories exist for all zsh_setup_users
-          ansible.builtin.stat:
-            path: "{{ (item.username == 'root') | ternary('/root', '/home/' + item.username) }}/.oh-my-zsh"
-          register: oh_my_zsh_test
-          with_items: "{{ zsh_setup_users }}"
+    - name: Confirm per-user $HOME/.oh-my-zsh directories exist for all zsh_setup_users
+      ansible.builtin.stat:
+        path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.oh-my-zsh"
+      register: oh_my_zsh_test
+      loop: "{{ zsh_setup_users }}"
 
-        - name: Assert per-user $HOME/.oh-my-zsh directories
-          ansible.builtin.assert:
-            that:
-              - "oh_my_zsh_test.results[item | int].stat.exists"
-              - "oh_my_zsh_test.results[item | int].stat.mode == '0755'"
-            msg: "$HOME/.oh-my-zsh directory check failed for {{ item.username }}"
-          with_items: "{{ zsh_setup_users }}"
+    - name: Assert per-user $HOME/.oh-my-zsh directories
+      ansible.builtin.assert:
+        that:
+          - "oh_my_zsh_test.results[item | int].stat.exists"
+          - "oh_my_zsh_test.results[item | int].stat.mode == '0755'"
+        msg: "$HOME/.oh-my-zsh directory check failed for {{ item.username }}"
+      loop: "{{ zsh_setup_users }}"
+
+    - name: Assert .oh-my-zsh installation
+      ansible.builtin.assert:
+        that:
+          - "oh_my_zsh_test.results[item | int].stat.exists"
+        msg: ".oh-my-zsh installation check failed for {{ item.username }}"
+      loop: "{{ zsh_setup_users }}"

--- a/roles/zsh_setup/molecule/default/verify.yml
+++ b/roles/zsh_setup/molecule/default/verify.yml
@@ -51,7 +51,7 @@
           ansible.builtin.assert:
             that:
               - "zshrc_test.results[item | int].stat.exists"
-              - "zshrc_test.results[item | int].stat.mode == '0755'"
+              - "zshrc_test.results[item | int].stat.mode == '0644'"
             msg: "$HOME/.zshrc file check failed for {{ item.username }}"
           with_items: "{{ zsh_setup_users }}"
 

--- a/roles/zsh_setup/molecule/default/verify.yml
+++ b/roles/zsh_setup/molecule/default/verify.yml
@@ -7,43 +7,46 @@
       ansible.builtin.include_vars:
         file: "../../defaults/main.yml"
 
-    - name: Check contents of .zshrc
-      ansible.builtin.command: "cat {{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.zshrc"
-      register: zshrc_contents
-      changed_when: false
-      loop: "{{ zsh_setup_users }}"
+    - name: Define zsh_setup_users
+      ansible.builtin.set_fact:
+        zsh_setup_users:
+          - username: "{{ ansible_env.USER if ansible_distribution == 'mac' else zsh_setup_default_username }}"
+            usergroup: "{{ 'staff' if ansible_distribution == 'mac' else zsh_setup_default_group }}"
+
+    - name: Include get_enriched_users tasks
+      ansible.builtin.include_tasks: "../../tasks/get_enriched_users.yml"
 
     - name: Confirm .oh-my-zsh is installed for all zsh_setup_users
       ansible.builtin.stat:
-        path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.oh-my-zsh"
+        path: "{{ item.home_path }}/.oh-my-zsh"
       register: oh_my_zsh_test
-      loop: "{{ zsh_setup_users }}"
+      loop: "{{ enriched_setup_users }}"
 
     - name: Assert .oh-my-zsh installation
       ansible.builtin.assert:
         that:
           - "oh_my_zsh_test.results[item | int].stat.exists"
         msg: ".oh-my-zsh installation check failed for {{ item.username }}"
-      loop: "{{ zsh_setup_users }}"
+      loop: "{{ enriched_setup_users }}"
 
-    - name: Confirm zsh-installer.sh is removed for all zsh_setup_users
+    - name: Confirm omz-installer.sh is removed for all zsh_setup_users
       ansible.builtin.stat:
-        path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}/zsh-installer.sh"
+        path: "{{ item.home_path }}/omz-installer.sh"
       register: zsh_installer_test
-      loop: "{{ zsh_setup_users }}"
+      loop: "{{ enriched_setup_users }}"
 
-    - name: Assert zsh-installer.sh removal
+    - name: Assert omz-installer.sh removal
       ansible.builtin.assert:
         that:
           - "not zsh_installer_test.results[item | int].stat.exists"
         msg: "zsh-installer.sh removal check failed for {{ item.username }}"
-      loop: "{{ zsh_setup_users }}"
+      loop: "{{ enriched_setup_users }}"
 
     - name: Confirm per-user $HOME/.zshrc files exist for all zsh_setup_users
       ansible.builtin.stat:
-        path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.zshrc"
+        path: "{{ item.home_path }}/.zshrc"
       register: zshrc_test
-      loop: "{{ zsh_setup_users }}"
+      loop: "{{ enriched_setup_users }}"
 
     - name: Assert per-user $HOME/.zshrc files
       ansible.builtin.assert:
@@ -51,13 +54,13 @@
           - "zshrc_test.results[item | int].stat.exists"
           - "zshrc_test.results[item | int].stat.mode == '0644'"
         msg: "$HOME/.zshrc file check failed for {{ item.username }}"
-      loop: "{{ zsh_setup_users }}"
+      loop: "{{ enriched_setup_users }}"
 
     - name: Confirm per-user $HOME/.oh-my-zsh directories exist for all zsh_setup_users
       ansible.builtin.stat:
-        path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.oh-my-zsh"
+        path: "{{ item.home_path }}/.oh-my-zsh"
       register: oh_my_zsh_test
-      loop: "{{ zsh_setup_users }}"
+      loop: "{{ enriched_setup_users }}"
 
     - name: Assert per-user $HOME/.oh-my-zsh directories
       ansible.builtin.assert:
@@ -65,11 +68,4 @@
           - "oh_my_zsh_test.results[item | int].stat.exists"
           - "oh_my_zsh_test.results[item | int].stat.mode == '0755'"
         msg: "$HOME/.oh-my-zsh directory check failed for {{ item.username }}"
-      loop: "{{ zsh_setup_users }}"
-
-    - name: Assert .oh-my-zsh installation
-      ansible.builtin.assert:
-        that:
-          - "oh_my_zsh_test.results[item | int].stat.exists"
-        msg: ".oh-my-zsh installation check failed for {{ item.username }}"
-      loop: "{{ zsh_setup_users }}"
+      loop: "{{ enriched_setup_users }}"

--- a/roles/zsh_setup/molecule/default/verify.yml
+++ b/roles/zsh_setup/molecule/default/verify.yml
@@ -10,8 +10,8 @@
     - name: Define zsh_setup_users
       ansible.builtin.set_fact:
         zsh_setup_users:
-          - username: "{{ ansible_env.USER if ansible_distribution == 'mac' else zsh_setup_default_username }}"
-            usergroup: "{{ 'staff' if ansible_distribution == 'mac' else zsh_setup_default_group }}"
+          - username: "{{ ansible_env.USER if ansible_distribution == 'MacOSX' else zsh_setup_default_username }}"
+            usergroup: "{{ 'staff' if ansible_distribution == 'MacOSX' else zsh_setup_default_group }}"
 
     - name: Include get_enriched_users tasks
       ansible.builtin.include_tasks: "../../tasks/get_enriched_users.yml"

--- a/roles/zsh_setup/tasks/get_enriched_users.yml
+++ b/roles/zsh_setup/tasks/get_enriched_users.yml
@@ -1,0 +1,13 @@
+---
+- name: Get home directory for each user
+  ansible.builtin.shell: "eval echo ~{{ item.username }}"
+  loop: "{{ zsh_setup_users }}"
+  register: home_dirs
+  become: true
+  become_user: "{{ item.username }}"
+  changed_when: false
+
+- name: Update home_path for each user in zsh_setup_users
+  ansible.builtin.set_fact:
+    enriched_setup_users: "{{ enriched_setup_users | default([]) + [item.0 | combine({'home_path': item.1.stdout})] }}"
+  loop: "{{ zsh_setup_users | zip(home_dirs.results) }}"

--- a/roles/zsh_setup/tasks/get_enriched_users.yml
+++ b/roles/zsh_setup/tasks/get_enriched_users.yml
@@ -1,6 +1,6 @@
 ---
 - name: Get home directory for each user
-  ansible.builtin.shell: "eval echo ~{{ item.username }}"
+  ansible.builtin.shell: "eval echo ~{{ item.username }}" # noqa command-instead-of-shell
   loop: "{{ zsh_setup_users }}"
   register: home_dirs
   become: true

--- a/roles/zsh_setup/tasks/main.yml
+++ b/roles/zsh_setup/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 - name: Check if .oh-my-zsh exists for all zsh_setup_users
   ansible.builtin.stat:
-    path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var/root' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.oh-my-zsh"
+    path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.oh-my-zsh"
   register: oh_my_zsh_installed
   loop: "{{ zsh_setup_users }}"
 
 - name: Download oh-my-zsh install script for all zsh_setup_users
   ansible.builtin.get_url:
-    url: "https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh"
-    dest: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var/root' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}/zsh-installer.sh"
+    url: "{{ zsh_setup_omz_install_script_url }}"
+    dest: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/zsh-installer.sh"
     mode: "0755"
     owner: "{{ item.username }}"
     group: "{{ item.usergroup | default(item.username) }}"
@@ -16,9 +16,9 @@
   when: "not oh_my_zsh_installed.results | json_query('[*].stat.exists') | select('equalto', false) | list | length > 0"
 
 - name: Install oh-my-zsh for all zsh_setup_users
-  ansible.builtin.command: "echo 'y' | ZSH={{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var/root' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.oh-my-zsh bash {{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var/root' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}/zsh-installer.sh"
+  ansible.builtin.command: "echo 'y' | ZSH={{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.oh-my-zsh bash {{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/zsh-installer.sh"
   args:
-    creates: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var/root' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.oh-my-zsh"
+    creates: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.oh-my-zsh"
   become: true
   become_user: "{{ item.username }}"
   loop: "{{ zsh_setup_users }}"
@@ -27,13 +27,13 @@
 
 - name: Check if zsh-installer.sh exists for all zsh_setup_users
   ansible.builtin.stat:
-    path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var/root' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}/zsh-installer.sh"
+    path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/zsh-installer.sh"
   loop: "{{ zsh_setup_users }}"
   register: zsh_installer_exists
 
 - name: Ensure zsh-installer.sh is executable for all zsh_setup_users
   ansible.builtin.file:
-    path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.item.username != 'root' else ('/var/root' if ansible_os_family == 'Darwin' and item.item.username == 'root' else ('/root' if item.item.username == 'root' else '/home'))) }}/{{ item.item.username }}/zsh-installer.sh"
+    path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.item.username == 'root' else ('/' if item.item.username == 'root' else '/home'))) }}/{{ item.item.username }}/zsh-installer.sh"
     mode: "0755"
     owner: "{{ item.item.username }}"
     group: "{{ item.item.usergroup | default(item.item.username) }}"
@@ -42,7 +42,7 @@
 
 - name: Execute zsh-installer.sh for all zsh_setup_users
   ansible.builtin.shell:
-    cmd: "bash {{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var/root' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}/zsh-installer.sh"
+    cmd: "bash {{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/zsh-installer.sh"
   args:
     executable: "/bin/bash"
   become: true
@@ -53,7 +53,7 @@
 
 - name: Remove zsh-installer.sh for all zsh_setup_users
   ansible.builtin.file:
-    path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var/root' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}/zsh-installer.sh"
+    path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/zsh-installer.sh"
     state: absent
   loop: "{{ zsh_setup_users }}"
 

--- a/roles/zsh_setup/tasks/main.yml
+++ b/roles/zsh_setup/tasks/main.yml
@@ -1,28 +1,28 @@
 ---
 - name: Check if .oh-my-zsh exists for all zsh_setup_users
   ansible.builtin.stat:
-    path: "{{ (item.username == 'root') | ternary('/root', '/home/' + item.username) }}/.oh-my-zsh"
+    path: "{{ (ansible_system == 'Darwin') | ternary('/Users', '/home') }}/{{ item.username }}/.oh-my-zsh"
   register: oh_my_zsh_installed
   with_items: "{{ zsh_setup_users }}"
 
 - name: Download oh-my-zsh install script for all zsh_setup_users
   ansible.builtin.get_url:
     url: "{{ zsh_setup_omz_install_script_url }}"
-    dest: "{{ (item.username == 'root') | ternary('/root', '/home/' + item.username) }}/zsh-installer.sh"
+    dest: "{{ (ansible_system == 'Darwin' and item.username != 'root') | ternary('/Users', '/home') }}/{{ item.username }}/zsh-installer.sh"
     mode: "0755"
     owner: "{{ item.username }}"
     group: "{{ item.usergroup | default(item.username) }}"
-  when: "not oh_my_zsh_installed.results[item | int].stat.exists"
+  when: "not oh_my_zsh_installed.results[item | int].stat.exists and ansible_system != 'Darwin'"
   with_items: "{{ zsh_setup_users }}"
   changed_when: false
 
 - name: Install oh-my-zsh for all zsh_setup_users
-  ansible.builtin.command: "echo 'y' | ZSH=/home/{{ item.username }}/.oh-my-zsh bash /home/{{ item.username }}/zsh-installer.sh"
+  ansible.builtin.command: "echo 'y' | ZSH={{ (ansible_system == 'Darwin' and item.username != 'root') | ternary('/Users', '/home') }}/{{ item.username }}/.oh-my-zsh bash {{ (ansible_system == 'Darwin' and item.username != 'root') | ternary('/Users', '/home') }}/{{ item.username }}/zsh-installer.sh"
   args:
-    creates: "/home/{{ item.username }}/.oh-my-zsh"
+    creates: "{{ (ansible_system == 'Darwin' and item.username != 'root') | ternary('/Users', '/home') }}/{{ item.username }}/.oh-my-zsh"
   become: true
   become_user: "{{ item.username }}"
-  when: "not oh_my_zsh_installed.results[item | int].stat.exists"
+  when: "not oh_my_zsh_installed.results[item | int].stat.exists and ansible_system != 'Darwin'"
   with_items: "{{ zsh_setup_users }}"
   changed_when: false
 
@@ -34,7 +34,7 @@
 
 - name: Ensure zsh-installer.sh is executable for all zsh_setup_users
   ansible.builtin.file:
-    path: "{{ (item.username == 'root') | ternary('/root', '/home/' + item.username) }}/zsh-installer.sh"
+    path: "{{ (ansible_system == 'Darwin' and item.username != 'root') | ternary('/Users', '/home') }}/{{ item.username }}/zsh-installer.sh"
     mode: "0755"
   become: true
   become_user: "{{ item.username }}"
@@ -55,7 +55,7 @@
 
 - name: Remove zsh-installer.sh for all zsh_setup_users
   ansible.builtin.file:
-    path: "{{ (item.username == 'root') | ternary('/root', '/home/' + item.username) }}/zsh-installer.sh"
+    path: "{{ (ansible_system == 'Darwin' and item.username != 'root') | ternary('/Users', '/home') }}/{{ item.username }}/zsh-installer.sh"
     state: absent
   become: true
   become_user: "{{ item.username }}"
@@ -66,7 +66,7 @@
 - name: Create per-user $HOME/.zshrc files
   ansible.builtin.template:
     src: zshrc.j2
-    dest: "{{ (item.username == 'root') | ternary('/root', '/home/' + item.username) }}/.zshrc"
+    dest: "{{ (ansible_system == 'Darwin' and item.username != 'root') | ternary('/Users', '/home') }}/{{ item.username }}/.zshrc"
     mode: "0755"
     owner: "{{ item.username }}"
     group: "{{ item.usergroup | default(item.username) }}"

--- a/roles/zsh_setup/tasks/main.yml
+++ b/roles/zsh_setup/tasks/main.yml
@@ -63,11 +63,18 @@
   with_items: "{{ zsh_setup_users }}"
   changed_when: false
 
-- name: Create per-user $HOME/.zshrc files
+- name: Create per-user $HOME/.zshrc files if they do not exist
+  ansible.builtin.stat:
+    path: "{{ (item.username == 'root') | ternary('/root', (ansible_system == 'Darwin' and item.username != 'root') | ternary('/Users', '/home') + '/' + item.username) }}/.zshrc"
+  register: zshrc_exists
+  loop: "{{ zsh_setup_users }}"
+
+- name: Copy .zshrc template to user's home directory if it does not exist
   ansible.builtin.template:
     src: zshrc.j2
-    dest: "{{ (item.username == 'root') | ternary('/root', (ansible_system == 'Darwin' and item.username != 'root') | ternary('/Users', '/home') + '/' + item.username) }}/.zshrc"
+    dest: "{{ (item.0.username == 'root') | ternary('/root', (ansible_system == 'Darwin' and item.0.username != 'root') | ternary('/Users', '/home') + '/' + item.0.username) }}/.zshrc"
     mode: "0755"
-    owner: "{{ item.username }}"
-    group: "{{ item.usergroup | default(item.username) }}"
-  loop: "{{ zsh_setup_users }}"
+    owner: "{{ item.0.username }}"
+    group: "{{ item.0.usergroup | default(item.0.username) }}"
+  loop: "{{ zshrc_exists.results | zip(zsh_setup_users) }}"
+  when: not item.0.stat.exists

--- a/roles/zsh_setup/tasks/main.yml
+++ b/roles/zsh_setup/tasks/main.yml
@@ -1,78 +1,64 @@
 ---
+- name: Include get_enriched_users tasks
+  ansible.builtin.include_tasks: get_enriched_users.yml
+
 - name: Check if .oh-my-zsh exists for all zsh_setup_users
   ansible.builtin.stat:
-    path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.oh-my-zsh"
+    path: "{{ item.home_path }}/.oh-my-zsh"
   register: oh_my_zsh_installed
-  loop: "{{ zsh_setup_users }}"
+  loop: "{{ enriched_setup_users }}"
 
 - name: Download oh-my-zsh install script for all zsh_setup_users
   ansible.builtin.get_url:
     url: "{{ zsh_setup_omz_install_script_url }}"
-    dest: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/zsh-installer.sh"
+    dest: "{{ item.home_path }}/omz-installer.sh"
     mode: "0755"
     owner: "{{ item.username }}"
-    group: "{{ item.usergroup | default(item.username) }}"
-  loop: "{{ zsh_setup_users }}"
-  when: "not oh_my_zsh_installed.results | json_query('[*].stat.exists') | select('equalto', false) | list | length > 0"
+    group: "{{ item.usergroup }}"
+  become: true
+  become_user: "{{ item.username }}"
+  when: "not oh_my_zsh_installed.results[item | int].stat.exists"
+  loop: "{{ enriched_setup_users }}"
+  changed_when: false
 
 - name: Install oh-my-zsh for all zsh_setup_users
-  ansible.builtin.command: "echo 'y' | ZSH={{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.oh-my-zsh bash {{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/zsh-installer.sh"
+  ansible.builtin.shell: echo 'y' | {{ item.home_path }}/omz-installer.sh --unattended --keep-zshrc
   args:
-    creates: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.oh-my-zsh"
+    creates: "{{ item.home_path }}/.oh-my-zsh"
   become: true
   become_user: "{{ item.username }}"
-  loop: "{{ zsh_setup_users }}"
-  changed_when: false
-  when: "not oh_my_zsh_installed.results | json_query('[*].stat.exists') | select('equalto', false) | list | length > 0"
-
-- name: Check if zsh-installer.sh exists for all zsh_setup_users
-  ansible.builtin.stat:
-    path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/zsh-installer.sh"
-  loop: "{{ zsh_setup_users }}"
-  register: zsh_installer_exists
-
-- name: Ensure zsh-installer.sh is executable for all zsh_setup_users
-  ansible.builtin.file:
-    path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.item.username == 'root' else ('/' if item.item.username == 'root' else '/home'))) }}/{{ item.item.username }}/zsh-installer.sh"
-    mode: "0755"
-    owner: "{{ item.item.username }}"
-    group: "{{ item.item.usergroup | default(item.item.username) }}"
-  loop: "{{ zsh_installer_exists.results }}"
-  when: item.stat.exists
-
-- name: Execute zsh-installer.sh for all zsh_setup_users
-  ansible.builtin.shell:
-    cmd: "bash {{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/zsh-installer.sh"
-  args:
-    executable: "/bin/bash"
-  become: true
-  become_user: "{{ item.username }}"
-  loop: "{{ zsh_setup_users }}"
-  when: "not oh_my_zsh_installed.results | json_query('[*].stat.exists') | select('equalto', false) | list | length > 0"
+  when: "not oh_my_zsh_installed.results[item | int].stat.exists"
+  loop: "{{ enriched_setup_users }}"
   changed_when: false
 
-- name: Remove zsh-installer.sh for all zsh_setup_users
+- name: Remove omz-installer.sh for all zsh_setup_users
   ansible.builtin.file:
-    path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/zsh-installer.sh"
+    path: "{{ item.home_path }}/omz-installer.sh"
     state: absent
-  loop: "{{ zsh_setup_users }}"
+  become: true
+  become_user: "{{ item.username }}"
+  loop: "{{ enriched_setup_users }}"
 
 - name: Check if .zshrc exists for all zsh_setup_users
   ansible.builtin.stat:
-    path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.zshrc"
+    path: "{{ item.home_path }}/.zshrc"
   register: zshrc_exists
   loop_control:
     index_var: loop_index
-  loop: "{{ zsh_setup_users }}"
+  become: true
+  become_user: "{{ item.username }}"
+  loop: "{{ enriched_setup_users }}"
 
 - name: Copy .zshrc template to user's home directory if it does not exist
   ansible.builtin.template:
     src: zshrc.j2
     mode: "0755"
-    dest: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.zshrc"
+    dest: "{{ item.home_path }}/.zshrc"
     owner: "{{ item.username }}"
     group: "{{ item.usergroup | default(item.username) }}"
-  loop: "{{ zsh_setup_users }}"
+  loop: "{{ enriched_setup_users }}"
   loop_control:
     index_var: loop_index
+  become: true
+  become_user: "{{ item.username }}"
   when: "not zshrc_exists.results[loop_index].stat.exists"

--- a/roles/zsh_setup/tasks/main.yml
+++ b/roles/zsh_setup/tasks/main.yml
@@ -7,12 +7,12 @@
 
 - name: Download oh-my-zsh install script for all zsh_setup_users
   ansible.builtin.get_url:
-    url: "{{ zsh_setup_omz_install_script_url }}"
-    dest: "{{ (ansible_system == 'Darwin' and item.username != 'root') | ternary('/Users', '/home') }}/{{ item.username }}/zsh-installer.sh"
+    url: "https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh"
+    dest: "{{ (item.username == 'root') | ternary('/root', (ansible_system == 'Darwin' and item.username != 'root') | ternary('/Users', '/home') + '/' + item.username) }}/zsh-installer.sh"
     mode: "0755"
     owner: "{{ item.username }}"
     group: "{{ item.usergroup | default(item.username) }}"
-  when: "not oh_my_zsh_installed.results[item | int].stat.exists and ansible_system != 'Darwin'"
+  when: "not oh_my_zsh_installed.results[item | int].stat.exists"
   with_items: "{{ zsh_setup_users }}"
   changed_when: false
 
@@ -34,7 +34,7 @@
 
 - name: Ensure zsh-installer.sh is executable for all zsh_setup_users
   ansible.builtin.file:
-    path: "{{ (ansible_system == 'Darwin' and item.username != 'root') | ternary('/Users', '/home') }}/{{ item.username }}/zsh-installer.sh"
+    path: "{{ (item.username == 'root') | ternary('/root', (ansible_system == 'Darwin' and item.username != 'root') | ternary('/Users', '/home') + '/' + item.username) }}/zsh-installer.sh"
     mode: "0755"
   become: true
   become_user: "{{ item.username }}"
@@ -66,7 +66,7 @@
 - name: Create per-user $HOME/.zshrc files
   ansible.builtin.template:
     src: zshrc.j2
-    dest: "{{ (ansible_system == 'Darwin' and item.username != 'root') | ternary('/Users', '/home') }}/{{ item.username }}/.zshrc"
+    dest: "{{ (item.username == 'root') | ternary('/root', (ansible_system == 'Darwin' and item.username != 'root') | ternary('/Users', '/home') + '/' + item.username) }}/.zshrc"
     mode: "0755"
     owner: "{{ item.username }}"
     group: "{{ item.usergroup | default(item.username) }}"

--- a/roles/zsh_setup/tasks/main.yml
+++ b/roles/zsh_setup/tasks/main.yml
@@ -22,7 +22,7 @@
   changed_when: false
 
 - name: Install oh-my-zsh for all zsh_setup_users
-  ansible.builtin.shell: echo 'y' | {{ item.home_path }}/omz-installer.sh --unattended --keep-zshrc
+  ansible.builtin.shell: "echo 'y' | {{ item.home_path }}/omz-installer.sh --unattended --keep-zshrc" # noqa risky-shell-pipe
   args:
     creates: "{{ item.home_path }}/.oh-my-zsh"
   become: true

--- a/roles/zsh_setup/tasks/main.yml
+++ b/roles/zsh_setup/tasks/main.yml
@@ -1,80 +1,78 @@
 ---
 - name: Check if .oh-my-zsh exists for all zsh_setup_users
   ansible.builtin.stat:
-    path: "{{ (ansible_system == 'Darwin') | ternary('/Users', '/home') }}/{{ item.username }}/.oh-my-zsh"
+    path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var/root' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.oh-my-zsh"
   register: oh_my_zsh_installed
-  with_items: "{{ zsh_setup_users }}"
+  loop: "{{ zsh_setup_users }}"
 
 - name: Download oh-my-zsh install script for all zsh_setup_users
   ansible.builtin.get_url:
     url: "https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh"
-    dest: "{{ (item.username == 'root') | ternary('/root', (ansible_system == 'Darwin' and item.username != 'root') | ternary('/Users', '/home') + '/' + item.username) }}/zsh-installer.sh"
+    dest: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var/root' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}/zsh-installer.sh"
     mode: "0755"
     owner: "{{ item.username }}"
     group: "{{ item.usergroup | default(item.username) }}"
-  when: "not oh_my_zsh_installed.results[item | int].stat.exists"
-  with_items: "{{ zsh_setup_users }}"
-  changed_when: false
+  loop: "{{ zsh_setup_users }}"
+  when: "not oh_my_zsh_installed.results | json_query('[*].stat.exists') | select('equalto', false) | list | length > 0"
 
 - name: Install oh-my-zsh for all zsh_setup_users
-  ansible.builtin.command: "echo 'y' | ZSH={{ (ansible_system == 'Darwin' and item.username != 'root') | ternary('/Users', '/home') }}/{{ item.username }}/.oh-my-zsh bash {{ (ansible_system == 'Darwin' and item.username != 'root') | ternary('/Users', '/home') }}/{{ item.username }}/zsh-installer.sh"
+  ansible.builtin.command: "echo 'y' | ZSH={{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var/root' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.oh-my-zsh bash {{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var/root' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}/zsh-installer.sh"
   args:
-    creates: "{{ (ansible_system == 'Darwin' and item.username != 'root') | ternary('/Users', '/home') }}/{{ item.username }}/.oh-my-zsh"
+    creates: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var/root' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.oh-my-zsh"
   become: true
   become_user: "{{ item.username }}"
-  when: "not oh_my_zsh_installed.results[item | int].stat.exists and ansible_system != 'Darwin'"
-  with_items: "{{ zsh_setup_users }}"
+  loop: "{{ zsh_setup_users }}"
   changed_when: false
+  when: "not oh_my_zsh_installed.results | json_query('[*].stat.exists') | select('equalto', false) | list | length > 0"
 
 - name: Check if zsh-installer.sh exists for all zsh_setup_users
   ansible.builtin.stat:
-    path: "/home/{{ item.username }}/zsh-installer.sh"
+    path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var/root' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}/zsh-installer.sh"
+  loop: "{{ zsh_setup_users }}"
   register: zsh_installer_exists
-  with_items: "{{ zsh_setup_users }}"
 
 - name: Ensure zsh-installer.sh is executable for all zsh_setup_users
   ansible.builtin.file:
-    path: "{{ (item.username == 'root') | ternary('/root', (ansible_system == 'Darwin' and item.username != 'root') | ternary('/Users', '/home') + '/' + item.username) }}/zsh-installer.sh"
+    path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.item.username != 'root' else ('/var/root' if ansible_os_family == 'Darwin' and item.item.username == 'root' else ('/root' if item.item.username == 'root' else '/home'))) }}/{{ item.item.username }}/zsh-installer.sh"
     mode: "0755"
-  become: true
-  become_user: "{{ item.username }}"
-  when: "zsh_installer_exists.results[item | int].stat.exists"
-  with_items: "{{ zsh_setup_users }}"
-  changed_when: false
+    owner: "{{ item.item.username }}"
+    group: "{{ item.item.usergroup | default(item.item.username) }}"
+  loop: "{{ zsh_installer_exists.results }}"
+  when: item.stat.exists
 
 - name: Execute zsh-installer.sh for all zsh_setup_users
   ansible.builtin.shell:
-    cmd: "bash {{ (item.username == 'root') | ternary('/root', '/home/' + item.username) }}/zsh-installer.sh"
+    cmd: "bash {{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var/root' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}/zsh-installer.sh"
   args:
     executable: "/bin/bash"
   become: true
   become_user: "{{ item.username }}"
-  when: "zsh_installer_exists.results[item | int].stat.exists"
-  with_items: "{{ zsh_setup_users }}"
+  loop: "{{ zsh_setup_users }}"
+  when: "not oh_my_zsh_installed.results | json_query('[*].stat.exists') | select('equalto', false) | list | length > 0"
   changed_when: false
 
 - name: Remove zsh-installer.sh for all zsh_setup_users
   ansible.builtin.file:
-    path: "{{ (ansible_system == 'Darwin' and item.username != 'root') | ternary('/Users', '/home') }}/{{ item.username }}/zsh-installer.sh"
+    path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var/root' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/root' if item.username == 'root' else '/home'))) }}/{{ item.username }}/zsh-installer.sh"
     state: absent
-  become: true
-  become_user: "{{ item.username }}"
-  when: "zsh_installer_exists.results[item | int].stat.exists"
-  with_items: "{{ zsh_setup_users }}"
-  changed_when: false
+  loop: "{{ zsh_setup_users }}"
 
-- name: Create per-user $HOME/.zshrc files if they do not exist
+- name: Check if .zshrc exists for all zsh_setup_users
   ansible.builtin.stat:
-    path: "{{ (item.username == 'root') | ternary('/root', (ansible_system == 'Darwin' and item.username != 'root') | ternary('/Users', '/home') + '/' + item.username) }}/.zshrc"
+    path: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.zshrc"
   register: zshrc_exists
+  loop_control:
+    index_var: loop_index
   loop: "{{ zsh_setup_users }}"
 
 - name: Copy .zshrc template to user's home directory if it does not exist
   ansible.builtin.template:
     src: zshrc.j2
-    dest: "{{ (item.0.username == 'root') | ternary('/root', (ansible_system == 'Darwin' and item.0.username != 'root') | ternary('/Users', '/home') + '/' + item.0.username) }}/.zshrc"
     mode: "0755"
-    owner: "{{ item.0.username }}"
-    group: "{{ item.0.usergroup | default(item.0.username) }}"
-  loop: "{{ zshrc_exists.results | zip(zsh_setup_users) }}"
-  when: not item.0.stat.exists
+    dest: "{{ ('/Users' if ansible_os_family == 'Darwin' and item.username != 'root' else ('/var' if ansible_os_family == 'Darwin' and item.username == 'root' else ('/' if item.username == 'root' else '/home'))) }}/{{ item.username }}/.zshrc"
+    owner: "{{ item.username }}"
+    group: "{{ item.usergroup | default(item.username) }}"
+  loop: "{{ zsh_setup_users }}"
+  loop_control:
+    index_var: loop_index
+  when: "not zshrc_exists.results[loop_index].stat.exists"


### PR DESCRIPTION
**Added:**
- New inventory and molecule test setup for workstation playbook.
- Molecule testing configurations for asdf role with Docker support.
- Dynamic setting of shell profiles based on OS in asdf role.

**Changed:**
- Enhanced asdf role for macOS and Linux compatibility.
- Revised asdf tasks to dynamically set paths and permissions.
- Updated user_setup role to correctly handle macOS user and group setup.
- Modified zsh_setup tasks to accommodate Darwin system peculiarities.

**Fixed:**
- Corrected libyaml installation task issue in asdf role.
- Resolved directory creation issue for setup_asdf_env.sh script.