### PR TITLE
Refactored Molecule Workflow and Improved Verification Tasks

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -28,147 +28,22 @@ env:
   RUNZERO_DOWNLOAD_TOKEN: ${{ secrets.RUNZERO_DOWNLOAD_TOKEN }}
 
 jobs:
-  determine-tests:
-    runs-on: ubuntu-latest
-    outputs:
-      roles-matrix: ${{ steps.set-matrix.outputs.roles-matrix }}
-      playbooks-matrix: ${{ steps.set-matrix.outputs.playbooks-matrix }}
-      should-run: ${{ steps.check-changes.outputs.should-run }}
-    steps:
-      - name: Checkout git repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          fetch-depth: 0
-
-      - name: Check for relevant changes and labels
-        id: check-changes
-        shell: bash
-        run: |
-          should_run="false"
-
-          if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "workflow_dispatch" || "${{ github.event_name }}" == "push" ]]; then
-            should_run="true"
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # Check labels
-            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'area/roles') }}" == "true" || \
-                  "${{ contains(github.event.pull_request.labels.*.name, 'area/playbooks') }}" == "true" ]]; then
-              should_run="true"
-            fi
-
-            # Check individual role labels
-            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/asdf') }}" == "true" || \
-                  "${{ contains(github.event.pull_request.labels.*.name, 'role/user_setup') }}" == "true" || \
-                  "${{ contains(github.event.pull_request.labels.*.name, 'role/package_management') }}" == "true" || \
-                  "${{ contains(github.event.pull_request.labels.*.name, 'role/zsh_setup') }}" == "true" ]]; then
-              should_run="true"
-            fi
-
-            # Check individual playbook labels
-            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'playbook/workstation') }}" == "true" || \
-                  "${{ contains(github.event.pull_request.labels.*.name, 'playbook/runzero-explorer') }}" == "true" ]]; then
-              should_run="true"
-            fi
-
-            # Check changed files
-            git fetch origin "${{ github.base_ref }}"
-            changed_files="$(git diff --name-only "origin/${{ github.base_ref }}"..HEAD)"
-
-            if echo "${changed_files}" | grep -qE "^(roles/|playbooks/|molecule/|requirements\.yml)"; then
-              should_run="true"
-            fi
-          fi
-
-          echo "should-run=${should_run}" >> "$GITHUB_OUTPUT"
-
-          # Debug output
-          echo "Event: ${{ github.event_name }}"
-          echo "Should run: ${should_run}"
-
-      - name: Determine affected components
-        id: set-matrix
-        if: steps.check-changes.outputs.should-run == 'true'
-        shell: bash
-        run: |
-          # Function to create compact JSON
-          create_json() {
-            local items=("$@")
-            local json
-            if [ ${#items[@]} -eq 0 ]; then
-              json='{"include":[]}'
-            else
-              json="$(printf '{"include":[%s]}' "$(IFS=,; echo "${items[*]}")")"
-            fi
-            echo "${json}"
-          }
-
-          # Initialize arrays
-          roles=()
-          playbooks=()
-
-          # Safely get available roles
-          while IFS= read -r -d '' role_dir; do
-            available_roles+=("$(basename "$role_dir")")
-          done < <(find roles -maxdepth 1 -mindepth 1 -type d -print0)
-          echo "Available roles: ${available_roles[*]}"
-
-          # Full test suite for non-PR events
-          if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "workflow_dispatch" || "${{ github.event_name }}" == "push" ]]; then
-            for role in "${available_roles[@]}"; do
-              roles+=("{\"name\":\"Role Test - ${role}\",\"path\":\"roles/${role}\"}")
-            done
-
-            # Handle playbooks similarly
-            while IFS= read -r -d '' playbook_dir; do
-              playbook=$(basename "$playbook_dir")
-              playbooks+=("{\"name\":\"Playbook Test - ${playbook}\",\"path\":\"playbooks/${playbook}\"}")
-            done < <(find playbooks -maxdepth 1 -mindepth 1 -type d -print0)
-          else
-            # PR handling
-            echo "Processing PR with labels"
-
-            # If area/roles is present, test all roles
-            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'area/roles') }}" == "true" ]]; then
-              echo "area/roles label found - testing all roles"
-              for role in "${available_roles[@]}"; do
-                roles+=("{\"name\":\"Role Test - ${role}\",\"path\":\"roles/${role}\"}")
-              done
-            else
-              # Get changed files
-              git fetch origin "${{ github.base_ref || 'main' }}"
-              changed_files="$(git diff --name-only "origin/${{ github.base_ref || 'main' }}"..HEAD)"
-
-              for role in "${available_roles[@]}"; do
-                # Check for role-specific label or changes
-                if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/${role}') }}" == "true" ]] || \
-                    grep -q "^roles/${role}/" <<< "$changed_files"; then
-                  roles+=("{\"name\":\"Role Test - ${role}\",\"path\":\"roles/${role}\"}")
-                fi
-              done
-            fi
-          fi
-
-          # Create JSON outputs
-          roles_json=$(create_json "${roles[@]}")
-          playbooks_json=$(create_json "${playbooks[@]}")
-
-          {
-            echo "roles-matrix=${roles_json}"
-            echo "playbooks-matrix=${playbooks_json}"
-          } >> "$GITHUB_OUTPUT"
-
-          echo "Event: ${{ github.event_name }}"
-          echo "Roles matrix: ${roles_json}"
-          echo "Playbooks matrix: ${playbooks_json}"
-
   role_test:
-    needs: determine-tests
-    if: needs.determine-tests.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false
       max-parallel: 2
-      matrix: ${{ fromJson(needs.determine-tests.outputs.roles-matrix) }}
+      matrix:
+        include:
+          - name: "Role Test - asdf"
+            path: "roles/asdf"
+          - name: "Role Test - user_setup"
+            path: "roles/user_setup"
+          - name: "Role Test - package_management"
+            path: "roles/package_management"
+          - name: "Role Test - zsh_setup"
+            path: "roles/zsh_setup"
 
     steps:
       - name: Install Act dependencies
@@ -248,14 +123,17 @@ jobs:
           fi
 
   playbook_test:
-    needs: determine-tests
-    if: needs.determine-tests.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false
       max-parallel: 2
-      matrix: ${{ fromJson(needs.determine-tests.outputs.playbooks-matrix) }}
+      matrix:
+        include:
+          - name: "Playbook Test - workstation"
+            path: "playbooks/workstation"
+          - name: "Playbook Test - runzero-explorer"
+            path: "playbooks/runzero-explorer"
 
     steps:
       - name: Install Act dependencies

--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -101,72 +101,49 @@ jobs:
             echo "${json}"
           }
 
-          # Initialize empty arrays
+          # Initialize arrays
           roles=()
           playbooks=()
 
-          # Get event type from GitHub context
-          event_type="${{ github.event_name }}"
-          echo "Event type: $event_type"
+          # Safely get available roles
+          while IFS= read -r -d '' role_dir; do
+            available_roles+=("$(basename "$role_dir")")
+          done < <(find roles -maxdepth 1 -mindepth 1 -type d -print0)
+          echo "Available roles: ${available_roles[*]}"
 
-          # For scheduled/manual runs or pushes, test everything
-          if [[ "$event_type" == "schedule" || "$event_type" == "workflow_dispatch" || "$event_type" == "push" ]]; then
-            echo "Running full test suite due to event type: $event_type"
-            roles=(
-              '{"name":"Role Test - asdf","path":"roles/asdf"}'
-              '{"name":"Role Test - logging","path":"roles/logging"}'
-              '{"name":"Role Test - package_management","path":"roles/package_management"}'
-              '{"name":"Role Test - runzero_explorer","path":"roles/runzero_explorer"}'
-              '{"name":"Role Test - user_setup","path":"roles/user_setup"}'
-              '{"name":"Role Test - vnc_setup","path":"roles/vnc_setup"}'
-              '{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}'
-            )
-            playbooks=(
-              '{"name":"Playbook Test - workstation","path":"playbooks/workstation"}'
-              '{"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}'
-            )
+          # Full test suite for non-PR events
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "workflow_dispatch" || "${{ github.event_name }}" == "push" ]]; then
+            for role in "${available_roles[@]}"; do
+              roles+=("{\"name\":\"Role Test - ${role}\",\"path\":\"roles/${role}\"}")
+            done
+
+            # Handle playbooks similarly
+            while IFS= read -r -d '' playbook_dir; do
+              playbook=$(basename "$playbook_dir")
+              playbooks+=("{\"name\":\"Playbook Test - ${playbook}\",\"path\":\"playbooks/${playbook}\"}")
+            done < <(find playbooks -maxdepth 1 -mindepth 1 -type d -print0)
           else
-            # For PRs, check labels and changed files
+            # PR handling
             echo "Processing PR with labels"
 
-            # Check if area/roles label is present
+            # If area/roles is present, test all roles
             if [[ "${{ contains(github.event.pull_request.labels.*.name, 'area/roles') }}" == "true" ]]; then
               echo "area/roles label found - testing all roles"
-              roles=(
-                '{"name":"Role Test - asdf","path":"roles/asdf"}'
-                '{"name":"Role Test - logging","path":"roles/logging"}'
-                '{"name":"Role Test - package_management","path":"roles/package_management"}'
-                '{"name":"Role Test - runzero_explorer","path":"roles/runzero_explorer"}'
-                '{"name":"Role Test - user_setup","path":"roles/user_setup"}'
-                '{"name":"Role Test - vnc_setup","path":"roles/vnc_setup"}'
-                '{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}'
-              )
+              for role in "${available_roles[@]}"; do
+                roles+=("{\"name\":\"Role Test - ${role}\",\"path\":\"roles/${role}\"}")
+              done
             else
-              # Check individual role labels
-              echo "Checking individual role labels"
-              [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/asdf') }}" == "true" ]] && roles+=('{"name":"Role Test - asdf","path":"roles/asdf"}')
-              [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/logging') }}" == "true" ]] && roles+=('{"name":"Role Test - logging","path":"roles/logging"}')
-              [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/package_management') }}" == "true" ]] && roles+=('{"name":"Role Test - package_management","path":"roles/package_management"}')
-              [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/runzero_explorer') }}" == "true" ]] && roles+=('{"name":"Role Test - runzero_explorer","path":"roles/runzero_explorer"}')
-              [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/user_setup') }}" == "true" ]] && roles+=('{"name":"Role Test - user_setup","path":"roles/user_setup"}')
-              [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/vnc_setup') }}" == "true" ]] && roles+=('{"name":"Role Test - vnc_setup","path":"roles/vnc_setup"}')
-              [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/zsh_setup') }}" == "true" ]] && roles+=('{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}')
+              # Get changed files
+              git fetch origin "${{ github.base_ref || 'main' }}"
+              changed_files="$(git diff --name-only "origin/${{ github.base_ref || 'main' }}"..HEAD)"
 
-              # Get changed files and check role directories
-              git fetch origin "${{ github.base_ref }}"
-              changed_files="$(git diff --name-only "origin/${{ github.base_ref }}"..HEAD)"
-              echo "Changed files:"
-              echo "$changed_files"
-
-              if [[ -n "$changed_files" ]]; then
-                grep -q "^roles/asdf/" <<< "$changed_files" && roles+=('{"name":"Role Test - asdf","path":"roles/asdf"}')
-                grep -q "^roles/logging/" <<< "$changed_files" && roles+=('{"name":"Role Test - logging","path":"roles/logging"}')
-                grep -q "^roles/package_management/" <<< "$changed_files" && roles+=('{"name":"Role Test - package_management","path":"roles/package_management"}')
-                grep -q "^roles/runzero_explorer/" <<< "$changed_files" && roles+=('{"name":"Role Test - runzero_explorer","path":"roles/runzero_explorer"}')
-                grep -q "^roles/user_setup/" <<< "$changed_files" && roles+=('{"name":"Role Test - user_setup","path":"roles/user_setup"}')
-                grep -q "^roles/vnc_setup/" <<< "$changed_files" && roles+=('{"name":"Role Test - vnc_setup","path":"roles/vnc_setup"}')
-                grep -q "^roles/zsh_setup/" <<< "$changed_files" && roles+=('{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}')
-              fi
+              for role in "${available_roles[@]}"; do
+                # Check for role-specific label or changes
+                if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/${role}') }}" == "true" ]] || \
+                    grep -q "^roles/${role}/" <<< "$changed_files"; then
+                  roles+=("{\"name\":\"Role Test - ${role}\",\"path\":\"roles/${role}\"}")
+                fi
+              done
             fi
           fi
 
@@ -174,14 +151,12 @@ jobs:
           roles_json=$(create_json "${roles[@]}")
           playbooks_json=$(create_json "${playbooks[@]}")
 
-          # Set outputs
           {
             echo "roles-matrix=${roles_json}"
             echo "playbooks-matrix=${playbooks_json}"
           } >> "$GITHUB_OUTPUT"
 
-          # Debug output
-          echo "Event: $event_type"
+          echo "Event: ${{ github.event_name }}"
           echo "Roles matrix: ${roles_json}"
           echo "Playbooks matrix: ${playbooks_json}"
 

--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -105,8 +105,13 @@ jobs:
           roles=()
           playbooks=()
 
-          if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "workflow_dispatch" || "${{ github.event_name }}" == "push" ]]; then
-            # Full test array for scheduled/manual runs
+          # Get event type from GitHub context
+          event_type="${{ github.event_name }}"
+          echo "Event type: $event_type"
+
+          # For scheduled/manual runs or pushes, test everything
+          if [[ "$event_type" == "schedule" || "$event_type" == "workflow_dispatch" || "$event_type" == "push" ]]; then
+            echo "Running full test suite due to event type: $event_type"
             roles=(
               '{"name":"Role Test - asdf","path":"roles/asdf"}'
               '{"name":"Role Test - logging","path":"roles/logging"}'
@@ -121,11 +126,12 @@ jobs:
               '{"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}'
             )
           else
-            git fetch origin "${{ github.base_ref }}" || true
-            changed_files="$(git diff --name-only "origin/${{ github.base_ref }}"..HEAD)" || true
+            # For PRs, check labels and changed files
+            echo "Processing PR with labels"
 
-            # Check requirements.yml changes first - this triggers all tests
-            if grep -q "^requirements\.yml$" <<< "${changed_files}"; then
+            # Check if area/roles label is present
+            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'area/roles') }}" == "true" ]]; then
+              echo "area/roles label found - testing all roles"
               roles=(
                 '{"name":"Role Test - asdf","path":"roles/asdf"}'
                 '{"name":"Role Test - logging","path":"roles/logging"}'
@@ -135,48 +141,36 @@ jobs:
                 '{"name":"Role Test - vnc_setup","path":"roles/vnc_setup"}'
                 '{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}'
               )
-              playbooks=(
-                '{"name":"Playbook Test - workstation","path":"playbooks/workstation"}'
-                '{"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}'
-              )
             else
-              # Check area/roles label
-              if [[ "${{ contains(github.event.pull_request.labels.*.name, 'area/roles') }}" == "true" ]]; then
-                roles=(
-                  '{"name":"Role Test - asdf","path":"roles/asdf"}'
-                  '{"name":"Role Test - logging","path":"roles/logging"}'
-                  '{"name":"Role Test - package_management","path":"roles/package_management"}'
-                  '{"name":"Role Test - runzero_explorer","path":"roles/runzero_explorer"}'
-                  '{"name":"Role Test - user_setup","path":"roles/user_setup"}'
-                  '{"name":"Role Test - vnc_setup","path":"roles/vnc_setup"}'
-                  '{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}'
-                )
-              else
-                # Check individual roles
-                [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/asdf') }}" == "true" ]] || grep -q "^roles/asdf/" <<< "${changed_files}" && roles+=('{"name":"Role Test - asdf","path":"roles/asdf"}')
-                [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/logging') }}" == "true" ]] || grep -q "^roles/logging/" <<< "${changed_files}" && roles+=('{"name":"Role Test - logging","path":"roles/logging"}')
-                [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/package_management') }}" == "true" ]] || grep -q "^roles/package_management/" <<< "${changed_files}" && roles+=('{"name":"Role Test - package_management","path":"roles/package_management"}')
-                [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/runzero_explorer') }}" == "true" ]] || grep -q "^roles/runzero_explorer/" <<< "${changed_files}" && roles+=('{"name":"Role Test - runzero_explorer","path":"roles/runzero_explorer"}')
-                [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/user_setup') }}" == "true" ]] || grep -q "^roles/user_setup/" <<< "${changed_files}" && roles+=('{"name":"Role Test - user_setup","path":"roles/user_setup"}')
-                [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/vnc_setup') }}" == "true" ]] || grep -q "^roles/vnc_setup/" <<< "${changed_files}" && roles+=('{"name":"Role Test - vnc_setup","path":"roles/vnc_setup"}')
-                [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/zsh_setup') }}" == "true" ]] || grep -q "^roles/zsh_setup/" <<< "${changed_files}" && roles+=('{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}')
-              fi
+              # Check individual role labels
+              echo "Checking individual role labels"
+              [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/asdf') }}" == "true" ]] && roles+=('{"name":"Role Test - asdf","path":"roles/asdf"}')
+              [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/logging') }}" == "true" ]] && roles+=('{"name":"Role Test - logging","path":"roles/logging"}')
+              [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/package_management') }}" == "true" ]] && roles+=('{"name":"Role Test - package_management","path":"roles/package_management"}')
+              [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/runzero_explorer') }}" == "true" ]] && roles+=('{"name":"Role Test - runzero_explorer","path":"roles/runzero_explorer"}')
+              [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/user_setup') }}" == "true" ]] && roles+=('{"name":"Role Test - user_setup","path":"roles/user_setup"}')
+              [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/vnc_setup') }}" == "true" ]] && roles+=('{"name":"Role Test - vnc_setup","path":"roles/vnc_setup"}')
+              [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/zsh_setup') }}" == "true" ]] && roles+=('{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}')
 
-              # Check area/playbooks label
-              if [[ "${{ contains(github.event.pull_request.labels.*.name, 'area/playbooks') }}" == "true" ]]; then
-                playbooks=(
-                  '{"name":"Playbook Test - workstation","path":"playbooks/workstation"}'
-                  '{"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}'
-                )
-              else
-                # Check individual playbooks
-                [[ "${{ contains(github.event.pull_request.labels.*.name, 'playbook/workstation') }}" == "true" ]] || grep -q "^playbooks/workstation/" <<< "${changed_files}" && playbooks+=('{"name":"Playbook Test - workstation","path":"playbooks/workstation"}')
-                [[ "${{ contains(github.event.pull_request.labels.*.name, 'playbook/runzero-explorer') }}" == "true" ]] || grep -q "^playbooks/runzero-explorer/" <<< "${changed_files}" && playbooks+=('{"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}')
+              # Get changed files and check role directories
+              git fetch origin "${{ github.base_ref }}"
+              changed_files="$(git diff --name-only "origin/${{ github.base_ref }}"..HEAD)"
+              echo "Changed files:"
+              echo "$changed_files"
+
+              if [[ -n "$changed_files" ]]; then
+                grep -q "^roles/asdf/" <<< "$changed_files" && roles+=('{"name":"Role Test - asdf","path":"roles/asdf"}')
+                grep -q "^roles/logging/" <<< "$changed_files" && roles+=('{"name":"Role Test - logging","path":"roles/logging"}')
+                grep -q "^roles/package_management/" <<< "$changed_files" && roles+=('{"name":"Role Test - package_management","path":"roles/package_management"}')
+                grep -q "^roles/runzero_explorer/" <<< "$changed_files" && roles+=('{"name":"Role Test - runzero_explorer","path":"roles/runzero_explorer"}')
+                grep -q "^roles/user_setup/" <<< "$changed_files" && roles+=('{"name":"Role Test - user_setup","path":"roles/user_setup"}')
+                grep -q "^roles/vnc_setup/" <<< "$changed_files" && roles+=('{"name":"Role Test - vnc_setup","path":"roles/vnc_setup"}')
+                grep -q "^roles/zsh_setup/" <<< "$changed_files" && roles+=('{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}')
               fi
             fi
           fi
 
-          # Create JSON with proper formatting
+          # Create JSON outputs
           roles_json=$(create_json "${roles[@]}")
           playbooks_json=$(create_json "${playbooks[@]}")
 
@@ -187,7 +181,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
           # Debug output
-          echo "Event: ${{ github.event_name }}"
+          echo "Event: $event_type"
           echo "Roles matrix: ${roles_json}"
           echo "Playbooks matrix: ${playbooks_json}"
 

--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -89,111 +89,102 @@ jobs:
         if: steps.check-changes.outputs.should-run == 'true'
         shell: bash
         run: |
-          # Initialize empty arrays and default JSON
+          # Function to create compact JSON
+          create_json() {
+            local items=("$@")
+            local json
+            if [ ${#items[@]} -eq 0 ]; then
+              json='{"include":[]}'
+            else
+              json="$(printf '{"include":[%s]}' "$(IFS=,; echo "${items[*]}")")"
+            fi
+            echo "${json}"
+          }
+
+          # Initialize empty arrays
           roles=()
           playbooks=()
-          roles_json='{"include":[]}'
-          playbooks_json='{"include":[]}'
 
           if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "workflow_dispatch" || "${{ github.event_name }}" == "push" ]]; then
-            # Test everything for scheduled/manual runs
-            roles_json='{"include":[
-              {"name":"Role Test - asdf","path":"roles/asdf"},
-              {"name":"Role Test - logging","path":"roles/logging"},
-              {"name":"Role Test - package_management","path":"roles/package_management"},
-              {"name":"Role Test - runzero_explorer","path":"roles/runzero_explorer"},
-              {"name":"Role Test - user_setup","path":"roles/user_setup"},
-              {"name":"Role Test - vnc_setup","path":"roles/vnc_setup"},
-              {"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}
-            ]}'
-            playbooks_json='{"include":[
-              {"name":"Playbook Test - workstation","path":"playbooks/workstation"},
-              {"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}
-            ]}'
+            # Full test array for scheduled/manual runs
+            roles=(
+              '{"name":"Role Test - asdf","path":"roles/asdf"}'
+              '{"name":"Role Test - logging","path":"roles/logging"}'
+              '{"name":"Role Test - package_management","path":"roles/package_management"}'
+              '{"name":"Role Test - runzero_explorer","path":"roles/runzero_explorer"}'
+              '{"name":"Role Test - user_setup","path":"roles/user_setup"}'
+              '{"name":"Role Test - vnc_setup","path":"roles/vnc_setup"}'
+              '{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}'
+            )
+            playbooks=(
+              '{"name":"Playbook Test - workstation","path":"playbooks/workstation"}'
+              '{"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}'
+            )
           else
             git fetch origin "${{ github.base_ref }}" || true
             changed_files="$(git diff --name-only "origin/${{ github.base_ref }}"..HEAD)" || true
 
             # Check requirements.yml changes first - this triggers all tests
             if grep -q "^requirements\.yml$" <<< "${changed_files}"; then
-              roles_json='{"include":[
-                {"name":"Role Test - asdf","path":"roles/asdf"},
-                {"name":"Role Test - logging","path":"roles/logging"},
-                {"name":"Role Test - package_management","path":"roles/package_management"},
-                {"name":"Role Test - runzero_explorer","path":"roles/runzero_explorer"},
-                {"name":"Role Test - user_setup","path":"roles/user_setup"},
-                {"name":"Role Test - vnc_setup","path":"roles/vnc_setup"},
-                {"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}
-              ]}'
-              playbooks_json='{"include":[
-                {"name":"Playbook Test - workstation","path":"playbooks/workstation"},
-                {"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}
-              ]}'
+              roles=(
+                '{"name":"Role Test - asdf","path":"roles/asdf"}'
+                '{"name":"Role Test - logging","path":"roles/logging"}'
+                '{"name":"Role Test - package_management","path":"roles/package_management"}'
+                '{"name":"Role Test - runzero_explorer","path":"roles/runzero_explorer"}'
+                '{"name":"Role Test - user_setup","path":"roles/user_setup"}'
+                '{"name":"Role Test - vnc_setup","path":"roles/vnc_setup"}'
+                '{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}'
+              )
+              playbooks=(
+                '{"name":"Playbook Test - workstation","path":"playbooks/workstation"}'
+                '{"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}'
+              )
             else
               # Check area/roles label
               if [[ "${{ contains(github.event.pull_request.labels.*.name, 'area/roles') }}" == "true" ]]; then
-                roles_json='{"include":[
-                  {"name":"Role Test - asdf","path":"roles/asdf"},
-                  {"name":"Role Test - logging","path":"roles/logging"},
-                  {"name":"Role Test - package_management","path":"roles/package_management"},
-                  {"name":"Role Test - runzero_explorer","path":"roles/runzero_explorer"},
-                  {"name":"Role Test - user_setup","path":"roles/user_setup"},
-                  {"name":"Role Test - vnc_setup","path":"roles/vnc_setup"},
-                  {"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}
-                ]}'
+                roles=(
+                  '{"name":"Role Test - asdf","path":"roles/asdf"}'
+                  '{"name":"Role Test - logging","path":"roles/logging"}'
+                  '{"name":"Role Test - package_management","path":"roles/package_management"}'
+                  '{"name":"Role Test - runzero_explorer","path":"roles/runzero_explorer"}'
+                  '{"name":"Role Test - user_setup","path":"roles/user_setup"}'
+                  '{"name":"Role Test - vnc_setup","path":"roles/vnc_setup"}'
+                  '{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}'
+                )
               else
                 # Check individual roles
-                if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/asdf') }}" == "true" ]] || grep -q "^roles/asdf/" <<< "${changed_files}"; then
-                  roles+=('{"name":"Role Test - asdf","path":"roles/asdf"}')
-                fi
-                if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/logging') }}" == "true" ]] || grep -q "^roles/logging/" <<< "${changed_files}"; then
-                  roles+=('{"name":"Role Test - logging","path":"roles/logging"}')
-                fi
-                if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/package_management') }}" == "true" ]] || grep -q "^roles/package_management/" <<< "${changed_files}"; then
-                  roles+=('{"name":"Role Test - package_management","path":"roles/package_management"}')
-                fi
-                if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/runzero_explorer') }}" == "true" ]] || grep -q "^roles/runzero_explorer/" <<< "${changed_files}"; then
-                  roles+=('{"name":"Role Test - runzero_explorer","path":"roles/runzero_explorer"}')
-                fi
-                if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/user_setup') }}" == "true" ]] || grep -q "^roles/user_setup/" <<< "${changed_files}"; then
-                  roles+=('{"name":"Role Test - user_setup","path":"roles/user_setup"}')
-                fi
-                if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/vnc_setup') }}" == "true" ]] || grep -q "^roles/vnc_setup/" <<< "${changed_files}"; then
-                  roles+=('{"name":"Role Test - vnc_setup","path":"roles/vnc_setup"}')
-                fi
-                if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/zsh_setup') }}" == "true" ]] || grep -q "^roles/zsh_setup/" <<< "${changed_files}"; then
-                  roles+=('{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}')
-                fi
-
-                # Create roles JSON if any roles were found
-                if [ ${#roles[@]} -gt 0 ]; then
-                  roles_json=$(printf '{"include":[%s]}' "$(IFS=,; echo "${roles[*]}")")
-                fi
+                [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/asdf') }}" == "true" ]] || grep -q "^roles/asdf/" <<< "${changed_files}" && roles+=('{"name":"Role Test - asdf","path":"roles/asdf"}')
+                [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/logging') }}" == "true" ]] || grep -q "^roles/logging/" <<< "${changed_files}" && roles+=('{"name":"Role Test - logging","path":"roles/logging"}')
+                [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/package_management') }}" == "true" ]] || grep -q "^roles/package_management/" <<< "${changed_files}" && roles+=('{"name":"Role Test - package_management","path":"roles/package_management"}')
+                [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/runzero_explorer') }}" == "true" ]] || grep -q "^roles/runzero_explorer/" <<< "${changed_files}" && roles+=('{"name":"Role Test - runzero_explorer","path":"roles/runzero_explorer"}')
+                [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/user_setup') }}" == "true" ]] || grep -q "^roles/user_setup/" <<< "${changed_files}" && roles+=('{"name":"Role Test - user_setup","path":"roles/user_setup"}')
+                [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/vnc_setup') }}" == "true" ]] || grep -q "^roles/vnc_setup/" <<< "${changed_files}" && roles+=('{"name":"Role Test - vnc_setup","path":"roles/vnc_setup"}')
+                [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/zsh_setup') }}" == "true" ]] || grep -q "^roles/zsh_setup/" <<< "${changed_files}" && roles+=('{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}')
               fi
 
               # Check area/playbooks label
               if [[ "${{ contains(github.event.pull_request.labels.*.name, 'area/playbooks') }}" == "true" ]]; then
-                playbooks_json='{"include":[{"name":"Playbook Test - workstation","path":"playbooks/workstation"},{"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}]}'
+                playbooks=(
+                  '{"name":"Playbook Test - workstation","path":"playbooks/workstation"}'
+                  '{"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}'
+                )
               else
                 # Check individual playbooks
-                if [[ "${{ contains(github.event.pull_request.labels.*.name, 'playbook/workstation') }}" == "true" ]] || grep -q "^playbooks/workstation/" <<< "${changed_files}"; then
-                  playbooks+=('{"name":"Playbook Test - workstation","path":"playbooks/workstation"}')
-                fi
-                if [[ "${{ contains(github.event.pull_request.labels.*.name, 'playbook/runzero-explorer') }}" == "true" ]] || grep -q "^playbooks/runzero-explorer/" <<< "${changed_files}"; then
-                  playbooks+=('{"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}')
-                fi
-
-                # Create playbooks JSON if any playbooks were found
-                if [ ${#playbooks[@]} -gt 0 ]; then
-                  playbooks_json=$(printf '{"include":[%s]}' "$(IFS=,; echo "${playbooks[*]}")")
-                fi
+                [[ "${{ contains(github.event.pull_request.labels.*.name, 'playbook/workstation') }}" == "true" ]] || grep -q "^playbooks/workstation/" <<< "${changed_files}" && playbooks+=('{"name":"Playbook Test - workstation","path":"playbooks/workstation"}')
+                [[ "${{ contains(github.event.pull_request.labels.*.name, 'playbook/runzero-explorer') }}" == "true" ]] || grep -q "^playbooks/runzero-explorer/" <<< "${changed_files}" && playbooks+=('{"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}')
               fi
             fi
           fi
 
+          # Create JSON with proper formatting
+          roles_json=$(create_json "${roles[@]}")
+          playbooks_json=$(create_json "${playbooks[@]}")
+
           # Set outputs
-          echo "roles-matrix=${roles_json}" >> "$GITHUB_OUTPUT"
-          echo "playbooks-matrix=${playbooks_json}" >> "$GITHUB_OUTPUT"
+          {
+            echo "roles-matrix=${roles_json}"
+            echo "playbooks-matrix=${playbooks_json}"
+          } >> "$GITHUB_OUTPUT"
 
           # Debug output
           echo "Event: ${{ github.event_name }}"

--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -97,30 +97,69 @@ jobs:
 
           if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "workflow_dispatch" || "${{ github.event_name }}" == "push" ]]; then
             # Test everything for scheduled/manual runs
-            roles_json='{"include":[{"name":"Role Test - asdf","path":"roles/asdf"},{"name":"Role Test - user_setup","path":"roles/user_setup"},{"name":"Role Test - package_management","path":"roles/package_management"},{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}]}'
-            playbooks_json='{"include":[{"name":"Playbook Test - workstation","path":"playbooks/workstation"},{"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}]}'
+            roles_json='{"include":[
+              {"name":"Role Test - asdf","path":"roles/asdf"},
+              {"name":"Role Test - logging","path":"roles/logging"},
+              {"name":"Role Test - package_management","path":"roles/package_management"},
+              {"name":"Role Test - runzero_explorer","path":"roles/runzero_explorer"},
+              {"name":"Role Test - user_setup","path":"roles/user_setup"},
+              {"name":"Role Test - vnc_setup","path":"roles/vnc_setup"},
+              {"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}
+            ]}'
+            playbooks_json='{"include":[
+              {"name":"Playbook Test - workstation","path":"playbooks/workstation"},
+              {"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}
+            ]}'
           else
             git fetch origin "${{ github.base_ref }}" || true
             changed_files="$(git diff --name-only "origin/${{ github.base_ref }}"..HEAD)" || true
 
             # Check requirements.yml changes first - this triggers all tests
             if grep -q "^requirements\.yml$" <<< "${changed_files}"; then
-              roles_json='{"include":[{"name":"Role Test - asdf","path":"roles/asdf"},{"name":"Role Test - user_setup","path":"roles/user_setup"},{"name":"Role Test - package_management","path":"roles/package_management"},{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}]}'
-              playbooks_json='{"include":[{"name":"Playbook Test - workstation","path":"playbooks/workstation"},{"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}]}'
+              roles_json='{"include":[
+                {"name":"Role Test - asdf","path":"roles/asdf"},
+                {"name":"Role Test - logging","path":"roles/logging"},
+                {"name":"Role Test - package_management","path":"roles/package_management"},
+                {"name":"Role Test - runzero_explorer","path":"roles/runzero_explorer"},
+                {"name":"Role Test - user_setup","path":"roles/user_setup"},
+                {"name":"Role Test - vnc_setup","path":"roles/vnc_setup"},
+                {"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}
+              ]}'
+              playbooks_json='{"include":[
+                {"name":"Playbook Test - workstation","path":"playbooks/workstation"},
+                {"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}
+              ]}'
             else
               # Check area/roles label
               if [[ "${{ contains(github.event.pull_request.labels.*.name, 'area/roles') }}" == "true" ]]; then
-                roles_json='{"include":[{"name":"Role Test - asdf","path":"roles/asdf"},{"name":"Role Test - user_setup","path":"roles/user_setup"},{"name":"Role Test - package_management","path":"roles/package_management"},{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}]}'
+                roles_json='{"include":[
+                  {"name":"Role Test - asdf","path":"roles/asdf"},
+                  {"name":"Role Test - logging","path":"roles/logging"},
+                  {"name":"Role Test - package_management","path":"roles/package_management"},
+                  {"name":"Role Test - runzero_explorer","path":"roles/runzero_explorer"},
+                  {"name":"Role Test - user_setup","path":"roles/user_setup"},
+                  {"name":"Role Test - vnc_setup","path":"roles/vnc_setup"},
+                  {"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}
+                ]}'
               else
                 # Check individual roles
                 if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/asdf') }}" == "true" ]] || grep -q "^roles/asdf/" <<< "${changed_files}"; then
                   roles+=('{"name":"Role Test - asdf","path":"roles/asdf"}')
                 fi
-                if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/user_setup') }}" == "true" ]] || grep -q "^roles/user_setup/" <<< "${changed_files}"; then
-                  roles+=('{"name":"Role Test - user_setup","path":"roles/user_setup"}')
+                if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/logging') }}" == "true" ]] || grep -q "^roles/logging/" <<< "${changed_files}"; then
+                  roles+=('{"name":"Role Test - logging","path":"roles/logging"}')
                 fi
                 if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/package_management') }}" == "true" ]] || grep -q "^roles/package_management/" <<< "${changed_files}"; then
                   roles+=('{"name":"Role Test - package_management","path":"roles/package_management"}')
+                fi
+                if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/runzero_explorer') }}" == "true" ]] || grep -q "^roles/runzero_explorer/" <<< "${changed_files}"; then
+                  roles+=('{"name":"Role Test - runzero_explorer","path":"roles/runzero_explorer"}')
+                fi
+                if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/user_setup') }}" == "true" ]] || grep -q "^roles/user_setup/" <<< "${changed_files}"; then
+                  roles+=('{"name":"Role Test - user_setup","path":"roles/user_setup"}')
+                fi
+                if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/vnc_setup') }}" == "true" ]] || grep -q "^roles/vnc_setup/" <<< "${changed_files}"; then
+                  roles+=('{"name":"Role Test - vnc_setup","path":"roles/vnc_setup"}')
                 fi
                 if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/zsh_setup') }}" == "true" ]] || grep -q "^roles/zsh_setup/" <<< "${changed_files}"; then
                   roles+=('{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}')

--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -46,13 +46,26 @@ jobs:
         run: |
           should_run="false"
 
-          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "push" ]; then
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "workflow_dispatch" || "${{ github.event_name }}" == "push" ]]; then
             should_run="true"
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             # Check labels
-            if [ "${{ contains(github.event.pull_request.labels.*.name, 'area/roles') }}" = "true" ] || \
-                [ "${{ contains(github.event.pull_request.labels.*.name, 'area/ansible-role') }}" = "true" ] || \
-                [ "${{ contains(github.event.pull_request.labels.*.name, 'area/ansible-playbook') }}" = "true" ]; then
+            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'area/roles') }}" == "true" || \
+                  "${{ contains(github.event.pull_request.labels.*.name, 'area/playbooks') }}" == "true" ]]; then
+              should_run="true"
+            fi
+
+            # Check individual role labels
+            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/asdf') }}" == "true" || \
+                  "${{ contains(github.event.pull_request.labels.*.name, 'role/user_setup') }}" == "true" || \
+                  "${{ contains(github.event.pull_request.labels.*.name, 'role/package_management') }}" == "true" || \
+                  "${{ contains(github.event.pull_request.labels.*.name, 'role/zsh_setup') }}" == "true" ]]; then
+              should_run="true"
+            fi
+
+            # Check individual playbook labels
+            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'playbook/workstation') }}" == "true" || \
+                  "${{ contains(github.event.pull_request.labels.*.name, 'playbook/runzero-explorer') }}" == "true" ]]; then
               should_run="true"
             fi
 
@@ -67,85 +80,86 @@ jobs:
 
           echo "should-run=${should_run}" >> "$GITHUB_OUTPUT"
 
+          # Debug output
+          echo "Event: ${{ github.event_name }}"
+          echo "Should run: ${should_run}"
+
       - name: Determine affected components
         id: set-matrix
         if: steps.check-changes.outputs.should-run == 'true'
         shell: bash
         run: |
-          declare -a roles_to_test
-          declare -a playbooks_to_test
-
-          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "push" ]; then
-            roles_to_test=(
-              '{"name": "Role Test - asdf", "path": "roles/asdf"}'
-              '{"name": "Role Test - user_setup", "path": "roles/user_setup"}'
-              '{"name": "Role Test - package_management", "path": "roles/package_management"}'
-              '{"name": "Role Test - zsh_setup", "path": "roles/zsh_setup"}'
-            )
-            playbooks_to_test=(
-              '{"name": "Playbook Test - workstation", "path": "playbooks/workstation"}'
-              '{"name": "Playbook Test - runzero-explorer", "path": "playbooks/runzero-explorer"}'
-            )
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "workflow_dispatch" || "${{ github.event_name }}" == "push" ]]; then
+            # Test everything for scheduled/manual runs
+            roles_json='{"include":[{"name":"Role Test - asdf","path":"roles/asdf"},{"name":"Role Test - user_setup","path":"roles/user_setup"},{"name":"Role Test - package_management","path":"roles/package_management"},{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}]}'
+            playbooks_json='{"include":[{"name":"Playbook Test - workstation","path":"playbooks/workstation"},{"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}]}'
           else
             git fetch origin "${{ github.base_ref }}"
             changed_files="$(git diff --name-only "origin/${{ github.base_ref }}"..HEAD)"
+            roles=()
+            playbooks=()
 
-            # Check roles
-            if echo "${changed_files}" | grep -q "^roles/asdf/"; then
-              roles_to_test+=('{"name": "Role Test - asdf", "path": "roles/asdf"}')
-            fi
-            if echo "${changed_files}" | grep -q "^roles/user_setup/"; then
-              roles_to_test+=('{"name": "Role Test - user_setup", "path": "roles/user_setup"}')
-            fi
-            if echo "${changed_files}" | grep -q "^roles/package_management/"; then
-              roles_to_test+=('{"name": "Role Test - package_management", "path": "roles/package_management"}')
-            fi
-            if echo "${changed_files}" | grep -q "^roles/zsh_setup/"; then
-              roles_to_test+=('{"name": "Role Test - zsh_setup", "path": "roles/zsh_setup"}')
-            fi
-
-            # Check playbooks
-            if echo "${changed_files}" | grep -q "^playbooks/workstation/"; then
-              playbooks_to_test+=('{"name": "Playbook Test - workstation", "path": "playbooks/workstation"}')
-            fi
-            if echo "${changed_files}" | grep -q "^playbooks/runzero-explorer/"; then
-              playbooks_to_test+=('{"name": "Playbook Test - runzero-explorer", "path": "playbooks/runzero-explorer"}')
+            # Check for area labels or requirements.yml changes
+            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'area/roles') }}" == "true" || $(echo "${changed_files}" | grep -q "^requirements\.yml$"; echo $?) -eq 0 ]]; then
+              roles=('{"name":"Role Test - asdf","path":"roles/asdf"}' '{"name":"Role Test - user_setup","path":"roles/user_setup"}' '{"name":"Role Test - package_management","path":"roles/package_management"}' '{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}')
+            else
+              # Check individual roles
+              if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/asdf') }}" == "true" || $(echo "${changed_files}" | grep -q "^roles/asdf/"; echo $?) -eq 0 ]]; then
+                roles+=('{"name":"Role Test - asdf","path":"roles/asdf"}')
+              fi
+              if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/user_setup') }}" == "true" || $(echo "${changed_files}" | grep -q "^roles/user_setup/"; echo $?) -eq 0 ]]; then
+                roles+=('{"name":"Role Test - user_setup","path":"roles/user_setup"}')
+              fi
+              if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/package_management') }}" == "true" || $(echo "${changed_files}" | grep -q "^roles/package_management/"; echo $?) -eq 0 ]]; then
+                roles+=('{"name":"Role Test - package_management","path":"roles/package_management"}')
+              fi
+              if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/zsh_setup') }}" == "true" || $(echo "${changed_files}" | grep -q "^roles/zsh_setup/"; echo $?) -eq 0 ]]; then
+                roles+=('{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}')
+              fi
             fi
 
-            # If requirements.yml changed, test everything
-            if echo "${changed_files}" | grep -q "^requirements.yml$"; then
-              roles_to_test=(
-                '{"name": "Role Test - asdf", "path": "roles/asdf"}'
-                '{"name": "Role Test - user_setup", "path": "roles/user_setup"}'
-                '{"name": "Role Test - package_management", "path": "roles/package_management"}'
-                '{"name": "Role Test - zsh_setup", "path": "roles/zsh_setup"}'
-              )
-              playbooks_to_test=(
-                '{"name": "Playbook Test - workstation", "path": "playbooks/workstation"}'
-                '{"name": "Playbook Test - runzero-explorer", "path": "playbooks/runzero-explorer"}'
-              )
+            # Check for playbooks area label or requirements.yml changes
+            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'area/playbooks') }}" == "true" || $(echo "${changed_files}" | grep -q "^requirements\.yml$"; echo $?) -eq 0 ]]; then
+              playbooks=('{"name":"Playbook Test - workstation","path":"playbooks/workstation"}' '{"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}')
+            else
+              # Check individual playbooks
+              if [[ "${{ contains(github.event.pull_request.labels.*.name, 'playbook/workstation') }}" == "true" || $(echo "${changed_files}" | grep -q "^playbooks/workstation/"; echo $?) -eq 0 ]]; then
+                playbooks+=('{"name":"Playbook Test - workstation","path":"playbooks/workstation"}')
+              fi
+              if [[ "${{ contains(github.event.pull_request.labels.*.name, 'playbook/runzero-explorer') }}" == "true" || $(echo "${changed_files}" | grep -q "^playbooks/runzero-explorer/"; echo $?) -eq 0 ]]; then
+                playbooks+=('{"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}')
+              fi
+            fi
+
+            # Create the final JSON objects with empty array fallbacks
+            roles_json='{"include":[]}'
+            if [ ${#roles[@]} -gt 0 ]; then
+              roles_json=$(printf '{"include":[%s]}' "$(IFS=,; echo "${roles[*]}")")
+            fi
+
+            playbooks_json='{"include":[]}'
+            if [ ${#playbooks[@]} -gt 0 ]; then
+              playbooks_json=$(printf '{"include":[%s]}' "$(IFS=,; echo "${playbooks[*]}")")
             fi
           fi
 
-          # Convert arrays to JSON
-          roles_json=$(jq -nc --argjson data "$(printf '%s\n' "${roles_to_test[@]}" | jq -R . | jq -s .)" '$data')
-          playbooks_json=$(jq -nc --argjson data "$(printf '%s\n' "${playbooks_to_test[@]}" | jq -R . | jq -s .)" '$data')
+          # Set outputs
+          echo "roles-matrix=${roles_json}" >> "$GITHUB_OUTPUT"
+          echo "playbooks-matrix=${playbooks_json}" >> "$GITHUB_OUTPUT"
 
-          {
-            echo "roles-matrix=${roles_json}"
-            echo "playbooks-matrix=${playbooks_json}"
-          } >> "$GITHUB_OUTPUT"
+          # Debug output
+          echo "Roles matrix: ${roles_json}"
+          echo "Playbooks matrix: ${playbooks_json}"
 
   role_test:
     needs: determine-tests
-    if: needs.determine-tests.outputs.should-run == 'true' && fromJSON(needs.determine-tests.outputs.roles-matrix)[0] != null
+    if: needs.determine-tests.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false
       max-parallel: 2
-      matrix:
-        include: ${{ fromJSON(needs.determine-tests.outputs.roles-matrix) }}
+      matrix: ${{ fromJson(needs.determine-tests.outputs.roles-matrix) }}
 
     steps:
       - name: Install Act dependencies
@@ -226,14 +240,13 @@ jobs:
 
   playbook_test:
     needs: determine-tests
-    if: needs.determine-tests.outputs.should-run == 'true' && fromJSON(needs.determine-tests.outputs.playbooks-matrix)[0] != null
+    if: needs.determine-tests.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false
       max-parallel: 2
-      matrix:
-        include: ${{ fromJSON(needs.determine-tests.outputs.playbooks-matrix) }}
+      matrix: ${{ fromJson(needs.determine-tests.outputs.playbooks-matrix) }}
 
     steps:
       - name: Install Act dependencies

--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -89,57 +89,66 @@ jobs:
         if: steps.check-changes.outputs.should-run == 'true'
         shell: bash
         run: |
+          # Initialize empty arrays and default JSON
+          roles=()
+          playbooks=()
+          roles_json='{"include":[]}'
+          playbooks_json='{"include":[]}'
+
           if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "workflow_dispatch" || "${{ github.event_name }}" == "push" ]]; then
             # Test everything for scheduled/manual runs
             roles_json='{"include":[{"name":"Role Test - asdf","path":"roles/asdf"},{"name":"Role Test - user_setup","path":"roles/user_setup"},{"name":"Role Test - package_management","path":"roles/package_management"},{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}]}'
             playbooks_json='{"include":[{"name":"Playbook Test - workstation","path":"playbooks/workstation"},{"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}]}'
           else
-            git fetch origin "${{ github.base_ref }}"
-            changed_files="$(git diff --name-only "origin/${{ github.base_ref }}"..HEAD)"
-            roles=()
-            playbooks=()
+            git fetch origin "${{ github.base_ref }}" || true
+            changed_files="$(git diff --name-only "origin/${{ github.base_ref }}"..HEAD)" || true
 
-            # Check for area labels or requirements.yml changes
-            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'area/roles') }}" == "true" || $(echo "${changed_files}" | grep -q "^requirements\.yml$"; echo $?) -eq 0 ]]; then
-              roles=('{"name":"Role Test - asdf","path":"roles/asdf"}' '{"name":"Role Test - user_setup","path":"roles/user_setup"}' '{"name":"Role Test - package_management","path":"roles/package_management"}' '{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}')
+            # Check requirements.yml changes first - this triggers all tests
+            if grep -q "^requirements\.yml$" <<< "${changed_files}"; then
+              roles_json='{"include":[{"name":"Role Test - asdf","path":"roles/asdf"},{"name":"Role Test - user_setup","path":"roles/user_setup"},{"name":"Role Test - package_management","path":"roles/package_management"},{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}]}'
+              playbooks_json='{"include":[{"name":"Playbook Test - workstation","path":"playbooks/workstation"},{"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}]}'
             else
-              # Check individual roles
-              if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/asdf') }}" == "true" || $(echo "${changed_files}" | grep -q "^roles/asdf/"; echo $?) -eq 0 ]]; then
-                roles+=('{"name":"Role Test - asdf","path":"roles/asdf"}')
-              fi
-              if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/user_setup') }}" == "true" || $(echo "${changed_files}" | grep -q "^roles/user_setup/"; echo $?) -eq 0 ]]; then
-                roles+=('{"name":"Role Test - user_setup","path":"roles/user_setup"}')
-              fi
-              if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/package_management') }}" == "true" || $(echo "${changed_files}" | grep -q "^roles/package_management/"; echo $?) -eq 0 ]]; then
-                roles+=('{"name":"Role Test - package_management","path":"roles/package_management"}')
-              fi
-              if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/zsh_setup') }}" == "true" || $(echo "${changed_files}" | grep -q "^roles/zsh_setup/"; echo $?) -eq 0 ]]; then
-                roles+=('{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}')
-              fi
-            fi
+              # Check area/roles label
+              if [[ "${{ contains(github.event.pull_request.labels.*.name, 'area/roles') }}" == "true" ]]; then
+                roles_json='{"include":[{"name":"Role Test - asdf","path":"roles/asdf"},{"name":"Role Test - user_setup","path":"roles/user_setup"},{"name":"Role Test - package_management","path":"roles/package_management"},{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}]}'
+              else
+                # Check individual roles
+                if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/asdf') }}" == "true" ]] || grep -q "^roles/asdf/" <<< "${changed_files}"; then
+                  roles+=('{"name":"Role Test - asdf","path":"roles/asdf"}')
+                fi
+                if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/user_setup') }}" == "true" ]] || grep -q "^roles/user_setup/" <<< "${changed_files}"; then
+                  roles+=('{"name":"Role Test - user_setup","path":"roles/user_setup"}')
+                fi
+                if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/package_management') }}" == "true" ]] || grep -q "^roles/package_management/" <<< "${changed_files}"; then
+                  roles+=('{"name":"Role Test - package_management","path":"roles/package_management"}')
+                fi
+                if [[ "${{ contains(github.event.pull_request.labels.*.name, 'role/zsh_setup') }}" == "true" ]] || grep -q "^roles/zsh_setup/" <<< "${changed_files}"; then
+                  roles+=('{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"}')
+                fi
 
-            # Check for playbooks area label or requirements.yml changes
-            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'area/playbooks') }}" == "true" || $(echo "${changed_files}" | grep -q "^requirements\.yml$"; echo $?) -eq 0 ]]; then
-              playbooks=('{"name":"Playbook Test - workstation","path":"playbooks/workstation"}' '{"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}')
-            else
-              # Check individual playbooks
-              if [[ "${{ contains(github.event.pull_request.labels.*.name, 'playbook/workstation') }}" == "true" || $(echo "${changed_files}" | grep -q "^playbooks/workstation/"; echo $?) -eq 0 ]]; then
-                playbooks+=('{"name":"Playbook Test - workstation","path":"playbooks/workstation"}')
+                # Create roles JSON if any roles were found
+                if [ ${#roles[@]} -gt 0 ]; then
+                  roles_json=$(printf '{"include":[%s]}' "$(IFS=,; echo "${roles[*]}")")
+                fi
               fi
-              if [[ "${{ contains(github.event.pull_request.labels.*.name, 'playbook/runzero-explorer') }}" == "true" || $(echo "${changed_files}" | grep -q "^playbooks/runzero-explorer/"; echo $?) -eq 0 ]]; then
-                playbooks+=('{"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}')
+
+              # Check area/playbooks label
+              if [[ "${{ contains(github.event.pull_request.labels.*.name, 'area/playbooks') }}" == "true" ]]; then
+                playbooks_json='{"include":[{"name":"Playbook Test - workstation","path":"playbooks/workstation"},{"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}]}'
+              else
+                # Check individual playbooks
+                if [[ "${{ contains(github.event.pull_request.labels.*.name, 'playbook/workstation') }}" == "true" ]] || grep -q "^playbooks/workstation/" <<< "${changed_files}"; then
+                  playbooks+=('{"name":"Playbook Test - workstation","path":"playbooks/workstation"}')
+                fi
+                if [[ "${{ contains(github.event.pull_request.labels.*.name, 'playbook/runzero-explorer') }}" == "true" ]] || grep -q "^playbooks/runzero-explorer/" <<< "${changed_files}"; then
+                  playbooks+=('{"name":"Playbook Test - runzero-explorer","path":"playbooks/runzero-explorer"}')
+                fi
+
+                # Create playbooks JSON if any playbooks were found
+                if [ ${#playbooks[@]} -gt 0 ]; then
+                  playbooks_json=$(printf '{"include":[%s]}' "$(IFS=,; echo "${playbooks[*]}")")
+                fi
               fi
-            fi
-
-            # Create the final JSON objects with empty array fallbacks
-            roles_json='{"include":[]}'
-            if [ ${#roles[@]} -gt 0 ]; then
-              roles_json=$(printf '{"include":[%s]}' "$(IFS=,; echo "${roles[*]}")")
-            fi
-
-            playbooks_json='{"include":[]}'
-            if [ ${#playbooks[@]} -gt 0 ]; then
-              playbooks_json=$(printf '{"include":[%s]}' "$(IFS=,; echo "${playbooks[*]}")")
             fi
           fi
 
@@ -148,6 +157,7 @@ jobs:
           echo "playbooks-matrix=${playbooks_json}" >> "$GITHUB_OUTPUT"
 
           # Debug output
+          echo "Event: ${{ github.event_name }}"
           echo "Roles matrix: ${roles_json}"
           echo "Playbooks matrix: ${playbooks_json}"
 

--- a/roles/asdf/README.md
+++ b/roles/asdf/README.md
@@ -1,6 +1,6 @@
 # Ansible Role: asdf
 
-This role installs and configures the asdf version manager for multiple
+This role installs and configures the `asdf` version manager for multiple
 programming languages on Unix-like systems.
 
 ---

--- a/roles/asdf/molecule/default/verify.yml
+++ b/roles/asdf/molecule/default/verify.yml
@@ -108,15 +108,29 @@
       when: not asdf_global_install | default(false)
 
     - name: Check contents of .tool-versions for each user
-      ansible.builtin.shell: |
-        {% if shell_executable != '/bin/sh' %}
-        set -o pipefail
-        {% endif %}
-        cat /home/{{ user.username }}/.tool-versions
-      args:
-        executable: "{{ user.shell }}"
+      ansible.builtin.command:
+        cmd: "cat /home/{{ user.username }}/.tool-versions"
+      register: tool_versions_content
       loop: "{{ asdf_users }}"
       loop_control:
         loop_var: user
       changed_when: false
+      when: not asdf_global_install | default(false)
+
+    - name: Set expected version facts
+      ansible.builtin.set_fact:
+        expected_golang_version: "{{ asdf_users[0].plugins[0].version }}"
+      when: not asdf_global_install | default(false)
+
+    - name: Assert .tool-versions content
+      ansible.builtin.assert:
+        that:
+          - "'golang' in item.stdout"
+          - "expected_golang_version in item.stdout"
+        fail_msg: "Expected version {{ expected_golang_version }} not found in .tool-versions"
+        success_msg: "Found expected golang version {{ expected_golang_version }}"
+      loop: "{{ tool_versions_content.results }}"
+      loop_control:
+        loop_var: item
+        label: "Checking .tool-versions content"
       when: not asdf_global_install | default(false)

--- a/roles/asdf/tasks/main.yml
+++ b/roles/asdf/tasks/main.yml
@@ -165,7 +165,7 @@
 - name: Gather installed ASDF plugins and versions for each user
   ansible.builtin.shell:
     cmd: |
-      {% if shell_executable != '/bin/sh' %}
+      {% if user.shell != '/bin/sh' %}
       set -o pipefail
       {% endif %}
       export ASDF_DIR="{{ user.home }}/.asdf"
@@ -174,11 +174,15 @@
       fi
       {% if user.plugins is defined %}
       {% for plugin in user.plugins %}
-      if ! asdf plugin list 2>/dev/null | grep -q {{ plugin.name }}; then
-        asdf plugin add {{ plugin.name }};
+      if command -v asdf >/dev/null 2>&1; then
+        if ! asdf plugin list 2>/dev/null | grep -q {{ plugin.name }}; then
+          asdf plugin add {{ plugin.name }} || true;
+        fi;
       fi;
       {% endfor %}
-      echo "plugins:$(asdf plugin list 2>/dev/null),versions:$(asdf list all 2>/dev/null | tr '\n' ',')"
+      plugins=$(asdf plugin list 2>/dev/null || echo "")
+      versions=$(asdf list all 2>/dev/null | tr '\n' ',' || echo "")
+      echo "plugins:${plugins},versions:${versions}"
       {% else %}
       echo "plugins:,versions:"
       {% endif %}
@@ -190,6 +194,7 @@
   loop: "{{ asdf_enriched_users }}"
   loop_control:
     loop_var: user
+  ignore_errors: true
   when: not asdf_global_install
 
 - name: Install libyaml from source

--- a/roles/asdf/tasks/main.yml
+++ b/roles/asdf/tasks/main.yml
@@ -112,19 +112,6 @@
     - not asdf_global_install
     - user.plugins is defined
 
-- name: Ensure correct permissions for .tool-versions
-  ansible.builtin.file:
-    path: "{{ user.home }}/.tool-versions"
-    owner: "{{ user.username }}"
-    group: "{{ user.usergroup | default(user.username) }}"
-    mode: "0644"
-  become: true
-  become_user: "{{ user.username }}"
-  loop: "{{ asdf_enriched_users }}"
-  loop_control:
-    loop_var: user
-  when: not asdf_global_install
-
 - name: Ensure .asdf directory exists for each user
   ansible.builtin.include_tasks: ensure_directory_exists.yml
   args:

--- a/roles/zsh_setup/tasks/common.yml
+++ b/roles/zsh_setup/tasks/common.yml
@@ -33,10 +33,9 @@
 
 - name: Install oh-my-zsh for all zsh_setup_enriched_users
   ansible.builtin.shell: |
-    {% if shell_executable != '/bin/sh' %}
+    {% if ansible_facts.shell != '/bin/sh' %}
     set -o pipefail
     {% endif %}
-
     echo 'y' | {{ item.home }}/omz-installer.sh --unattended --keep-zshrc
   args:
     creates: "{{ item.home }}/.oh-my-zsh"

--- a/roles/zsh_setup/tasks/common.yml
+++ b/roles/zsh_setup/tasks/common.yml
@@ -31,15 +31,26 @@
   loop_control:
     index_var: loop_index
 
+- name: Check for bash
+  ansible.builtin.command: which bash
+  register: bash_check
+  changed_when: false
+  ignore_errors: true
+
+- name: Set shell executable
+  ansible.builtin.set_fact:
+    shell_executable: >-
+      {% if bash_check.rc == 0 and bash_check.stdout is defined %}{{- bash_check.stdout | trim -}}{% else %}/bin/sh{% endif %}
+
 - name: Install oh-my-zsh for all zsh_setup_enriched_users
   ansible.builtin.shell: |
-    {% if ansible_facts.shell != '/bin/sh' %}
+    {% if shell_executable != '/bin/sh' %}
     set -o pipefail
     {% endif %}
     echo 'y' | {{ item.home }}/omz-installer.sh --unattended --keep-zshrc
   args:
     creates: "{{ item.home }}/.oh-my-zsh"
-    executable: /bin/zsh
+    executable: "{{ shell_executable }}"
   become: true
   become_user: "{{ item.username }}"
   loop: "{{ zsh_setup_enriched_users }}"

--- a/roles/zsh_setup/tasks/common.yml
+++ b/roles/zsh_setup/tasks/common.yml
@@ -21,14 +21,15 @@
 
 - name: Download oh-my-zsh install script for all zsh_setup_enriched_users
   ansible.builtin.get_url:
-    url: https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh
-    dest: "{{ item.home }}/omz-installer.sh"
+    url: "{{ zsh_setup_omz_install_script_url }}"
+    dest: "{{ user_item.home }}/omz-installer.sh"
     mode: '0755'
   become: true
-  become_user: "{{ item.username }}"
+  become_user: "{{ user_item.username }}"
   when: not oh_my_zsh_installed.results[loop_index].stat.exists
   loop: "{{ zsh_setup_enriched_users }}"
   loop_control:
+    loop_var: user_item
     index_var: loop_index
 
 - name: Check for bash
@@ -47,14 +48,15 @@
     {% if shell_executable != '/bin/sh' %}
     set -o pipefail
     {% endif %}
-    echo 'y' | {{ item.home }}/omz-installer.sh --unattended --keep-zshrc
+    echo 'y' | {{ user_item.home }}/omz-installer.sh --unattended --keep-zshrc
   args:
-    creates: "{{ item.home }}/.oh-my-zsh"
+    creates: "{{ user_item.home }}/.oh-my-zsh"
     executable: "{{ shell_executable }}"
   become: true
-  become_user: "{{ item.username }}"
+  become_user: "{{ user_item.username }}"
   loop: "{{ zsh_setup_enriched_users }}"
   loop_control:
+    loop_var: user_item
     index_var: loop_index
 
 - name: Remove omz-installer.sh for all zsh_setup_enriched_users


### PR DESCRIPTION
**Key Changes:**

- Removed the `determine-tests` job from `molecule.yaml` workflow.
- Refactored matrix definitions for `role_test` and `playbook_test` to simplify.
- Enhanced `.tool-versions` verification for better accuracy and clarity.

**Added:**

- Added new verification tasks in `roles/asdf/molecule/default/verify.yml` 
  to assert `.tool-versions` content accurately.
- Introduced a `bash_check` to determine availability of bash before running 
  Oh-My-Zsh installer scripts.
- Set up a new `zsh_setup_omz_install_script_url` variable for flexible Oh-My-Zsh
  script download paths.

**Changed:**

- Replaced dynamic test matrix generation with a static definition for 
  `role_test` and `playbook_test` in the `molecule.yaml` workflow.
- Updated `verify.yml` for the `asdf` role to use `ansible.builtin.command` 
  instead of `shell` for content verification, and added assertions for expected 
  versions.
- Refactored shell script usage in `zsh_setup` tasks to dynamically choose the 
  executable based on system environment (`bash` vs `/bin/sh`).
- Updated `pre-commit.yaml` to use a newer version of `actions/setup-go` for 
  setting up Go environment.

**Removed:**

- Removed the file permission enforcement task for `.tool-versions` in `roles/asdf`
  to streamline role tasks and reduce redundancy.
- Eliminated the need for `determine-tests` logic in GitHub Actions to simplify 
  the workflow and improve maintainability.