### PR TITLE
feat: Add VNC box playbook and Molecule test

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -146,8 +146,8 @@ jobs:
         working-directory: ${{ env.COLLECTION_PATH }}
         shell: bash
         run: |
-          ansible-galaxy collection build
-          ansible-galaxy collection install cowdogmoo-workstation-*.tar.gz --force
+          ansible-galaxy collection build --force
+          ansible-galaxy collection install cowdogmoo-workstation-*.tar.gz -p ~/.ansible/collections --force --pre
 
       - name: Run molecule test
         working-directory: ${{ env.COLLECTION_PATH }}/${{ matrix.path }}
@@ -247,8 +247,8 @@ jobs:
         working-directory: ${{ env.COLLECTION_PATH }}
         shell: bash
         run: |
-          ansible-galaxy collection build
-          ansible-galaxy collection install cowdogmoo-workstation-*.tar.gz --force
+          ansible-galaxy collection build --force
+          ansible-galaxy collection install cowdogmoo-workstation-*.tar.gz -p ~/.ansible/collections --force --pre
 
       - name: Run molecule test
         working-directory: ${{ env.COLLECTION_PATH }}/${{ matrix.path }}
@@ -358,8 +358,8 @@ jobs:
         working-directory: ${{ env.COLLECTION_PATH }}
         shell: bash
         run: |
-          ansible-galaxy collection build
-          ansible-galaxy collection install cowdogmoo-workstation-*.tar.gz --force
+          ansible-galaxy collection build --force
+          ansible-galaxy collection install cowdogmoo-workstation-*.tar.gz -p ~/.ansible/collections --force --pre
 
       - name: Run molecule test
         working-directory: ${{ env.COLLECTION_PATH }}/${{ matrix.path }}

--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -305,6 +305,8 @@ jobs:
             path: "roles/logging"
           - name: "Playbook Test - workstation"
             path: "playbooks/workstation"
+          - name: "Playbook Test - vnc_box"
+            path: "playbooks/vnc_box"
 
     steps:
       - name: Install Act dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ changelogs/.plugin-cache.yaml
 *.pyc
 .task/
 .ansible
+*.tar.gz

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Install latest version of the Workstation collection:
 ansible-galaxy collection install git+https://github.com/CowDogMoo/ansible-collection-workstation.git,main
 ```
 
+Alternatively, you can build the collection locally and install it from
+the generated tarball:
+
+```bash
+ansible-galaxy collection build --force && \
+  ansible-galaxy collection install cowdogmoo-workstation-*.tar.gz -p ~/.ansible/collections --force --pre
+```
+
 ## Roles
 
 ### ASDF

--- a/playbooks/vnc_box/molecule/default/converge.yml
+++ b/playbooks/vnc_box/molecule/default/converge.yml
@@ -2,6 +2,6 @@
 - name: Converge
   hosts: all
   gather_facts: true
-  roles:
-    - name: Setup VNC Server
-      role: cowdogmoo.workstation.vnc_setup
+
+- name: Run the vnc_box playbook
+  ansible.builtin.import_playbook: ../../vnc_box.yml

--- a/playbooks/vnc_box/molecule/default/converge.yml
+++ b/playbooks/vnc_box/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: true
+
+- name: Run the vnc box playbook
+  ansible.builtin.import_playbook: ../../vnc_box.yml

--- a/playbooks/vnc_box/molecule/default/converge.yml
+++ b/playbooks/vnc_box/molecule/default/converge.yml
@@ -2,6 +2,6 @@
 - name: Converge
   hosts: all
   gather_facts: true
-
-- name: Run the vnc box playbook
-  ansible.builtin.import_playbook: ../../vnc_box.yml
+  roles:
+    - name: Setup VNC Server
+      role: cowdogmoo.workstation.vnc_setup

--- a/playbooks/vnc_box/molecule/default/inventory
+++ b/playbooks/vnc_box/molecule/default/inventory
@@ -1,0 +1,2 @@
+[local]
+localhost ansible_connection=local

--- a/playbooks/vnc_box/molecule/default/molecule.yml
+++ b/playbooks/vnc_box/molecule/default/molecule.yml
@@ -23,9 +23,6 @@ platforms:
     privileged: true
     environment:
       ANSIBLE_PYTHON_INTERPRETER: /usr/bin/python3
-    hostname: ubuntu-vnc_box
-    extra_hosts:
-      - "ubuntu-vnc_box:127.0.1.1"
 
 provisioner:
   name: ansible

--- a/playbooks/vnc_box/molecule/default/molecule.yml
+++ b/playbooks/vnc_box/molecule/default/molecule.yml
@@ -14,12 +14,15 @@ driver:
 
 platforms:
   - name: ubuntu-vnc_box
-    image: geerlingguy/docker-ubuntu2204-ansible:latest
+    image: geerlingguy/docker-ubuntu2404-ansible:latest
+    # Setting the command to this is necessary for systemd containers
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
     privileged: true
+    environment:
+      ANSIBLE_PYTHON_INTERPRETER: /usr/bin/python3
     hostname: ubuntu-vnc_box
     extra_hosts:
       - "ubuntu-vnc_box:127.0.1.1"

--- a/playbooks/vnc_box/molecule/default/molecule.yml
+++ b/playbooks/vnc_box/molecule/default/molecule.yml
@@ -1,0 +1,33 @@
+---
+# Use Ansible Galaxy to install dependencies
+dependency:
+  name: galaxy
+  options:
+    # Install required galaxy roles
+    role-file: ../../requirements.yml
+    # Install required collections
+    requirements-file: ../../requirements.yml
+
+# Run molecule inside of a docker container
+driver:
+  name: docker
+
+platforms:
+  - name: ubuntu-vnc_box
+    image: geerlingguy/docker-ubuntu2204-ansible:latest
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    hostname: ubuntu-vnc_box
+    extra_hosts:
+      - "ubuntu-vnc_box:127.0.1.1"
+
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+
+verifier:
+  name: ansible

--- a/playbooks/vnc_box/vnc_box.yml
+++ b/playbooks/vnc_box/vnc_box.yml
@@ -1,0 +1,19 @@
+---
+- name: VNC Box
+  hosts: all
+  gather_facts: true
+  roles:
+    - name: Setup users on workstation
+      role: cowdogmoo.workstation.user_setup
+      # For debugging
+      # role: ../../roles/user_setup
+
+    - name: Setup ZSH Configuration
+      role: cowdogmoo.workstation.zsh_setup
+      # For debugging
+      # role: ../../roles/zsh_setup
+
+    - name: Setup VNC Server
+      role: cowdogmoo.workstation.vnc_setup
+      # For debugging
+      # role: ../../roles/vnc_setup

--- a/roles/vnc_setup/molecule/default/converge.yml
+++ b/roles/vnc_setup/molecule/default/converge.yml
@@ -2,7 +2,6 @@
 - name: Converge
   hosts: all
   gather_facts: true
-  tasks:
-    - name: Include role under test
-      ansible.builtin.include_role:
-        name: cowdogmoo.workstation.vnc_setup
+  roles:
+    - name: Setup VNC Server
+      role: cowdogmoo.workstation.vnc_setup

--- a/roles/vnc_setup/molecule/default/molecule.yml
+++ b/roles/vnc_setup/molecule/default/molecule.yml
@@ -14,7 +14,7 @@ driver:
 
 platforms:
   - name: ubuntu-vnc-setup
-    image: geerlingguy/docker-ubuntu2204-ansible:latest
+    image: geerlingguy/docker-ubuntu2404-ansible:latest
     # Setting the command to this is necessary for systemd containers
     command: ""
     volumes:
@@ -23,6 +23,9 @@ platforms:
     privileged: true
     environment:
       ANSIBLE_PYTHON_INTERPRETER: /usr/bin/python3
+    hostname: ubuntu-vnc_box
+    extra_hosts:
+      - "ubuntu-vnc_box:127.0.1.1"
 
   - name: kali-vnc-setup
     image: cisagov/docker-kali-ansible:latest

--- a/roles/vnc_setup/molecule/default/molecule.yml
+++ b/roles/vnc_setup/molecule/default/molecule.yml
@@ -23,9 +23,6 @@ platforms:
     privileged: true
     environment:
       ANSIBLE_PYTHON_INTERPRETER: /usr/bin/python3
-    hostname: ubuntu-vnc_box
-    extra_hosts:
-      - "ubuntu-vnc_box:127.0.1.1"
 
   - name: kali-vnc-setup
     image: cisagov/docker-kali-ansible:latest

--- a/roles/zsh_setup/tasks/zsh_setup_get_user_home.yml
+++ b/roles/zsh_setup/tasks/zsh_setup_get_user_home.yml
@@ -15,10 +15,10 @@
 
 - name: Set user home directory
   ansible.builtin.set_fact:
-    zsh_setup_user_home: "{{ getent_passwd[zsh_setup_username].home | default('/home/' + zsh_setup_username) }}"
+    zsh_setup_user_home: "{{ getent_passwd[zsh_setup_username].home | default('/root' if zsh_setup_username == 'root' else '/home/' + zsh_setup_username) }}"
   when: ansible_os_family != 'Darwin'
 
 - name: Set user home directory for macOS
   ansible.builtin.set_fact:
-    zsh_setup_user_home: "{{ getent_passwd[zsh_setup_username].home | default('/Users/' + zsh_setup_username) }}"
+    zsh_setup_user_home: "{{ getent_passwd[zsh_setup_username].home | default('/var/root' if zsh_setup_username == 'root' else '/Users/' + zsh_setup_username) }}"
   when: ansible_os_family == 'Darwin'


### PR DESCRIPTION
**Key Changes:**

- Introduced a new `vnc_box` playbook to configure a VNC-enabled workstation.
- Added Molecule test scenario for the `vnc_box` playbook.
- Updated Molecule GitHub Actions workflow to include `vnc_box` testing.
- Fixed broken Molecule test execution for the new playbook.
- Upgraded base Molecule images to Ubuntu 24.04 for futureproof platform support.

**Added:**

- `playbooks/vnc_box/vnc_box.yml` playbook for configuring VNC workstations.
- Molecule scenario in `playbooks/vnc_box/molecule/default/` for test coverage.
- GitHub Actions workflow entry for the `vnc_box` playbook.

**Changed:**

- `.gitignore` updated to exclude `.tar.gz` artifacts generated during collection builds.
- `README.md` updated with local build/install instructions for the collection.
- `vnc_setup` role Molecule converge task updated to use role-based syntax.
- `zsh_setup_get_user_home.yml` updated to correctly return home for `root` on Linux/macOS.
- Molecule platform images switched to `geerlingguy/docker-ubuntu2404-ansible:latest`.
- Systemd compatibility improved by setting `ANSIBLE_PYTHON_INTERPRETER` and (now removed) `hostname`/`extra_hosts`.
- Molecule workflow updated with `--force` and `--pre` flags for collection build/install to improve pre-release compatibility.
- Custom collection path set in GitHub Actions to ensure test consistency.