### PR TITLE
feat: update Renovate config, remove old bot config, clean up dashboard step

### DIFF
--- a/.github/renovate-bot.json5
+++ b/.github/renovate-bot.json5
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "username": "rosey-bot[bot]",
-  "gitAuthor": "rosey-bot <98030736+rosey-bot[bot]@users.noreply.github.com>",
-  "repositories": ["cowdogmoo/ansible-collection-workstation"]
-}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "username": "rosey-bot[bot]",
+  "gitAuthor": "rosey-bot <98030736+rosey-bot[bot]@users.noreply.github.com>",
   "extends": [
     "config:recommended",
     "docker:enableMajor",
@@ -10,6 +12,7 @@
     ":automergeDigest",
     "helpers:pinGitHubActionDigests"
   ],
+  "dependencyDashboardLabels": ["renovate-dashboard"],
   "dependencyDashboardTitle": "Renovate Dashboard 🤖",
   "suppressNotifications": ["prIgnoreNotification"],
   "rebaseWhen": "conflicted",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "username": "rosey-bot[bot]",
-  "gitAuthor": "rosey-bot <98030736+rosey-bot[bot]@users.noreply.github.com>",
+  "username": "cowdogmoo-renovate-bot[bot]",
+  "gitAuthor": "cowdogmoo-renovate-bot <157187596+cowdogmoo-renovate-bot[bot]@users.noreply.github.com>",
   "extends": [
     "config:recommended",
     "docker:enableMajor",

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -70,17 +70,6 @@ jobs:
           echo "RENOVATE_DRY_RUN=${{ github.event.inputs.dryRun || env.WORKFLOW_DRY_RUN }}" >> "${GITHUB_ENV}"
           echo "LOG_LEVEL=${{ github.event.inputs.logLevel || env.WORKFLOW_LOG_LEVEL }}" >> "${GITHUB_ENV}"
 
-      - name: Delete old dashboard
-        run: |
-          ISSUE_NUMBER=$(gh issue list -S 'Renovate Dashboard 🤖' --json number -q '.[0].number')
-          if [ "$ISSUE_NUMBER" != "null" ] && [ -n "$ISSUE_NUMBER" ]; then
-            gh issue close "$ISSUE_NUMBER"
-          else
-            echo "No issue found to close."
-          fi
-        env:
-          GITHUB_TOKEN: "${{ steps.app-token.outputs.token }}"
-
       - name: Renovate
         uses: renovatebot/github-action@2e8e8c59e00d930224943f86f6812fbc6640f454 # v42.0.3
         with:


### PR DESCRIPTION
**Added:**
- Renovate config: added `username` and `gitAuthor` to `.github/renovate.json5`
- Added `dependencyDashboardLabels` to flag the dashboard issue with a label

**Changed:**
- Dependency dashboard workflow: updated config for new metadata structure
- Fixed renovate bot values for cowdogmoo renovate bot

**Removed:**
- Deleted `.github/renovate-bot.json5` (old, redundant Renovate config)
- Removed "Delete old dashboard" step from `renovate.yaml` workflow