### PR TITLE
Refactored ASDF Role for Improved User Handling

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -139,6 +139,13 @@ jobs:
           ansible-galaxy collection install -r requirements.yml
           ansible-galaxy install -r requirements.yml
 
+      - name: Build and install collection locally
+        working-directory: ${{ env.COLLECTION_PATH }}
+        shell: bash
+        run: |
+          ansible-galaxy collection build
+          ansible-galaxy collection install cowdogmoo-workstation-*.tar.gz --force
+
       - name: Run molecule test
         working-directory: ${{ env.COLLECTION_PATH }}/${{ matrix.path }}
         shell: bash
@@ -232,6 +239,13 @@ jobs:
         run: |
           ansible-galaxy collection install -r requirements.yml
           ansible-galaxy install -r requirements.yml
+
+      - name: Build and install collection locally
+        working-directory: ${{ env.COLLECTION_PATH }}
+        shell: bash
+        run: |
+          ansible-galaxy collection build
+          ansible-galaxy collection install cowdogmoo-workstation-*.tar.gz --force
 
       - name: Run molecule test
         working-directory: ${{ env.COLLECTION_PATH }}/${{ matrix.path }}
@@ -332,6 +346,13 @@ jobs:
         run: |
           ansible-galaxy collection install -r requirements.yml
           ansible-galaxy install -r requirements.yml
+
+      - name: Build and install collection locally
+        working-directory: ${{ env.COLLECTION_PATH }}
+        shell: bash
+        run: |
+          ansible-galaxy collection build
+          ansible-galaxy collection install cowdogmoo-workstation-*.tar.gz --force
 
       - name: Run molecule test
         working-directory: ${{ env.COLLECTION_PATH }}/${{ matrix.path }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -82,7 +82,7 @@ jobs:
           GITHUB_TOKEN: "${{ steps.app-token.outputs.token }}"
 
       - name: Renovate
-        uses: renovatebot/github-action@531c6786d6cf05ef148c4cfe251745c2c6de442c # v41.0.9
+        uses: renovatebot/github-action@d385c88822a237acaead89c462fa0aef7502748f # v41.0.11
         with:
           configurationFile: "${{ env.RENOVATE_ONBOARDING_CONFIG_FILE_NAME }}"
           token: "${{ steps.app-token.outputs.token }}"

--- a/playbooks/workstation/molecule/default/converge.yml
+++ b/playbooks/workstation/molecule/default/converge.yml
@@ -8,5 +8,9 @@
         ansible_user_id: "{{ 'ubuntu' if ansible_distribution == 'Ubuntu' else 'rocky' }}"
       when: ansible_distribution in ['Ubuntu', 'RedHat', 'Rocky']
 
-- name: Import playbook for testing
+    - name: Setup role paths for testing
+      ansible.builtin.set_fact:
+        ansible_roles_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/../../roles:{{ lookup('env', 'ANSIBLE_ROLES_PATH') | default('/etc/ansible/roles', true) }}"
+
+- name: Run the workstation playbook
   ansible.builtin.import_playbook: ../../workstation.yml

--- a/playbooks/workstation/molecule/default/converge.yml
+++ b/playbooks/workstation/molecule/default/converge.yml
@@ -3,10 +3,18 @@
   hosts: all
   gather_facts: true
   pre_tasks:
-    - name: Set ansible_user_id based on OS
+    - name: Create test user
+      ansible.builtin.user:
+        name: "{{ ansible_distribution | lower }}"
+        shell: /bin/bash
+        create_home: true
+      become: true
+
+    - name: Set ansible_user_id and home facts
       ansible.builtin.set_fact:
-        ansible_user_id: "{{ 'ubuntu' if ansible_distribution == 'Ubuntu' else 'rocky' }}"
-      when: ansible_distribution in ['Ubuntu', 'RedHat', 'Rocky']
+        ansible_user_id: "{{ ansible_distribution | lower }}"
+        ansible_env:
+          HOME: "/home/{{ ansible_distribution | lower }}"
 
     - name: Setup role paths for testing
       ansible.builtin.set_fact:
@@ -14,3 +22,5 @@
 
 - name: Run the workstation playbook
   ansible.builtin.import_playbook: ../../workstation.yml
+  vars:
+    asdf_username: "{{ ansible_distribution | lower }}"

--- a/playbooks/workstation/molecule/default/molecule.yml
+++ b/playbooks/workstation/molecule/default/molecule.yml
@@ -24,6 +24,8 @@ provisioner:
     defaults:
       interpreter_python: auto_silent
       roles_path: ../../../../roles
+      collections_paths: ~/.ansible/collections:/usr/share/ansible/collections:../../../../
+
   ansible_args:
     - --connection=docker
     - -v

--- a/playbooks/workstation/molecule/default/molecule.yml
+++ b/playbooks/workstation/molecule/default/molecule.yml
@@ -20,11 +20,19 @@ provisioner:
   name: ansible
   env:
     ANSIBLE_ROLES_PATH: "../../../../roles:${ANSIBLE_ROLES_PATH:-/etc/ansible/roles}"
+    ANSIBLE_COLLECTIONS_PATH: "~/.ansible/collections"
+
   config_options:
     defaults:
       interpreter_python: auto_silent
-      roles_path: ../../../../roles
-      collections_paths: ~/.ansible/collections:/usr/share/ansible/collections:../../../../
+      collections_paths: "~/.ansible/collections"
+
+  inventory:
+    links:
+      hosts: inventory
+
+  playbooks:
+    converge: converge.yml
 
   ansible_args:
     - --connection=docker

--- a/playbooks/workstation/molecule/default/molecule.yml
+++ b/playbooks/workstation/molecule/default/molecule.yml
@@ -1,29 +1,16 @@
 ---
-# Use Ansible Galaxy to install dependencies
 dependency:
   name: galaxy
   options:
-    # Install required galaxy roles
-    role-file: ../../requirements.yml
-    # Install required collections
     requirements-file: ../../requirements.yml
 
-# Run molecule inside of a docker container
 driver:
   name: docker
 
 platforms:
   - name: ubuntu-workstation
     image: geerlingguy/docker-ubuntu2204-ansible:latest
-    command: "" # necessary for systemd
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-
-  - name: redhat-workstation
-    image: "geerlingguy/docker-rockylinux9-ansible:latest"
-    command: "" # necessary for systemd
+    command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -31,8 +18,15 @@ platforms:
 
 provisioner:
   name: ansible
-  playbooks:
-    converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+  env:
+    ANSIBLE_ROLES_PATH: "../../../../roles:${ANSIBLE_ROLES_PATH:-/etc/ansible/roles}"
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      roles_path: ../../../../roles
+  ansible_args:
+    - --connection=docker
+    - -v
 
 verifier:
   name: ansible

--- a/roles/asdf/defaults/main.yml
+++ b/roles/asdf/defaults/main.yml
@@ -1,7 +1,9 @@
 ---
 asdf_version: "0.16.0"
-asdf_username: "{{ ansible_env.USER if ansible_os_family == 'Darwin' else ansible_distribution | lower }}"
-asdf_usergroup: "{{ 'staff' if ansible_os_family == 'Darwin' else ansible_distribution | lower }}"
+asdf_username: "{{ ansible_user_id | default(ansible_user) }}"
+asdf_usergroup: "{{ asdf_username }}"
+asdf_user_home: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_env.HOME, '/home/' + asdf_username) }}"
+asdf_dir: "{{ asdf_user_home }}/.asdf"
 asdf_install_script_path: /tmp/setup_asdf_env
 asdf_shells:
   - "/usr/bin/zsh"

--- a/roles/asdf/molecule/default/verify.yml
+++ b/roles/asdf/molecule/default/verify.yml
@@ -13,6 +13,8 @@
       ansible.builtin.set_fact:
         ansible_env:
           HOME: "{{ container_home }}"
+        asdf_username: "{{ container_user }}"
+        asdf_user_home: "{{ container_home }}"
 
     - name: Check available shells
       ansible.builtin.stat:
@@ -32,10 +34,10 @@
 
     - name: Check if .asdf directory exists
       ansible.builtin.stat:
-        path: "{{ ansible_env.HOME }}/.asdf"
+        path: "{{ asdf_user_home }}/.asdf"
       register: asdf_dir
-      become: true
-      become_user: "{{ container_user }}"
+      become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+      become_user: "{{ asdf_username }}"
 
     - name: Assert that .asdf directory exists
       ansible.builtin.assert:
@@ -45,19 +47,19 @@
 
     - name: Verify ASDF is accessible
       ansible.builtin.shell: |
-        export ASDF_DIR="{{ ansible_env.HOME }}/.asdf"
+        export ASDF_DIR="{{ asdf_user_home }}/.asdf"
         export PATH="${ASDF_DIR}/bin:$PATH"
         . "${ASDF_DIR}/asdf.sh"
         asdf --version
       register: asdf_check
       failed_when: asdf_check.rc != 0
       changed_when: false
-      become: true
-      become_user: "{{ container_user }}"
+      become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+      become_user: "{{ asdf_username }}"
 
     - name: Check installed ASDF plugins and versions
       ansible.builtin.shell: |
-        export ASDF_DIR="{{ ansible_env.HOME }}/.asdf"
+        export ASDF_DIR="{{ asdf_user_home }}/.asdf"
         export PATH="${ASDF_DIR}/bin:${ASDF_DIR}/shims:$PATH"
         . "${ASDF_DIR}/asdf.sh"
         echo "Current PATH: $PATH"
@@ -69,48 +71,20 @@
         asdf list || true
       register: asdf_plugins_versions
       changed_when: false
-      become: true
-      become_user: "{{ container_user }}"
-      environment:
-        HOME: "{{ ansible_env.HOME }}"
-        ASDF_DIR: "{{ ansible_env.HOME }}/.asdf"
-        USER: "{{ container_user }}"
-
-    - name: Assert that ASDF plugins and versions are installed
-      ansible.builtin.shell: |
-        # Ensure proper environment
-        export HOME="{{ ansible_env.HOME }}"
-        export ASDF_DIR="${HOME}/.asdf"
-        export PATH="${ASDF_DIR}/bin:${ASDF_DIR}/shims:$PATH"
-
-        # Source ASDF explicitly
-        if [ -f "${ASDF_DIR}/asdf.sh" ]; then
-          source "${ASDF_DIR}/asdf.sh"
-        else
-          echo "ASDF initialization script not found!" >&2
-          exit 1
-        fi
-
-        # Verify ASDF is working
-        if ! command -v asdf >/dev/null 2>&1; then
-          echo "ASDF command not found after sourcing!" >&2
-          exit 1
-        fi
-
-        # List plugins
-        asdf plugin list
-      register: asdf_plugins_versions
-      changed_when: false
-      become: true
+      become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
       become_user: "{{ asdf_username }}"
-      args:
-        executable: /bin/bash
+      environment:
+        HOME: "{{ asdf_user_home }}"
+        ASDF_DIR: "{{ asdf_user_home }}/.asdf"
+        USER: "{{ asdf_username }}"
 
     - name: Check contents of .tool-versions
       ansible.builtin.command:
-        cmd: "cat {{ ansible_env.HOME }}/.tool-versions"
+        cmd: "cat {{ asdf_user_home }}/.tool-versions"
       register: tool_versions_content
       changed_when: false
+      become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+      become_user: "{{ asdf_username }}"
 
     - name: Set expected version facts
       ansible.builtin.set_fact:
@@ -126,8 +100,10 @@
 
     - name: Check shell profile setup
       ansible.builtin.stat:
-        path: "{{ ansible_env.HOME }}/{{ (available_shell == '/bin/zsh') | ternary('.zshrc', '.bashrc') }}"
+        path: "{{ asdf_user_home }}/{{ (available_shell == '/bin/zsh') | ternary('.zshrc', '.bashrc') }}"
       register: shell_profile
+      become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+      become_user: "{{ asdf_username }}"
 
     - name: Assert shell profile exists
       ansible.builtin.assert:
@@ -137,9 +113,11 @@
 
     - name: Check shell profile content
       ansible.builtin.command:
-        cmd: "cat {{ ansible_env.HOME }}/{{ (available_shell == '/bin/zsh') | ternary('.zshrc', '.bashrc') }}"
+        cmd: "cat {{ asdf_user_home }}/{{ (available_shell == '/bin/zsh') | ternary('.zshrc', '.bashrc') }}"
       register: profile_content
       changed_when: false
+      become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+      become_user: "{{ asdf_username }}"
 
     - name: Assert shell profile content
       ansible.builtin.assert:

--- a/roles/asdf/tasks/main.yml
+++ b/roles/asdf/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+- name: Debug user variables
+  ansible.builtin.debug:
+    msg: |
+      ansible_user_id: {{ ansible_user_id | default('not set') }}
+      ansible_user: {{ ansible_user | default('not set') }}
+      ansible_env.HOME: {{ ansible_env.HOME }}
+      ansible_facts['env'].HOME: {{ ansible_facts['env'].HOME }}
+      effective_user: {{ ansible_effective_user_id | default('not set') }}
+
 - name: Set default username for Kali systems
   ansible.builtin.set_fact:
     asdf_username: "kali"
@@ -40,7 +49,7 @@
 
 - name: Ensure .asdf directory exists
   ansible.builtin.file:
-    path: "{{ ansible_env.HOME }}/.asdf"
+    path: "{{ asdf_dir }}"
     state: directory
     owner: "{{ asdf_username }}"
     group: "{{ asdf_usergroup }}"
@@ -50,13 +59,13 @@
 - name: Extract ASDF binary
   ansible.builtin.unarchive:
     src: "/tmp/asdf-{{ asdf_version }}.tar.gz"
-    dest: "{{ ansible_env.HOME }}/.asdf"
+    dest: "{{ asdf_dir }}"
     remote_src: true
     extra_opts: [ "--strip-components=1" ]
     owner: "{{ asdf_username }}"
-    group: "{{ asdf_username }}"
+    group: "{{ asdf_usergroup }}"
     mode: "0755"
-  become: true
+  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
 
 - name: Update shell profile for ASDF
   ansible.builtin.include_tasks: update_shell_profile.yml
@@ -64,41 +73,41 @@
     asdf_enriched_user:
       username: "{{ asdf_username }}"
       usergroup: "{{ asdf_usergroup }}"
-      home: "{{ ansible_env.HOME }}"
+      home: "{{ asdf_user_home }}"
       shell: "{{ available_shell }}"
       shell_profile_lines:
         - "# ASDF Setup"
-        - "export ASDF_DIR=$HOME/.asdf"
-        - ". \"$HOME/.asdf/asdf.sh\""
-        - ". \"$HOME/.asdf/completions/asdf.bash\""
+        - "export ASDF_DIR={{ asdf_dir }}"
+        - ". \"{{ asdf_dir }}/asdf.sh\""
+        - ". \"{{ asdf_dir }}/completions/asdf.bash\""
 
 - name: Ensure ASDF bin directory exists
   ansible.builtin.file:
-    path: "{{ ansible_env.HOME }}/.asdf/bin"
+    path: "{{ asdf_dir }}/bin"
     state: directory
     owner: "{{ asdf_username }}"
-    group: "{{ asdf_username }}"
+    group: "{{ asdf_usergroup }}"
     mode: "0755"
   become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
 
 - name: Download asdf.sh file
   ansible.builtin.get_url:
     url: "https://raw.githubusercontent.com/asdf-vm/asdf/master/asdf.sh"
-    dest: "{{ ansible_env.HOME }}/.asdf/asdf.sh"
+    dest: "{{ asdf_dir }}/asdf.sh"
     mode: "0644"
     owner: "{{ asdf_username }}"
-    group: "{{ asdf_username }}"
-  become: true
+    group: "{{ asdf_usergroup }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
 
 - name: Copy asdf script to bin directory
   ansible.builtin.copy:
-    src: "{{ ansible_env.HOME }}/.asdf/asdf.sh"
-    dest: "{{ ansible_env.HOME }}/.asdf/bin/asdf"
+    src: "{{ asdf_dir }}/asdf.sh"
+    dest: "{{ asdf_dir }}/bin/asdf"
     remote_src: yes
     mode: "0755"
     owner: "{{ asdf_username }}"
     group: "{{ asdf_username }}"
-  become: true
+  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
 
 - name: Install libyaml from source
   ansible.builtin.include_tasks: install_libyaml.yml
@@ -107,9 +116,9 @@
 - name: Set common ASDF environment variables
   ansible.builtin.set_fact:
     asdf_env:
-      HOME: "{{ ansible_env.HOME }}"
-      ASDF_DIR: "{{ ansible_env.HOME }}/.asdf"
-      PATH: "{{ ansible_env.HOME }}/.asdf/bin:{{ ansible_env.HOME }}/.asdf/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+      HOME: "{{ asdf_user_home }}"
+      ASDF_DIR: "{{ asdf_dir }}"
+      PATH: "{{ asdf_dir }}/bin:{{ asdf_dir }}/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
       USER: "{{ asdf_username }}"
 
 - name: Verify ASDF installation and initialize environment
@@ -127,7 +136,7 @@
   args:
     executable: /bin/bash
   environment: "{{ asdf_env }}"
-  become: true
+  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
   become_user: "{{ asdf_username }}"
   changed_when: false
 
@@ -164,7 +173,7 @@
   args:
     executable: /bin/bash
   environment: "{{ asdf_env }}"
-  become: true
+  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
   become_user: "{{ asdf_username }}"
   register: plugin_versions
   changed_when: false
@@ -173,7 +182,7 @@
 - name: Generate .tool-versions file
   ansible.builtin.template:
     src: tool-versions.j2
-    dest: "{{ ansible_env.HOME }}/.tool-versions"
+    dest: "{{ asdf_user_home }}/.tool-versions"
     owner: "{{ asdf_username }}"
     group: "{{ asdf_usergroup }}"
     mode: "0644"
@@ -181,9 +190,9 @@
 
 - name: Ensure proper ownership of ASDF directory
   ansible.builtin.file:
-    path: "{{ ansible_env.HOME }}/.asdf"
+    path: "{{ asdf_user_home }}/.asdf"
     state: directory
     owner: "{{ asdf_username }}"
     group: "{{ asdf_username }}"
     recurse: true
-  become: true
+  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"

--- a/roles/asdf/tasks/update_shell_profile.yml
+++ b/roles/asdf/tasks/update_shell_profile.yml
@@ -9,10 +9,6 @@
   ansible.builtin.set_fact:
     detected_shell: "{{ shell_path.stdout if shell_path.stdout != '' else '/bin/bash' }}"
 
-- name: Update asdf_enriched_user with detected shell
-  ansible.builtin.set_fact:
-    asdf_enriched_user: "{{ asdf_enriched_user | combine({'shell': detected_shell}) }}"
-
 - name: Set ASDF profile lines
   ansible.builtin.set_fact:
     asdf_profile_lines:
@@ -24,24 +20,13 @@
 
 - name: Update shell profile for the user
   ansible.builtin.blockinfile:
-    path: "{{ asdf_enriched_user.home }}/{{ (detected_shell == '/bin/zsh') | ternary('.zshrc', '.bashrc') }}"
+    path: "{{ asdf_user_home }}/{{ (detected_shell == '/bin/zsh') | ternary('.zshrc', '.bashrc') }}"
     block: |
       {% for line in asdf_profile_lines %}
       {{ line }}
       {% endfor %}
     create: true
     mode: "0644"
-  become: true
-  become_user: "{{ asdf_enriched_user.username }}"
-
-- name: Ensure user home directory exists (via include)
-  ansible.builtin.include_tasks: ensure_directory_exists.yml
-  args:
-    apply:
-      become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
-  vars:
-    directories:
-      - path: "{{ asdf_enriched_user.home }}"
-        owner: "{{ asdf_enriched_user.username }}"
-        group: "{{ asdf_enriched_user.usergroup | default(asdf_enriched_user.username) }}"
-        mode: "0755"
+    owner: "{{ asdf_username }}"
+    group: "{{ asdf_usergroup }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"

--- a/roles/asdf/templates/setup_asdf_env.sh.j2
+++ b/roles/asdf/templates/setup_asdf_env.sh.j2
@@ -6,11 +6,11 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-export ASDF_DATA_DIR="$1/.asdf"
-export PATH="$ASDF_DATA_DIR/bin:$PATH"
-if [ ! -d "$ASDF_DATA_DIR" ]; then
-    echo "ASDF_DATA_DIR '$ASDF_DATA_DIR' does not exist" >&2
+export ASDF_DIR="$1/.asdf"
+export PATH="$ASDF_DIR/bin:$PATH"
+if [ ! -d "$ASDF_DIR" ]; then
+    echo "ASDF_DIR '$ASDF_DIR' does not exist" >&2
     exit 1
 fi
 
-echo "Set ASDF_DATA_DIR to: $ASDF_DATA_DIR"
+echo "Set ASDF_DIR to: $ASDF_DIR"


### PR DESCRIPTION
**Key Changes:**

- Standardized user and home directory handling across Molecule tests.
- Ensured ASDF installs under the correct user on all platforms.
- Updated test playbooks to set up a dedicated test user dynamically.

**Added:**

- Test user creation in `converge.yml` for consistent execution.
- Debug task in `asdf` role to verify user environment variables.
- `asdf_user_home` fact for cross-platform compatibility.

**Changed:**

- `molecule.yml` now sets `ANSIBLE_ROLES_PATH` correctly.
- ASDF-related tasks use `asdf_user_home` instead of `ansible_env.HOME`.
- All `become` statements updated for macOS compatibility.

**Removed:**

- Hardcoded role paths in Molecule configuration.
- Redundant user-related set_fact tasks in `update_shell_profile.yml`.