### PR TITLE
Decoupled zsh_setup from asdf role for modular role usage

### DIFF
--- a/roles/asdf/defaults/main.yml
+++ b/roles/asdf/defaults/main.yml
@@ -10,7 +10,7 @@ asdf_shells:
   - "/bin/zsh"
   - "/usr/bin/bash"
   - "/bin/bash"
-asdf_shell: "{{ '/bin/zsh' if ansible_distribution == 'MacOSX' else '/usr/bin/zsh' }}"
+asdf_shell: "{{ '/bin/zsh' if ansible_distribution == 'MacOSX' else '/bin/bash' }}"
 asdf_plugins:
   - name: golang
     version: "1.23.5"

--- a/roles/asdf/meta/main.yml
+++ b/roles/asdf/meta/main.yml
@@ -22,4 +22,3 @@ galaxy_info:
 
 dependencies:
   - role: cowdogmoo.workstation.package_management
-  - role: cowdogmoo.workstation.zsh_setup


### PR DESCRIPTION
**Changed:**

- Set default `asdf_shell` to `/bin/bash` instead of `/usr/bin/zsh`
- Removed `zsh_setup` dependency from `asdf/meta/main.yml`
- Ensured `asdf` can be used independently or combined in playbooks as needed