### PR TITLE
feat: Release v2.0.6

### DIFF
--- a/changelogs/CHANGELOG.rst
+++ b/changelogs/CHANGELOG.rst
@@ -1,8 +1,36 @@
 ============================================================
-CowDogMoo Workstation Ansible Collection 2.0.5 Release Notes
+CowDogMoo Workstation Ansible Collection 2.0.6 Release Notes
 ============================================================
 
 .. contents:: Topics
+
+v2.0.6
+======
+
+Release Summary
+---------------
+
+This release focuses on improving package management reliability, especially for Debian-based systems with better apt lock handling. Added support for Kali Linux package verification and simplified VNC service management. Several dependencies were also updated to their latest versions.
+
+Added
+-----
+
+- Added Kali archive keyring installation task for Kali-based systems
+- Added Molecule verification to ensure no apt/dpkg locks remain after package_management role runs
+- Added `area/molecule` and `playbook/vnc_box` labels for improved PR categorization
+- Added retry loop in package_management role to wait until apt locks are released
+
+Changed
+-------
+
+- Fixed label formatting and added missing area label for playbooks
+- Improved reliability of package installation on Debian-based systems
+- Simplified VNC service setup by removing redundant XDG_RUNTIME_DIR handling
+- Updated Debian package tasks to proactively prevent apt lock contention
+- Updated actions/create-github-app-token from v2.0.2 to v2.0.6
+- Updated adrienverge/yamllint from v1.37.0 to v1.37.1
+- Updated community.docker from 4.5.2 to 4.6.0
+- Updated renovatebot/github-action from v41.0.22 to v42.0.1
 
 v2.0.5
 ======
@@ -25,6 +53,13 @@ Added
 Changed
 -------
 
+- Addressed minor inaccuracy in releases.md
+- Fixed ASDF path in dotfile configuration
+- Fixed bug determining asdf_user_home for the root user
+- Fixed bug in workstation playbook molecule tests
+- Fixed idempotency issues in various roles
+- Fixed issue with zsh_setup_get_user_home.yml to handle root user home on Linux and macOS
+- Fixed naming issue causing molecule test failure for vnc_box playbook
 - Improved ASDF shell profile setup for v0.16+ compatibility and CI environments
 - Improved VNC service startup and cleanup reliability with better process handling
 - Optimized task running documentation
@@ -37,17 +72,6 @@ Changed
 - Updated helm/helm from v3.17.2 to v1.17.3
 - Updated kubernetes/kubernetes from v1.32.3 to v1.33.0
 - Updated python/cpython from v3.13.2 to v3.13.3
-
-Fixed
------
-
-- Addressed minor inaccuracy in releases.md
-- Fixed ASDF path in dotfile configuration
-- Fixed bug determining asdf_user_home for the root user
-- Fixed bug in workstation playbook molecule tests
-- Fixed idempotency issues in various roles
-- Fixed issue with zsh_setup_get_user_home.yml to handle root user home on Linux and macOS
-- Fixed naming issue causing molecule test failure for vnc_box playbook
 
 v2.0.4
 ======

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -530,6 +530,14 @@ releases:
       - Added shell completions for ASDF in Bash and Zsh via `update_shell_profile.yml`
       - Added verification for Golang functionality in ASDF Molecule tests
       changed:
+      - Addressed minor inaccuracy in releases.md
+      - Fixed ASDF path in dotfile configuration
+      - Fixed bug determining asdf_user_home for the root user
+      - Fixed bug in workstation playbook molecule tests
+      - Fixed idempotency issues in various roles
+      - Fixed issue with zsh_setup_get_user_home.yml to handle root user home on Linux
+        and macOS
+      - Fixed naming issue causing molecule test failure for vnc_box playbook
       - Improved ASDF shell profile setup for v0.16+ compatibility and CI environments
       - Improved VNC service startup and cleanup reliability with better process handling
       - Optimized task running documentation
@@ -543,17 +551,30 @@ releases:
       - Updated helm/helm from v3.17.2 to v1.17.3
       - Updated kubernetes/kubernetes from v1.32.3 to v1.33.0
       - Updated python/cpython from v3.13.2 to v3.13.3
-      fixed:
-      - Addressed minor inaccuracy in releases.md
-      - Fixed ASDF path in dotfile configuration
-      - Fixed bug determining asdf_user_home for the root user
-      - Fixed bug in workstation playbook molecule tests
-      - Fixed idempotency issues in various roles
-      - Fixed issue with zsh_setup_get_user_home.yml to handle root user home on Linux
-        and macOS
-      - Fixed naming issue causing molecule test failure for vnc_box playbook
       release_summary: Added VNC box playbook, thoroughly refactored ASDF role to
         support binary-based installs, improved service reliability, and updated numerous
         dependencies. Fixed issues with user home detection, shell integrations, and
         Molecule testing.
     release_date: '2025-04-30'
+  2.0.6:
+    changes:
+      added:
+      - Added Kali archive keyring installation task for Kali-based systems
+      - Added Molecule verification to ensure no apt/dpkg locks remain after package_management
+        role runs
+      - Added `area/molecule` and `playbook/vnc_box` labels for improved PR categorization
+      - Added retry loop in package_management role to wait until apt locks are released
+      changed:
+      - Fixed label formatting and added missing area label for playbooks
+      - Improved reliability of package installation on Debian-based systems
+      - Simplified VNC service setup by removing redundant XDG_RUNTIME_DIR handling
+      - Updated Debian package tasks to proactively prevent apt lock contention
+      - Updated actions/create-github-app-token from v2.0.2 to v2.0.6
+      - Updated adrienverge/yamllint from v1.37.0 to v1.37.1
+      - Updated community.docker from 4.5.2 to 4.6.0
+      - Updated renovatebot/github-action from v41.0.22 to v42.0.1
+      release_summary: This release focuses on improving package management reliability,
+        especially for Debian-based systems with better apt lock handling. Added support
+        for Kali Linux package verification and simplified VNC service management.
+        Several dependencies were also updated to their latest versions.
+    release_date: '2025-05-08'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: cowdogmoo
 name: workstation
-version: 2.0.5
+version: 2.0.6
 readme: README.md
 authors:
   - Jayson Grace <techvomit.net>


### PR DESCRIPTION
**Added:**

* Kali archive keyring task for Kali-based systems
* Molecule verification to ensure no apt/dpkg locks remain post-run
* Retry loop to wait for apt locks in `package_management` role
* Labels `area/molecule` and `playbook/vnc_box` for better PR categorization

**Changed:**

* Improved Debian package install reliability and apt lock prevention
* Simplified VNC service setup by removing redundant XDG\_RUNTIME\_DIR handling
* Fixed label formatting; added missing area label for playbooks
* Updated actions/create-github-app-token v2.0.2 → v2.0.6
* Updated adrienverge/yamllint v1.37.0 → v1.37.1
* Updated community.docker v4.5.2 → v4.6.0
* Updated renovatebot/github-action v41.0.22 → v42.0.1

**Removed:**

* Removed redundant "Fixed" sections in CHANGELOG for clarity