### PR TITLE
Enhancements and Refactoring in Workstation and ASDF Roles

### DIFF
--- a/playbooks/workstation/workstation.yml
+++ b/playbooks/workstation/workstation.yml
@@ -15,6 +15,8 @@
     - name: Setup ZSH Configuration
       ansible.builtin.include_role:
         name: cowdogmoo.workstation.zsh_setup
+        # For local debugging
+        # name: roles/zsh_setup
       vars:
         zsh_setup_users:
           - username: "{{ ansible_user_id }}"
@@ -23,6 +25,8 @@
     - name: Setup ASDF Configuration
       ansible.builtin.include_role:
         name: cowdogmoo.workstation.asdf
+        # For local debugging
+        # name: roles/asdf
       vars:
         asdf_users:
           - username: "{{ ansible_user_id }}"

--- a/roles/asdf/tasks/asdf_get_enriched_users.yml
+++ b/roles/asdf/tasks/asdf_get_enriched_users.yml
@@ -1,4 +1,3 @@
----
 - name: Get home directory for each user
   ansible.builtin.shell: 'python3 -c ''import pwd; print(pwd.getpwnam("{{ item.username }}").pw_dir)'''
   loop: "{{ asdf_users }}"
@@ -7,16 +6,14 @@
 
 - name: Update home_path, shell, and plugins for each user in asdf_users
   ansible.builtin.set_fact:
-    enriched_setup_users: >-
-      {{ (enriched_setup_users | default([])) | rejectattr('username', 'equalto', item.0.username) | list +
+    enriched_asdf_enriched_users: >-
+      {{ (enriched_asdf_enriched_users | default([])) | rejectattr('username', 'equalto', item.0.username) | list +
       [item.0 | combine({
         'home_path': item.1.stdout,
         'shell': (item.0.shell | default('/bin/bash')),
-        'plugins': item.0.plugins,
         'shell_profile_lines': [
           'export ASDF_PATH="' + item.1.stdout + '/.asdf"',
           'export PATH="$ASDF_PATH/bin:$ASDF_PATH/shims:$PATH"',
           '. "$ASDF_PATH/asdf.sh"'
-        ]
-      })] }}
+        ]})] }}
   loop: "{{ asdf_users | zip(home_dirs.results) }}"

--- a/roles/asdf/tasks/main.yml
+++ b/roles/asdf/tasks/main.yml
@@ -4,8 +4,8 @@
     asdf_default_username: "kali"
   when: ansible_distribution_release == "kali-rolling"
 
-- name: Include get_enriched_users tasks
-  ansible.builtin.include_tasks: get_enriched_users.yml
+- name: Include asdf_get_enriched_users tasks
+  ansible.builtin.include_tasks: asdf_get_enriched_users.yml
 
 - name: Clone asdf for each user
   ansible.builtin.git:
@@ -13,7 +13,7 @@
     dest: "{{ item.home_path }}/.asdf"
     clone: true
     update: false
-  loop: "{{ enriched_setup_users }}"
+  loop: "{{ enriched_asdf_enriched_users }}"
   when:
     - item.username != 'root'
 
@@ -24,7 +24,7 @@
     owner: "{{ item.username }}"
     group: "{{ item.usergroup | default(item.username) }}"
     mode: "0644"
-  loop: "{{ enriched_setup_users }}"
+  loop: "{{ enriched_asdf_enriched_users }}"
   when:
     - item.username != 'root'
 
@@ -34,7 +34,7 @@
     owner: "{{ item.username }}"
     group: "{{ item.usergroup | default(item.username) }}"
     mode: "0644"
-  loop: "{{ enriched_setup_users }}"
+  loop: "{{ enriched_asdf_enriched_users }}"
   when:
     - item.username != 'root'
 
@@ -44,7 +44,7 @@
     owner: "{{ item.username }}"
     group: "{{ item.usergroup | default(item.username) }}"
     recurse: true
-  loop: "{{ enriched_setup_users }}"
+  loop: "{{ enriched_asdf_enriched_users }}"
   when:
     - item.username != 'root'
 
@@ -52,11 +52,11 @@
   ansible.builtin.stat:
     path: "{{ item.home_path }}/.asdf"
   register: asdf_dir_check
-  loop: "{{ enriched_setup_users }}"
+  loop: "{{ enriched_asdf_enriched_users }}"
 
 - name: Include task to update shell profiles for each user
   ansible.builtin.include_tasks: update_shell_profiles.yml
-  loop: "{{ enriched_setup_users }}"
+  loop: "{{ enriched_asdf_enriched_users }}"
   loop_control:
     loop_var: user
   vars:
@@ -67,7 +67,9 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      . /usr/local/bin/setup_asdf_env "{{ item.home_path }}"
+      if [ -f "{{ item.home_path }}/.asdf/asdf.sh" ]; then
+        . "{{ item.home_path }}/.asdf/asdf.sh"
+      fi
       {% for plugin in item.plugins %}
       if ! asdf plugin list | grep -q {{ plugin.name }}; then
         asdf plugin add {{ plugin.name }};
@@ -79,7 +81,7 @@
   changed_when: false
   become: true
   become_user: "{{ item.username }}"
-  loop: "{{ enriched_setup_users }}"
+  loop: "{{ enriched_asdf_enriched_users }}"
 
 - name: Copy setup_asdf_env.sh to a common location for all users
   ansible.builtin.copy:
@@ -93,5 +95,5 @@
 
 - name: Install asdf plugins and set versions for each user
   ansible.builtin.include_tasks: package_individual_setup.yml
-  loop: "{{ enriched_setup_users }}"
+  loop: "{{ enriched_asdf_enriched_users }}"
   when: item.username != 'root'

--- a/roles/asdf/tasks/update_shell_profiles.yml
+++ b/roles/asdf/tasks/update_shell_profiles.yml
@@ -2,10 +2,8 @@
 - name: Update shell profile for user
   ansible.builtin.lineinfile:
     path: "{{ user.home_path }}/{{ (user.shell | default('/bin/bash') == '/bin/zsh') | ternary('.zshrc', '.bashrc') }}"
-    line: "{{ line }}"
+    line: "{{ item }}"
     insertafter: EOF
     create: true
     mode: "0644"
   loop: "{{ line }}"
-  when:
-    - user.username != 'root'

--- a/roles/zsh_setup/defaults/main.yml
+++ b/roles/zsh_setup/defaults/main.yml
@@ -3,9 +3,9 @@
 zsh_setup_theme: "af-magic"
 
 # List of users to configure zsh for
-zsh_setup_enriched_users:
-  - username: "{{ ansible_env.USER if ansible_distribution == 'mac' else zsh_setup_default_username }}"
-    usergroup: "{{ 'staff' if ansible_distribution == 'mac' else zsh_setup_default_group }}"
+zsh_setup_users:
+  - username: "{{ zsh_setup_default_username }}"
+    usergroup: "{{ zsh_setup_default_group }}"
     plugins:
       - asdf
       - docker

--- a/roles/zsh_setup/molecule/default/verify.yml
+++ b/roles/zsh_setup/molecule/default/verify.yml
@@ -7,26 +7,27 @@
       ansible.builtin.include_vars:
         file: "../../vars/main.yml"
 
-    - name: Define zsh_setup_enriched_users
+    - name: Define zsh_setup_users
       ansible.builtin.set_fact:
-        zsh_setup_enriched_users:
-          - username: "{{ ansible_env.USER if ansible_distribution == 'MacOSX' else zsh_setup_default_username }}"
-            usergroup: "{{ 'staff' if ansible_distribution == 'MacOSX' else zsh_setup_default_group }}"
+        zsh_setup_users:
+          - username: "{{ ansible_env.USER if ansible_os_family == 'Darwin' else ansible_distribution | lower }}"
+            usergroup: "{{ 'staff' if ansible_os_family == 'Darwin' else ansible_distribution | lower }}"
 
-    - name: Include zsh_setup_get_enriched_users.yml tasks
-      ansible.builtin.include_tasks: "../../tasks/zsh_setup_get_enriched_users.yml"
+    - name: Include zsh_setup_get_enriched_users tasks
+      ansible.builtin.include_tasks: ../../tasks/zsh_setup_get_enriched_users.yml
 
-    - name: Confirm .oh-my-zsh is installed for all zsh_setup_enriched_users
+    - name: Confirm per-user $HOME/.oh-my-zsh directories exist for all users
       ansible.builtin.stat:
         path: "{{ item.home_path }}/.oh-my-zsh"
       register: oh_my_zsh_test
       loop: "{{ zsh_setup_enriched_users }}"
 
-    - name: Assert .oh-my-zsh installation
+    - name: Assert per-user $HOME/.oh-my-zsh directories
       ansible.builtin.assert:
         that:
           - "oh_my_zsh_test.results[item | int].stat.exists"
-        msg: ".oh-my-zsh installation check failed for {{ item.username }}"
+          - "oh_my_zsh_test.results[item | int].stat.mode == '0755'"
+        msg: "$HOME/.oh-my-zsh directory check failed for {{ item.username }}"
       loop: "{{ zsh_setup_enriched_users }}"
 
     - name: Confirm omz-installer.sh is removed for all zsh_setup_enriched_users
@@ -42,7 +43,7 @@
         msg: "zsh-installer.sh removal check failed for {{ item.username }}"
       loop: "{{ zsh_setup_enriched_users }}"
 
-    - name: Confirm per-user $HOME/.zshrc files exist for all zsh_setup_enriched_users
+    - name: Confirm per-user $HOME/.zshrc files exist for all users
       ansible.builtin.stat:
         path: "{{ item.home_path }}/.zshrc"
       register: zshrc_test
@@ -54,18 +55,4 @@
           - "zshrc_test.results[item | int].stat.exists"
           - "zshrc_test.results[item | int].stat.mode == '0644'"
         msg: "$HOME/.zshrc file check failed for {{ item.username }}"
-      loop: "{{ zsh_setup_enriched_users }}"
-
-    - name: Confirm per-user $HOME/.oh-my-zsh directories exist for all zsh_setup_enriched_users
-      ansible.builtin.stat:
-        path: "{{ item.home_path }}/.oh-my-zsh"
-      register: oh_my_zsh_test
-      loop: "{{ zsh_setup_enriched_users }}"
-
-    - name: Assert per-user $HOME/.oh-my-zsh directories
-      ansible.builtin.assert:
-        that:
-          - "oh_my_zsh_test.results[item | int].stat.exists"
-          - "oh_my_zsh_test.results[item | int].stat.mode == '0755'"
-        msg: "$HOME/.oh-my-zsh directory check failed for {{ item.username }}"
       loop: "{{ zsh_setup_enriched_users }}"

--- a/roles/zsh_setup/tasks/zsh_setup_get_enriched_users.yml
+++ b/roles/zsh_setup/tasks/zsh_setup_get_enriched_users.yml
@@ -1,10 +1,8 @@
 ---
 - name: Get home directory for each user
   ansible.builtin.shell: 'python3 -c ''import pwd; print(pwd.getpwnam("{{ item.username }}").pw_dir)'''
-  loop: "{{ zsh_setup_enriched_users }}"
   register: home_dirs
-  become: true
-  become_user: "{{ item.username }}"
+  loop: "{{ zsh_setup_users }}"
   changed_when: false
 
 - name: Update home_path for all users
@@ -13,4 +11,4 @@
       {{ (zsh_setup_enriched_users | default([])) | rejectattr('username', 'equalto', item.0.username) | list + [item.0 | combine({
         'home_path': item.1.stdout,
         })] }}
-  loop: "{{ zsh_setup_enriched_users | zip(home_dirs.results) }}"
+  loop: "{{ zsh_setup_users | zip(home_dirs.results) }}"

--- a/roles/zsh_setup/vars/main.yml
+++ b/roles/zsh_setup/vars/main.yml
@@ -1,7 +1,7 @@
 ---
-# Default username value, derived from the ansible_distribution variable
-zsh_setup_default_username: "{{ ansible_distribution | lower }}"
-zsh_setup_default_group: "{{ ansible_distribution | lower }}"
+# Default username and group are set based on the operating system
+zsh_setup_default_username: "{{ ansible_env.USER if ansible_os_family == 'Darwin' else ansible_distribution | lower }}"
+zsh_setup_default_group: "{{ 'staff' if ansible_os_family == 'Darwin' else ansible_distribution | lower }}"
 
 # Oh My ZSH install script URL
 zsh_setup_omz_install_script_url: "https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh"


### PR DESCRIPTION
**Added:**

- Comments for local debugging in workstation.yml for ZSH and ASDF roles.
- Renamed task file in ASDF role for clarity (from get_enriched_users to 
  asdf_get_enriched_users).

**Changed:**

- Refactored workstation.yml to use `zsh_setup_users` and `asdf_users`.
- Updated variable names in ASDF role for better clarity and consistency.
- Modified tasks in ASDF role to align with new variable names.
- Adjusted ZSH setup defaults and variables to dynamically set values based on OS.
- Updated molecule tests in ZSH setup role to reflect new changes.
- Simplified task structure in zsh_setup_get_enriched_users.yml.
- Updated variable definitions in zsh_setup/vars/main.yml to be OS-specific.

**Removed:**

- Redundant user privilege elevation in ASDF role tasks.
- Unnecessary checks for MacOSX, integrated with OS checks in default vars.
- Duplicate assertions in ZSH setup molecule tests.

This update enhances the workstation and ASDF role configurations by introducing
dynamic user and group settings based on the operating system, streamlining the 
code, and improving readability and maintenance. The changes also include 
necessary updates to molecule tests and task file names for consistency.
