### PR TITLE
Refactored tasks to use consistent loop variables and improved idempotence

### DIFF
--- a/roles/asdf/tasks/asdf_get_enriched_users.yml
+++ b/roles/asdf/tasks/asdf_get_enriched_users.yml
@@ -17,28 +17,30 @@
 - name: Update home for all users
   ansible.builtin.set_fact:
     asdf_enriched_users: >-
-      {{ (asdf_enriched_users | default([])) |
-      rejectattr('username', 'equalto', item.username) | list +
-      [item | combine({
-        'home': ansible_facts.getent_passwd[item.username][4] if item.username in ansible_facts.getent_passwd else item.home,
-        'shell_profile_lines': [
-          "export ASDF_DIR=$HOME/.asdf",
-          "source $ASDF_DIR/asdf.sh"
-        ]
-        })] | selectattr('home', 'defined') | list }}
+      {{ (asdf_enriched_users | default([])) +
+         [user | combine({
+           'home': ansible_facts.getent_passwd[user.username][4] if user.username in ansible_facts.getent_passwd else user.home,
+           'shell_profile_lines': [
+             "export ASDF_DIR=$HOME/.asdf",
+             "source $ASDF_DIR/asdf.sh"
+           ]
+         })] | selectattr('home', 'defined') | list }}
   loop: "{{ asdf_users }}"
+  loop_control:
+    loop_var: user
   when:
-    - item.username in ansible_facts.getent_passwd
+    - user.username in ansible_facts.getent_passwd
 
 - name: Ensure user home directory exists
   become: true
-  become_user: "{{ item.username }}"
   ansible.builtin.file:
-    path: "{{ item.home }}"
+    path: "{{ user.home }}"
     state: directory
-    owner: "{{ item.username }}"
-    group: "{{ item.usergroup | default(item.username) }}"
+    owner: "{{ user.username }}"
+    group: "{{ user.usergroup | default(user.username) }}"
     mode: '0755'
   loop: "{{ asdf_enriched_users }}"
+  loop_control:
+    loop_var: user
   when:
-    - item.username in ansible_facts.getent_passwd
+    - user.username in ansible_facts.getent_passwd

--- a/roles/asdf/tasks/install_libyaml.yml
+++ b/roles/asdf/tasks/install_libyaml.yml
@@ -5,27 +5,25 @@
   failed_when: false
   changed_when: false
 
-- name: Download libyaml source
-  ansible.builtin.get_url:
-    url: https://pyyaml.org/download/libyaml/yaml-0.2.5.tar.gz
-    dest: /tmp/yaml-0.2.5.tar.gz
-    mode: "0644"
+- name: Download, extract, compile, and install libyaml
   when: libyaml_installed.rc != 0
-
-- name: Extract libyaml tarball
-  ansible.builtin.unarchive:
-    src: /tmp/yaml-0.2.5.tar.gz
-    dest: /tmp
-    remote_src: true
-  when: libyaml_installed.rc != 0
-
-- name: Compile and install libyaml
-  ansible.builtin.shell:
-    cmd: |
-      cd /tmp/yaml-0.2.5
-      ./configure
-      make
-      sudo make install
-  args:
-    creates: /usr/local/lib/libyaml.a
-  when: libyaml_installed.rc != 0
+  block:
+    - name: Download libyaml source
+      ansible.builtin.get_url:
+        url: https://pyyaml.org/download/libyaml/yaml-0.2.5.tar.gz
+        dest: /tmp/yaml-0.2.5.tar.gz
+        mode: "0644"
+    - name: Extract libyaml tarball
+      ansible.builtin.unarchive:
+        src: /tmp/yaml-0.2.5.tar.gz
+        dest: /tmp
+        remote_src: true
+    - name: Compile and install libyaml
+      ansible.builtin.shell:
+        cmd: |
+          cd /tmp/yaml-0.2.5
+          ./configure
+          make
+          sudo make install
+      args:
+        creates: /usr/local/lib/libyaml.a

--- a/roles/asdf/tasks/main.yml
+++ b/roles/asdf/tasks/main.yml
@@ -39,89 +39,101 @@
 - name: Clone asdf for each user
   ansible.builtin.git:
     repo: "{{ asdf_git_repo }}"
-    dest: "{{ item.home }}/.asdf"
+    dest: "{{ user.home }}/.asdf"
     clone: true
     update: true
   become: true
-  become_user: "{{ item.username }}"
+  become_user: "{{ user.username }}"
   loop: "{{ asdf_enriched_users }}"
+  loop_control:
+    loop_var: user
   when:
     - not asdf_global_install
 
 - name: Ensure asdf is cloned for each user
   ansible.builtin.file:
-    path: "{{ item.home }}/.asdf"
+    path: "{{ user.home }}/.asdf"
     state: directory
-    owner: "{{ item.username }}"
-    group: "{{ item.usergroup | default(item.username) }}"
+    owner: "{{ user.username }}"
+    group: "{{ user.usergroup | default(user.username) }}"
     mode: "0755"
   become: true
-  become_user: "{{ item.username }}"
+  become_user: "{{ user.username }}"
   loop: "{{ asdf_enriched_users }}"
+  loop_control:
+    loop_var: user
   when:
     - not asdf_global_install
 
 - name: Deploy .tool-versions file
   ansible.builtin.copy:
-    dest: "{{ item.home }}/.tool-versions"
+    dest: "{{ user.home }}/.tool-versions"
     content: |
-      {% for plugin in item.plugins %}
+      {% for plugin in user.plugins %}
       {{ plugin.name }} {{ plugin.version }}
       {% endfor %}
-    owner: "{{ item.username }}"
-    group: "{{ item.usergroup | default(item.username) }}"
+    owner: "{{ user.username }}"
+    group: "{{ user.usergroup | default(user.username) }}"
     mode: "0644"
   become: true
-  become_user: "{{ item.username }}"
+  become_user: "{{ user.username }}"
   loop: "{{ asdf_enriched_users }}"
+  loop_control:
+    loop_var: user
   when:
     - not asdf_global_install
-    - item.plugins is defined
+    - user.plugins is defined
 
 - name: Ensure correct permissions for .tool-versions
   ansible.builtin.file:
-    path: "{{ item.home }}/.tool-versions"
-    owner: "{{ item.username }}"
-    group: "{{ item.usergroup | default(item.username) }}"
+    path: "{{ user.home }}/.tool-versions"
+    owner: "{{ user.username }}"
+    group: "{{ user.usergroup | default(user.username) }}"
     mode: "0644"
   become: true
-  become_user: "{{ item.username }}"
+  become_user: "{{ user.username }}"
   loop: "{{ asdf_enriched_users }}"
+  loop_control:
+    loop_var: user
   when:
     - not asdf_global_install
 
 - name: Ensure .asdf directory exists for each user
   ansible.builtin.file:
-    path: "{{ item.home }}/.asdf"
+    path: "{{ user.home }}/.asdf"
     state: directory
-    owner: "{{ item.username }}"
-    group: "{{ item.usergroup | default(item.username) }}"
+    owner: "{{ user.username }}"
+    group: "{{ user.usergroup | default(user.username) }}"
     mode: "0755"
   become: true
-  become_user: "{{ item.username }}"
+  become_user: "{{ user.username }}"
   loop: "{{ asdf_enriched_users }}"
+  loop_control:
+    loop_var: user
   when:
     - not asdf_global_install
 
 - name: Set permissions for each user's ASDF directory
   ansible.builtin.file:
-    path: "{{ item.home }}/.asdf"
-    owner: "{{ item.username }}"
-    group: "{{ item.usergroup | default(item.username) }}"
+    path: "{{ user.home }}/.asdf"
+    owner: "{{ user.username }}"
+    group: "{{ user.usergroup | default(user.username) }}"
     recurse: true
   become: true
-  become_user: "{{ item.username }}"
+  become_user: "{{ user.username }}"
   loop: "{{ asdf_enriched_users }}"
+  loop_control:
+    loop_var: user
   when:
     - not asdf_global_install
 
 - name: Include task to update shell profiles for each user
   ansible.builtin.include_tasks: update_shell_profiles.yml
+  vars:
+    line: "{{ user.shell_profile_lines }}"
   loop: "{{ asdf_enriched_users }}"
   loop_control:
     loop_var: user
-  vars:
-    line: "{{ user.shell_profile_lines }}"
   when:
     - not asdf_global_install
 
@@ -129,11 +141,11 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      if [ -f "{{ item.home }}/.asdf/asdf.sh" ]; then
-        . "{{ item.home }}/.asdf/asdf.sh"
+      if [ -f "{{ user.home }}/.asdf/asdf.sh" ]; then
+        . "{{ user.home }}/.asdf/asdf.sh"
       fi
-      {% if item.plugins is defined %}
-      {% for plugin in item.plugins %}
+      {% if user.plugins is defined %}
+      {% for plugin in user.plugins %}
       if ! asdf plugin list | grep -q {{ plugin.name }}; then
         asdf plugin add {{ plugin.name }};
       fi;
@@ -142,12 +154,14 @@
       {% else %}
       echo "plugins:,versions:"
       {% endif %}
-    executable: "{{ item.shell }}"
+    executable: "{{ user.shell }}"
   register: asdf_info
   changed_when: false
   become: true
-  become_user: "{{ item.username }}"
+  become_user: "{{ user.username }}"
   loop: "{{ asdf_enriched_users }}"
+  loop_control:
+    loop_var: user
   when:
     - not asdf_global_install
 

--- a/roles/asdf/tasks/package_individual_setup.yml
+++ b/roles/asdf/tasks/package_individual_setup.yml
@@ -29,11 +29,6 @@
     - ansible_os_family == 'Darwin'
     - asdf_global_install
 
-- name: Debug getent_user_shell
-  ansible.builtin.debug:
-    var: getent_user_shell
-  when: asdf_global_install
-
 - name: Find Bash executable
   ansible.builtin.command:
     cmd: "which bash"
@@ -63,9 +58,9 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      . "{{ asdf_install_script_path }}" "{{ asdf_user.home }}"
-      {% if asdf_user.plugins is defined %}
-      {% for plugin in asdf_user.plugins %}
+      . "{{ asdf_install_script_path }}" "{{ user_item.home }}"
+      {% if user_item.plugins is defined %}
+      {% for plugin in user_item.plugins %}
       plugins=$(asdf plugin list)
       grep -q "{{ plugin.name }}" <<< "$plugins" || asdf plugin add "{{ plugin.name }}"
       asdf install "{{ plugin.name }}" "{{ plugin.version }}"
@@ -79,12 +74,11 @@
       fi
       {% endfor %}
       {% endif %}
-    executable: "{{ asdf_user.shell }}"
+    executable: "{{ user_item.shell }}"
   loop: "{{ asdf_enriched_users }}"
   loop_control:
-    loop_var: asdf_user
-    label: "{{ asdf_user.username }}"
+    loop_var: user_item
   become: true
-  become_user: "{{ asdf_user.username }}"
+  become_user: "{{ user_item.username }}"
   changed_when: false
   when: not asdf_global_install

--- a/roles/asdf/tasks/update_shell_profiles.yml
+++ b/roles/asdf/tasks/update_shell_profiles.yml
@@ -5,14 +5,18 @@
   ignore_errors: true
   changed_when: false
 
-- name: Update shell profile for user
-  ansible.builtin.lineinfile:
+- name: Update shell profile for users
+  ansible.builtin.blockinfile:
     path: "{{ user.home }}/{{ (shell_path.stdout == '') | ternary('.bashrc', (user.shell == '/bin/zsh') | ternary('.zshrc', '.bashrc')) }}"
-    line: "{{ item }}"
-    insertafter: EOF
+    block: |
+      {% for line in user.shell_profile_lines %}
+      {{ line }}
+      {% endfor %}
     create: true
     mode: "0644"
   become: true
   become_user: "{{ user.username }}"
-  loop: "{{ line }}"
+  loop: "{{ asdf_enriched_users }}"
+  loop_control:
+    loop_var: user
   when: shell_path.stdout != ""

--- a/roles/user_setup/tasks/main.yml
+++ b/roles/user_setup/tasks/main.yml
@@ -32,52 +32,62 @@
 - name: Install user-specific shells
   become: true
   ansible.builtin.package:
-    name: "{{ item }}"
+    name: "{{ shell }}"
     state: present
   loop: "{{ unique_shells }}"
+  loop_control:
+    loop_var: shell
   when:
-    - item != ''
-    - item != 'bash'
+    - shell != ''
+    - shell != 'bash'
     - ansible_os_family != 'Darwin'
   environment: "{{ (ansible_os_family == 'Debian') | ternary({'DEBIAN_FRONTEND': 'noninteractive'}, {}) }}"
 
 - name: Ensure groups exist for users
   become: true
   ansible.builtin.group:
-    name: "{{ item.usergroup }}"
+    name: "{{ group.usergroup }}"
     state: present
   loop: "{{ user_setup_default_users }}"
-  when: item.usergroup is defined and ansible_os_family != 'Darwin'
+  loop_control:
+    loop_var: group
+  when: group.usergroup is defined and ansible_os_family != 'Darwin'
 
 - name: Create users
   become: true
   ansible.builtin.user:
-    name: "{{ item.username }}"
-    group: "{{ item.usergroup }}"
-    shell: "{{ item.shell }}"
-    home: "{{ '/Users' if ansible_os_family == 'Darwin' else '/home' }}/{{ item.username }}"
+    name: "{{ user.username }}"
+    group: "{{ user.usergroup }}"
+    shell: "{{ user.shell }}"
+    home: "{{ '/Users' if ansible_os_family == 'Darwin' else '/home' }}/{{ user.username }}"
     state: present
   loop: "{{ user_setup_default_users }}"
-  when: item.username not in ansible_facts.getent_passwd and item.username != 'root'
+  loop_control:
+    loop_var: user
+  when: user.username not in ansible_facts.getent_passwd and user.username != 'root'
 
 - name: Ensure users exist and have home directories
   ansible.builtin.user:
-    name: "{{ item.username }}"
-    group: "{{ item.usergroup }}"
-    shell: "{{ item.shell }}"
+    name: "{{ user.username }}"
+    group: "{{ user.usergroup }}"
+    shell: "{{ user.shell }}"
     create_home: true
     move_home: false
-    home: "{{ '/Users' if ansible_os_family == 'Darwin' else '/home' }}/{{ item.username }}"
+    home: "{{ '/Users' if ansible_os_family == 'Darwin' else '/home' }}/{{ user.username }}"
   register: user_info
   loop: "{{ user_setup_default_users }}"
-  when: item.username not in ansible_facts.getent_passwd
+  loop_control:
+    loop_var: user
+  when: user.username not in ansible_facts.getent_passwd
 
 - name: Provide sudoers access for relevant users in sudoers.d
   become: true
   ansible.builtin.copy:
-    dest: "/etc/sudoers.d/{{ item.username }}"
-    content: "{{ item.username }} ALL=(ALL:ALL) NOPASSWD:ALL\n"
+    dest: "/etc/sudoers.d/{{ user.username }}"
+    content: "{{ user.username }} ALL=(ALL:ALL) NOPASSWD:ALL\n"
     validate: "visudo -cf %s"
     mode: "0440"
-  when: item.sudo and ansible_os_family != 'Darwin'
+  when: user.sudo and ansible_os_family != 'Darwin'
   loop: "{{ user_setup_default_users }}"
+  loop_control:
+    loop_var: user

--- a/roles/zsh_setup/tasks/main.yml
+++ b/roles/zsh_setup/tasks/main.yml
@@ -4,70 +4,83 @@
 
 - name: Check if .oh-my-zsh exists for each user
   ansible.builtin.stat:
-    path: "{{ item.home }}/.oh-my-zsh"
+    path: "{{ user.home }}/.oh-my-zsh"
   register: oh_my_zsh_installed
   loop: "{{ zsh_setup_enriched_users | flatten }}"
+  loop_control:
+    loop_var: user
 
 - name: Download oh-my-zsh install script for all zsh_setup_enriched_users
   ansible.builtin.get_url:
     url: "{{ zsh_setup_omz_install_script_url }}"
-    dest: "{{ item.home }}/omz-installer.sh"
+    dest: "{{ user.home }}/omz-installer.sh"
     mode: "0755"
-    owner: "{{ item.username }}"
-    group: "{{ item.usergroup }}"
+    owner: "{{ user.username }}"
+    group: "{{ user.usergroup }}"
   become: true
-  become_user: "{{ item.username }}"
+  become_user: "{{ user.username }}"
   when:
-    - item.home is defined
-    - item.home | length > 0
+    - user.home is defined
+    - user.home | length > 0
   loop: "{{ zsh_setup_enriched_users }}"
+  loop_control:
+    loop_var: user
   changed_when: false
 
 - name: Install oh-my-zsh for all zsh_setup_enriched_users
   ansible.builtin.shell: |
     set -o pipefail
-    echo 'y' | {{ item.home }}/omz-installer.sh --unattended --keep-zshrc
+    echo 'y' | {{ user.home }}/omz-installer.sh --unattended --keep-zshrc
   args:
-    creates: "{{ item.home }}/.oh-my-zsh"
+    creates: "{{ user.home }}/.oh-my-zsh"
     executable: /bin/zsh
   become: true
-  become_user: "{{ item.username }}"
-  when: "not oh_my_zsh_installed.results[item | int].stat.exists"
+  become_user: "{{ user.username }}"
+  when: "not oh_my_zsh_installed.results[user | int].stat.exists"
   loop: "{{ zsh_setup_enriched_users }}"
+  loop_control:
+    loop_var: user
   changed_when: false
 
 - name: Check if omz-installer.sh exists for each user
   ansible.builtin.stat:
-    path: "{{ item.home }}/omz-installer.sh"
+    path: "{{ user.home }}/omz-installer.sh"
   register: omz_installer_exists
   loop: "{{ zsh_setup_enriched_users }}"
+  loop_control:
+    loop_var: user
 
 - name: Remove omz-installer.sh for all zsh_setup_enriched_users
   ansible.builtin.file:
-    path: "{{ item.home }}/omz-installer.sh"
+    path: "{{ user.home }}/omz-installer.sh"
     state: absent
   become: true
-  become_user: "{{ item.username }}"
-  when: omz_installer_exists.results[item | int].stat.exists
+  become_user: "{{ user.username }}"
+  when: omz_installer_exists.results[user | int].stat.exists
   loop: "{{ zsh_setup_enriched_users }}"
+  loop_control:
+    loop_var: user
   changed_when: false
 
 - name: Check if .zshrc exists for all zsh_setup_enriched_users
   ansible.builtin.stat:
-    path: "{{ item.home }}/.zshrc"
+    path: "{{ user.home }}/.zshrc"
   register: zshrc_exists
   loop: "{{ zsh_setup_enriched_users }}"
+  loop_control:
+    loop_var: user
 
 - name: Copy .zshrc template to user's home directory if it does not exist
   ansible.builtin.template:
     src: zshrc.j2
     mode: "0644"
-    dest: "{{ item.home }}/.zshrc"
-    owner: "{{ item.username }}"
-    group: "{{ item.usergroup | default(item.username) }}"
+    dest: "{{ user.home }}/.zshrc"
+    owner: "{{ user.username }}"
+    group: "{{ user.usergroup | default(user.username) }}"
   loop: "{{ zsh_setup_enriched_users }}"
   loop_control:
     index_var: loop_index
+    loop_var: user
   become: true
-  become_user: "{{ item.username }}"
+  become_user: "{{ user.username }}"
   when: not zshrc_exists.results[loop_index].stat.exists

--- a/roles/zsh_setup/tasks/zsh_setup_get_enriched_users.yml
+++ b/roles/zsh_setup/tasks/zsh_setup_get_enriched_users.yml
@@ -14,21 +14,25 @@
   ansible.builtin.set_fact:
     zsh_setup_enriched_users: >-
       {{ (zsh_setup_enriched_users | default([])) |
-      rejectattr('username', 'equalto', item.username) | list +
-      [item | combine({
-        'home': ansible_facts.getent_passwd[item.username][4] if item.username in ansible_facts.getent_passwd else item.home,
-        'shell': item.shell,
-        'usergroup': item.usergroup,
-        'username': item.username
+      rejectattr('username', 'equalto', user.username) | list +
+      [user | combine({
+        'home': ansible_facts.getent_passwd[user.username][4] if user.username in ansible_facts.getent_passwd else user.home,
+        'shell': user.shell,
+        'usergroup': user.usergroup,
+        'username': user.username
         })] | selectattr('home', 'defined') | list }}
   loop: "{{ zsh_setup_users }}"
+  loop_control:
+    loop_var: user
 
 - name: Ensure user home directory exists
   ansible.builtin.file:
-    path: "{{ item.home }}"
+    path: "{{ user.home }}"
     state: directory
-    owner: "{{ item.username }}"
-    group: "{{ item.usergroup | default(item.username) }}"
+    owner: "{{ user.username }}"
+    group: "{{ user.usergroup | default(user.username) }}"
     mode: "0755"
   loop: "{{ zsh_setup_enriched_users }}"
-  when: item.username != 'root'
+  loop_control:
+    loop_var: user
+  when: user.username in ansible_facts.getent_passwd


### PR DESCRIPTION
**Changed:**
- Updated loop variables from 'item' to 'user' for consistency across tasks
- Used blockinfile instead of lineinfile for shell profile updates for idempotence
- Combined 'Download, extract, compile, and install libyaml' steps into a block
- Adjusted all relevant tasks in asdf and user_setup roles to use 'user' variable
- Ensured all loops use loop_control with loop_var for clarity

**Removed:**
- Removed unnecessary debug task for getent_user_shell in asdf role