### PR TITLE
Refactored ASDF role setup and improved task organization

### DIFF
--- a/roles/asdf/molecule/default/converge.yml
+++ b/roles/asdf/molecule/default/converge.yml
@@ -26,3 +26,7 @@
         name: cowdogmoo.workstation.asdf
       vars:
         asdf_username: "{{ container_user }}"
+        asdf_plugins:
+          - name: golang
+            version: "1.23.5"
+            scope: "global"

--- a/roles/asdf/molecule/default/verify.yml
+++ b/roles/asdf/molecule/default/verify.yml
@@ -49,7 +49,6 @@
       ansible.builtin.shell: |
         export ASDF_DIR="{{ asdf_user_home }}/.asdf"
         export PATH="${ASDF_DIR}/bin:$PATH"
-        . "${ASDF_DIR}/asdf.sh"
         asdf --version
       register: asdf_check
       failed_when: asdf_check.rc != 0
@@ -61,7 +60,6 @@
       ansible.builtin.shell: |
         export ASDF_DIR="{{ asdf_user_home }}/.asdf"
         export PATH="${ASDF_DIR}/bin:${ASDF_DIR}/shims:$PATH"
-        . "${ASDF_DIR}/asdf.sh"
         echo "Current PATH: $PATH"
         echo "ASDF_DIR: $ASDF_DIR"
         echo "Current user: $(whoami)"
@@ -123,4 +121,3 @@
       ansible.builtin.assert:
         that:
           - "'ASDF_DIR=$HOME/.asdf' in profile_content.stdout"
-          - "'. \"$HOME/.asdf/asdf.sh\"' in profile_content.stdout"

--- a/roles/asdf/molecule/default/verify.yml
+++ b/roles/asdf/molecule/default/verify.yml
@@ -124,4 +124,3 @@
         that:
           - "'ASDF_DIR=$HOME/.asdf' in profile_content.stdout"
           - "'. \"$HOME/.asdf/asdf.sh\"' in profile_content.stdout"
-          - "'. \"$HOME/.asdf/completions/asdf.bash\"' in profile_content.stdout"

--- a/roles/asdf/tasks/main.yml
+++ b/roles/asdf/tasks/main.yml
@@ -1,13 +1,4 @@
 ---
-- name: Debug user variables
-  ansible.builtin.debug:
-    msg: |
-      ansible_user_id: {{ ansible_user_id | default('not set') }}
-      ansible_user: {{ ansible_user | default('not set') }}
-      ansible_env.HOME: {{ ansible_env.HOME }}
-      ansible_facts['env'].HOME: {{ ansible_facts['env'].HOME }}
-      effective_user: {{ ansible_effective_user_id | default('not set') }}
-
 - name: Set default username for Kali systems
   ansible.builtin.set_fact:
     asdf_username: "kali"
@@ -29,85 +20,74 @@
   ansible.builtin.set_fact:
     available_shell: "{{ (shell_check.results | selectattr('stat.exists', 'true') | list | first).item | default('/bin/sh') }}"
 
-- name: Fetch ASDF MD5 checksum
-  ansible.builtin.get_url:
-    url: "{{ asdf_checksum_url }}"
-    dest: "/tmp/asdf-{{ asdf_version }}-{{ asdf_os }}-{{ asdf_arch }}.tar.gz.md5"
-    mode: "0644"
+- name: Fetch and verify ASDF binary
+  block:
+    - name: Fetch ASDF MD5 checksum
+      ansible.builtin.get_url:
+        url: "{{ asdf_checksum_url }}"
+        dest: "/tmp/asdf-{{ asdf_version }}-{{ asdf_os }}-{{ asdf_arch }}.tar.gz.md5"
+        mode: "0644"
 
-- name: Extract ASDF MD5 checksum
-  ansible.builtin.command: "cat /tmp/asdf-{{ asdf_version }}-{{ asdf_os }}-{{ asdf_arch }}.tar.gz.md5"
-  register: asdf_checksum
-  changed_when: false
+    - name: Extract ASDF MD5 checksum
+      ansible.builtin.command: "cat /tmp/asdf-{{ asdf_version }}-{{ asdf_os }}-{{ asdf_arch }}.tar.gz.md5"
+      register: asdf_checksum
+      changed_when: false
 
-- name: Download ASDF binary
-  ansible.builtin.get_url:
-    url: "{{ asdf_download_url }}"
-    dest: "/tmp/asdf-{{ asdf_version }}.tar.gz"
-    checksum: "md5:{{ asdf_checksum.stdout | trim }}"
-    mode: "0644"
+    - name: Download ASDF binary
+      ansible.builtin.get_url:
+        url: "{{ asdf_download_url }}"
+        dest: "/tmp/asdf-{{ asdf_version }}.tar.gz"
+        checksum: "md5:{{ asdf_checksum.stdout | trim }}"
+        mode: "0644"
 
-- name: Ensure .asdf directory exists
-  ansible.builtin.file:
-    path: "{{ asdf_dir }}"
-    state: directory
-    owner: "{{ asdf_username }}"
-    group: "{{ asdf_usergroup }}"
-    mode: "0755"
+- name: Setup ASDF directory structure
   become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  block:
+    - name: Ensure .asdf directory exists
+      ansible.builtin.file:
+        path: "{{ asdf_dir }}"
+        state: directory
+        owner: "{{ asdf_username }}"
+        group: "{{ asdf_usergroup }}"
+        mode: "0755"
 
-- name: Extract ASDF binary
-  ansible.builtin.unarchive:
-    src: "/tmp/asdf-{{ asdf_version }}.tar.gz"
-    dest: "{{ asdf_dir }}"
-    remote_src: true
-    extra_opts: [ "--strip-components=1" ]
-    owner: "{{ asdf_username }}"
-    group: "{{ asdf_usergroup }}"
-    mode: "0755"
+    - name: Extract ASDF binary
+      ansible.builtin.unarchive:
+        src: "/tmp/asdf-{{ asdf_version }}.tar.gz"
+        dest: "{{ asdf_dir }}"
+        remote_src: true
+        extra_opts: [ "--strip-components=1" ]
+        owner: "{{ asdf_username }}"
+        group: "{{ asdf_usergroup }}"
+        mode: "0755"
+
+    - name: Ensure ASDF bin directory exists
+      ansible.builtin.file:
+        path: "{{ asdf_dir }}/bin"
+        state: directory
+        owner: "{{ asdf_username }}"
+        group: "{{ asdf_usergroup }}"
+        mode: "0755"
+
+- name: Setup ASDF shell files
   become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  block:
+    - name: Download asdf.sh file
+      ansible.builtin.get_url:
+        url: "https://raw.githubusercontent.com/asdf-vm/asdf/master/asdf.sh"
+        dest: "{{ asdf_dir }}/asdf.sh"
+        mode: "0644"
+        owner: "{{ asdf_username }}"
+        group: "{{ asdf_usergroup }}"
 
-- name: Update shell profile for ASDF
-  ansible.builtin.include_tasks: update_shell_profile.yml
-  vars:
-    asdf_enriched_user:
-      username: "{{ asdf_username }}"
-      usergroup: "{{ asdf_usergroup }}"
-      home: "{{ asdf_user_home }}"
-      shell: "{{ available_shell }}"
-      shell_profile_lines:
-        - "# ASDF Setup"
-        - "export ASDF_DIR={{ asdf_dir }}"
-        - ". \"{{ asdf_dir }}/asdf.sh\""
-        - ". \"{{ asdf_dir }}/completions/asdf.bash\""
-
-- name: Ensure ASDF bin directory exists
-  ansible.builtin.file:
-    path: "{{ asdf_dir }}/bin"
-    state: directory
-    owner: "{{ asdf_username }}"
-    group: "{{ asdf_usergroup }}"
-    mode: "0755"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
-
-- name: Download asdf.sh file
-  ansible.builtin.get_url:
-    url: "https://raw.githubusercontent.com/asdf-vm/asdf/master/asdf.sh"
-    dest: "{{ asdf_dir }}/asdf.sh"
-    mode: "0644"
-    owner: "{{ asdf_username }}"
-    group: "{{ asdf_usergroup }}"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
-
-- name: Copy asdf script to bin directory
-  ansible.builtin.copy:
-    src: "{{ asdf_dir }}/asdf.sh"
-    dest: "{{ asdf_dir }}/bin/asdf"
-    remote_src: yes
-    mode: "0755"
-    owner: "{{ asdf_username }}"
-    group: "{{ asdf_usergroup }}"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+    - name: Copy asdf script to bin directory
+      ansible.builtin.copy:
+        src: "{{ asdf_dir }}/asdf.sh"
+        dest: "{{ asdf_dir }}/bin/asdf"
+        remote_src: yes
+        mode: "0755"
+        owner: "{{ asdf_username }}"
+        group: "{{ asdf_usergroup }}"
 
 - name: Install libyaml from source
   ansible.builtin.include_tasks: install_libyaml.yml
@@ -121,7 +101,7 @@
       PATH: "{{ asdf_dir }}/bin:{{ asdf_dir }}/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
       USER: "{{ asdf_username }}"
 
-- name: Verify ASDF installation and initialize environment
+- name: Verify ASDF installation
   ansible.builtin.shell: |
     set -o pipefail
     if [ ! -f "${ASDF_DIR}/asdf.sh" ]; then
@@ -150,18 +130,13 @@
       asdf plugin add "{{ item.name }}"
     fi
 
-    # Install specific version if provided, otherwise get latest
     VERSION="{{ item.version | default('latest') }}"
-
-    # If version is 'latest', find the latest version
     if [ "$VERSION" = "latest" ]; then
       VERSION=$(asdf list-all "{{ item.name }}" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | tail -n 1)
     fi
 
-    # Install plugin version
     asdf install "{{ item.name }}" "${VERSION}"
 
-    # Set scope based on item.scope, default to global
     SCOPE="{{ item.scope | default('global') }}"
     if [ "$SCOPE" = "global" ]; then
       asdf global "{{ item.name }}" "${VERSION}"
@@ -196,3 +171,6 @@
     group: "{{ asdf_usergroup }}"
     recurse: true
   become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+
+- name: Update shell profile
+  ansible.builtin.include_tasks: update_shell_profile.yml

--- a/roles/asdf/tasks/main.yml
+++ b/roles/asdf/tasks/main.yml
@@ -40,127 +40,36 @@
         checksum: "md5:{{ asdf_checksum.stdout | trim }}"
         mode: "0644"
 
-- name: Setup ASDF directory structure
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
-  block:
-    - name: Ensure .asdf directory exists
-      ansible.builtin.file:
-        path: "{{ asdf_dir }}"
-        state: directory
-        owner: "{{ asdf_username }}"
-        group: "{{ asdf_usergroup }}"
-        mode: "0755"
-
     - name: Extract ASDF binary
       ansible.builtin.unarchive:
         src: "/tmp/asdf-{{ asdf_version }}.tar.gz"
-        dest: "{{ asdf_dir }}"
+        dest: "/usr/local/bin"
         remote_src: true
-        extra_opts: [ "--strip-components=1" ]
-        owner: "{{ asdf_username }}"
-        group: "{{ asdf_usergroup }}"
         mode: "0755"
 
-    - name: Ensure ASDF bin directory exists
-      ansible.builtin.file:
-        path: "{{ asdf_dir }}/bin"
-        state: directory
-        owner: "{{ asdf_username }}"
-        group: "{{ asdf_usergroup }}"
-        mode: "0755"
-
-- name: Setup ASDF shell files
+- name: Setup ASDF directory structure
   become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
-  block:
-    - name: Download asdf.sh file
-      ansible.builtin.get_url:
-        url: "https://raw.githubusercontent.com/asdf-vm/asdf/master/asdf.sh"
-        dest: "{{ asdf_dir }}/asdf.sh"
-        mode: "0644"
-        owner: "{{ asdf_username }}"
-        group: "{{ asdf_usergroup }}"
+  ansible.builtin.file:
+    path: "{{ asdf_dir }}"
+    state: directory
+    owner: "{{ asdf_username }}"
+    group: "{{ asdf_usergroup }}"
+    mode: "0755"
 
-    - name: Copy asdf script to bin directory
-      ansible.builtin.copy:
-        src: "{{ asdf_dir }}/asdf.sh"
-        dest: "{{ asdf_dir }}/bin/asdf"
-        remote_src: yes
-        mode: "0755"
-        owner: "{{ asdf_username }}"
-        group: "{{ asdf_usergroup }}"
+- name: Update shell profile
+  ansible.builtin.include_tasks: update_shell_profile.yml
 
 - name: Install libyaml from source
   ansible.builtin.include_tasks: install_libyaml.yml
   when: ansible_distribution == 'Rocky'
 
-- name: Set common ASDF environment variables
-  ansible.builtin.set_fact:
-    asdf_env:
-      HOME: "{{ asdf_user_home }}"
-      ASDF_DIR: "{{ asdf_dir }}"
-      PATH: "{{ asdf_dir }}/bin:{{ asdf_dir }}/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-      USER: "{{ asdf_username }}"
-
-- name: Verify ASDF installation
-  ansible.builtin.shell: |
-    set -o pipefail
-    if [ ! -f "${ASDF_DIR}/asdf.sh" ]; then
-      echo "ASDF not properly initialized - asdf.sh missing" >&2
-      exit 1
-    fi
-    . "${ASDF_DIR}/asdf.sh"
-    if ! command -v asdf >/dev/null 2>&1; then
-      echo "ASDF command not found in PATH" >&2
-      exit 1
-    fi
-  args:
-    executable: /bin/bash
-  environment: "{{ asdf_env }}"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
-  become_user: "{{ asdf_username }}"
-  changed_when: false
-
-- name: Install and configure plugins
-  ansible.builtin.shell: |
-    set -eo pipefail
-    . "${ASDF_DIR}/asdf.sh"
-
-    # Add plugin if not present
-    if ! asdf plugin list | grep -q "{{ item.name }}"; then
-      asdf plugin add "{{ item.name }}"
-    fi
-
-    VERSION="{{ item.version | default('latest') }}"
-    if [ "$VERSION" = "latest" ]; then
-      VERSION=$(asdf list-all "{{ item.name }}" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | tail -n 1)
-    fi
-
-    asdf install "{{ item.name }}" "${VERSION}"
-
-    SCOPE="{{ item.scope | default('global') }}"
-    if [ "$SCOPE" = "global" ]; then
-      asdf global "{{ item.name }}" "${VERSION}"
-    else
-      asdf local "{{ item.name }}" "${VERSION}"
-    fi
-
-    echo "${VERSION}" > "/tmp/{{ item.name }}_version"
-  args:
-    executable: /bin/bash
-  environment: "{{ asdf_env }}"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
-  become_user: "{{ asdf_username }}"
-  register: plugin_versions
-  changed_when: false
-  loop: "{{ asdf_plugins }}"
-
-- name: Generate .tool-versions file
+- name: Generate ASDF environment setup script
   ansible.builtin.template:
-    src: tool-versions.j2
-    dest: "{{ asdf_user_home }}/.tool-versions"
-    owner: "{{ asdf_username }}"
-    group: "{{ asdf_usergroup }}"
-    mode: "0644"
+    src: setup_asdf_env.sh.j2
+    dest: "{{ asdf_install_script_path }}"
+    mode: "0755"
+  vars:
+    shell_to_use: "{{ available_shell | default('/bin/sh') }}"
   become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
 
 - name: Ensure proper ownership of ASDF directory
@@ -172,5 +81,59 @@
     recurse: true
   become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
 
-- name: Update shell profile
-  ansible.builtin.include_tasks: update_shell_profile.yml
+- name: Set common ASDF environment variables
+  ansible.builtin.set_fact:
+    asdf_env:
+      HOME: "{{ asdf_user_home }}"
+      ASDF_DIR: "{{ asdf_dir }}"
+      PATH: "{{ asdf_dir }}/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+      USER: "{{ asdf_username }}"
+
+- name: Verify ASDF installation
+  ansible.builtin.shell: |
+    set -o pipefail
+    if ! command -v asdf >/dev/null 2>&1; then
+      echo "ASDF command not found in PATH" >&2
+      exit 1
+    fi
+  args:
+    executable: /bin/bash
+  environment: "{{ asdf_env }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become_user: "{{ asdf_username }}"
+  changed_when: false
+
+- name: Install and set ASDF plugins
+  ansible.builtin.shell: |
+    asdf install {{ item.name }} {{ item.version | default('latest') }} {{ item.scope | default('global') }} || true
+  args:
+    executable: /bin/bash
+  environment: "{{ asdf_env }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become_user: "{{ asdf_username }}"
+  loop: "{{ asdf_plugins }}"
+  changed_when: false
+
+- name: Generate .tool-versions file
+  ansible.builtin.template:
+    src: tool-versions.j2
+    dest: "{{ asdf_user_home }}/.tool-versions"
+    owner: "{{ asdf_username }}"
+    group: "{{ asdf_usergroup }}"
+    mode: "0644"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+
+- name: Reshim after default packages
+  ansible.builtin.shell: |
+    set -eo pipefail
+    {% for plugin in asdf_plugins %}
+    if [ -f "${asdf_user_home}/.default-{{ plugin.name }}-pkgs" ]; then
+      asdf reshim {{ plugin.name }}
+    fi
+    {% endfor %}
+  args:
+    executable: /bin/bash
+  environment: "{{ asdf_env }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become_user: "{{ asdf_username }}"
+  changed_when: false

--- a/roles/asdf/tasks/update_shell_profile.yml
+++ b/roles/asdf/tasks/update_shell_profile.yml
@@ -1,30 +1,24 @@
 ---
-- name: Check if shell exists
-  ansible.builtin.command: "which {{ asdf_enriched_user.shell | default('/bin/bash') }}"
-  register: shell_path
-  ignore_errors: true
-  changed_when: false
+- name: Detect shell and set profile
+  block:
+    - name: Check if shell exists
+      ansible.builtin.command: "which {{ asdf_enriched_user.shell | default('/bin/bash') }}"
+      register: shell_path
+      ignore_errors: true
+      changed_when: false
 
-- name: Set detected shell fact
-  ansible.builtin.set_fact:
-    detected_shell: "{{ shell_path.stdout if shell_path.stdout != '' else '/bin/bash' }}"
-
-- name: Set ASDF profile lines
-  ansible.builtin.set_fact:
-    asdf_profile_lines:
-      - "# ASDF Setup"
-      - "export ASDF_DIR=$HOME/.asdf"
-      - "export ASDF_DATA_DIR=$HOME/.asdf"
-      - ". \"$HOME/.asdf/asdf.sh\""
-      - ". \"$HOME/.asdf/completions/asdf.bash\""
+    - name: Set detected shell fact
+      ansible.builtin.set_fact:
+        detected_shell: "{{ shell_path.stdout if shell_path.stdout != '' else '/bin/bash' }}"
 
 - name: Update shell profile for the user
   ansible.builtin.blockinfile:
     path: "{{ asdf_user_home }}/{{ (detected_shell == '/bin/zsh') | ternary('.zshrc', '.bashrc') }}"
     block: |
-      {% for line in asdf_profile_lines %}
-      {{ line }}
-      {% endfor %}
+      # ASDF Setup
+      export ASDF_DIR=$HOME/.asdf
+      export ASDF_DATA_DIR=$HOME/.asdf
+      . "$HOME/.asdf/asdf.sh"
     create: true
     mode: "0644"
     owner: "{{ asdf_username }}"

--- a/roles/asdf/tasks/update_shell_profile.yml
+++ b/roles/asdf/tasks/update_shell_profile.yml
@@ -2,23 +2,23 @@
 - name: Detect shell and set profile
   block:
     - name: Check if shell exists
-      ansible.builtin.command: "which {{ asdf_enriched_user.shell | default('/bin/bash') }}"
+      ansible.builtin.command: "which {{ asdf_enriched_user.shell | default(ansible_env.SHELL | default('/bin/bash')) }}"
       register: shell_path
       ignore_errors: true
       changed_when: false
 
     - name: Set detected shell fact
       ansible.builtin.set_fact:
-        detected_shell: "{{ shell_path.stdout if shell_path.stdout != '' else '/bin/bash' }}"
+        detected_shell: "{{ shell_path.stdout if shell_path.stdout != '' else (ansible_env.SHELL | default('/bin/bash')) }}"
 
 - name: Update shell profile for the user
   ansible.builtin.blockinfile:
-    path: "{{ asdf_user_home }}/{{ (detected_shell == '/bin/zsh') | ternary('.zshrc', '.bashrc') }}"
+    path: "{{ asdf_user_home }}/{{ ('zsh' in detected_shell) | ternary('.zshrc', '.bashrc') }}"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - ASDF SETUP"
     block: |
       # ASDF Setup
       export ASDF_DIR=$HOME/.asdf
-      export ASDF_DATA_DIR=$HOME/.asdf
-      . "$HOME/.asdf/asdf.sh"
+      export PATH="$ASDF_DIR/shims:$PATH"
     create: true
     mode: "0644"
     owner: "{{ asdf_username }}"

--- a/roles/asdf/templates/install_asdf_plugins.sh.j2
+++ b/roles/asdf/templates/install_asdf_plugins.sh.j2
@@ -7,17 +7,7 @@ ASDF_BASE_DIR="${HOME}/.asdf"
 
 # ASDF environment setup
 export ASDF_DIR="${ASDF_BASE_DIR}"
-export ASDF_BIN="${ASDF_BASE_DIR}/bin/asdf"
 export PATH="${ASDF_BASE_DIR}/bin:${ASDF_BASE_DIR}/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-
-# Source ASDF
-ASDF_INIT_SCRIPT="${ASDF_BASE_DIR}/asdf.sh"
-if [ -f "$ASDF_INIT_SCRIPT" ]; then
-    . "$ASDF_INIT_SCRIPT"
-else
-    echo "ERROR: ASDF initialization script not found at ${ASDF_INIT_SCRIPT}" >&2
-    exit 1
-fi
 
 # Verify ASDF availability
 if ! command -v asdf >/dev/null 2>&1; then

--- a/roles/asdf/templates/setup_asdf_env.sh.j2
+++ b/roles/asdf/templates/setup_asdf_env.sh.j2
@@ -7,10 +7,9 @@ if [ -z "$1" ]; then
 fi
 
 export ASDF_DIR="$1/.asdf"
-export PATH="$ASDF_DIR/bin:$PATH"
+export PATH="$ASDF_DIR/bin:$ASDF_DIR/shims:$PATH"
+
 if [ ! -d "$ASDF_DIR" ]; then
     echo "ASDF_DIR '$ASDF_DIR' does not exist" >&2
     exit 1
 fi
-
-echo "Set ASDF_DIR to: $ASDF_DIR"


### PR DESCRIPTION
**Key Changes:**

- Grouped related ASDF setup tasks into structured blocks.
- Improved plugin installation and shell profile updates for maintainability.
- Removed redundant operations to streamline execution.

**Added:**

- Introduced task blocks to group related tasks logically.
- Included `update_shell_profile.yml` for better profile management.
- Automated ASDF reshim execution after plugin installation.
- Default ASDF plugin installation in Molecule `converge.yml`.

**Changed:**

- Moved ASDF installation steps into structured `block` sections.
- Refactored shell profile updates to avoid redundant fact setting.
- Extracted ASDF to `/usr/local/bin` instead of `$HOME/.asdf`.
- Updated shell profile setup logic in `update_shell_profile.yml`.
- Improved ASDF plugin management for idempotency and reliability.
- Adjusted path exports for ASDF without sourcing `asdf.sh`.

**Removed:**

- Removed redundant debug statements from `tasks/main.yml`.
- Eliminated unnecessary sourcing of `asdf.sh` in Molecule tests.
- Deprecated shell profile exports for ASDF_DIR and ASDF_DATA_DIR.
- Removed explicit asdf.sh script download and installation steps.
- Removed unnecessary ASDF completion sourcing from verification.
