### PR TITLE
feat: Generate task lists in README files by sorted taskfile name

### DIFF
--- a/.hooks/docsible-hook.sh
+++ b/.hooks/docsible-hook.sh
@@ -37,7 +37,7 @@ for role_dir in roles/*/; do
 
     # Run docsible with custom template - let it do its thing
     cd "$role_dir"
-    if docsible --no-docsible --no-backup --comments --md-role-template "$REPO_ROOT/$TEMPLATE_PATH" > /dev/null 2>&1; then
+    if docsible --role . --no-docsible --no-backup --comments --md-role-template "$REPO_ROOT/$TEMPLATE_PATH" > /dev/null 2>&1; then
         cd "$REPO_ROOT"
 
         # Check if changed
@@ -70,7 +70,7 @@ find . -name ".docsible" -type f -delete 2> /dev/null || true
 # Exit
 if [ $FILES_MODIFIED -eq 1 ]; then
     echo -e "${YELLOW}Documentation updated with custom template. Review and commit.${NC}"
-    exit 0
+    exit 1
 else
     echo -e "${GREEN}All documentation up to date${NC}"
     exit 0

--- a/.hooks/docsible-hook.sh
+++ b/.hooks/docsible-hook.sh
@@ -37,7 +37,7 @@ for role_dir in roles/*/; do
 
     # Run docsible with custom template - let it do its thing
     cd "$role_dir"
-    if docsible --role . --no-docsible --no-backup --comments --md-role-template "$REPO_ROOT/$TEMPLATE_PATH" > /dev/null 2>&1; then
+    if docsible --no-docsible --no-backup --comments --md-role-template "$REPO_ROOT/$TEMPLATE_PATH" > /dev/null 2>&1; then
         cd "$REPO_ROOT"
 
         # Check if changed
@@ -70,7 +70,7 @@ find . -name ".docsible" -type f -delete 2> /dev/null || true
 # Exit
 if [ $FILES_MODIFIED -eq 1 ]; then
     echo -e "${YELLOW}Documentation updated with custom template. Review and commit.${NC}"
-    exit 1
+    exit 0
 else
     echo -e "${GREEN}All documentation up to date${NC}"
     exit 0

--- a/.hooks/linters/markdownlint.json
+++ b/.hooks/linters/markdownlint.json
@@ -12,5 +12,6 @@
   "MD055": false,
   "MD056": false,
   "MD057": false,
-  "line-length": false
+  "line-length": false,
+  "no-multiple-blanks": false
 }

--- a/.hooks/templates/docsible-template.md.j2
+++ b/.hooks/templates/docsible-template.md.j2
@@ -44,7 +44,7 @@
 {%- endif %}
 
 ## Tasks
-{%- for taskfile in role.tasks %}
+{%- for taskfile in role.tasks | sort(attribute='file') %}
 
 ### {{ taskfile.file }}
 {% for task in taskfile.tasks %}

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,5 +1,8 @@
 ---
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
 version: "3"
+
+set: [pipefail]
 
 includes:
   ansible: "https://raw.githubusercontent.com/CowDogMoo/taskfile-templates/main/ansible/Taskfile.yaml"
@@ -9,14 +12,14 @@ includes:
 
 tasks:
   default:
-    desc: "Run all CI tasks"
+    desc: Run all CI tasks
     cmds:
       - task: ansible:lint-ansible
       - task: run-pre-commit
       - task: ansible:run-molecule-tests
 
   run-pre-commit:
-    desc: "Update, clear cache, and run pre-commit hooks"
+    desc: Update, clear cache, and run pre-commit hooks
     cmds:
       - task: pre-commit:update-hooks
       - task: pre-commit:clear-cache

--- a/roles/asdf/README.md
+++ b/roles/asdf/README.md
@@ -51,12 +51,9 @@ Install asdf
 
 ## Tasks
 
-### update_shell_profile.yml
+### ensure_directory_exists.yml
 
-- **Detect shell and set profile** (block)
-- **Check if shell exists** (ansible.builtin.command)
-- **Set detected shell fact** (ansible.builtin.set_fact)
-- **Update shell profile for the user** (ansible.builtin.blockinfile)
+- **Ensure directory exists** (ansible.builtin.file)
 
 ### install_libyaml.yml
 
@@ -65,10 +62,6 @@ Install asdf
 - **Download libyaml source** (ansible.builtin.get_url)
 - **Extract libyaml tarball** (ansible.builtin.unarchive)
 - **Compile and install libyaml** (ansible.builtin.shell)
-
-### ensure_directory_exists.yml
-
-- **Ensure directory exists** (ansible.builtin.file)
 
 ### main.yml
 
@@ -92,6 +85,13 @@ Install asdf
 - **Install ASDF plugins** (ansible.builtin.shell)
 - **Generate .tool-versions file** (ansible.builtin.template)
 - **Reshim after default packages** (ansible.builtin.shell)
+
+### update_shell_profile.yml
+
+- **Detect shell and set profile** (block)
+- **Check if shell exists** (ansible.builtin.command)
+- **Set detected shell fact** (ansible.builtin.set_fact)
+- **Update shell profile for the user** (ansible.builtin.blockinfile)
 
 ## Example Playbook
 

--- a/roles/go_task/README.md
+++ b/roles/go_task/README.md
@@ -40,15 +40,6 @@ Installs go-task (Task runner) on Unix-like and Windows systems
 
 ## Tasks
 
-### install-windows.yml
-
-- **Set download filename for Windows** (ansible.builtin.set_fact)
-- **Create installation directory** (ansible.windows.win_file)
-- **Download go-task for Windows** (ansible.windows.win_get_url)
-- **Extract go-task archive** (community.windows.win_unzip)
-- **Remove downloaded archive** (ansible.windows.win_file)
-- **Add go-task to PATH** (ansible.windows.win_path) - Conditional
-
 ### install-unix.yml
 
 - **Set download filename for Unix-like systems** (ansible.builtin.set_fact)
@@ -63,6 +54,15 @@ Installs go-task (Task runner) on Unix-like and Windows systems
 - **Extract go-task archive** (ansible.builtin.unarchive)
 - **Ensure installation directory exists** (ansible.builtin.file) - Conditional
 - **Install go-task binary** (ansible.builtin.copy)
+
+### install-windows.yml
+
+- **Set download filename for Windows** (ansible.builtin.set_fact)
+- **Create installation directory** (ansible.windows.win_file)
+- **Download go-task for Windows** (ansible.windows.win_get_url)
+- **Extract go-task archive** (community.windows.win_unzip)
+- **Remove downloaded archive** (ansible.windows.win_file)
+- **Add go-task to PATH** (ansible.windows.win_path) - Conditional
 
 ### main.yml
 

--- a/roles/zsh_setup/README.md
+++ b/roles/zsh_setup/README.md
@@ -44,13 +44,6 @@ Installs and configures zsh with oh-my-zsh.
 
 ## Tasks
 
-### zsh_setup_get_user_home.yml
-
-- **Gather available local users** (ansible.builtin.getent) - Conditional
-- **Gather available local users on macOS** (cowdogmoo.workstation.getent_passwd) - Conditional
-- **Set user home directory** (ansible.builtin.set_fact) - Conditional
-- **Set user home directory for macOS** (ansible.builtin.set_fact) - Conditional
-
 ### common.yml
 
 - **Ensure user home directory exists** (ansible.builtin.include_tasks) - Conditional
@@ -70,6 +63,13 @@ Installs and configures zsh with oh-my-zsh.
 - **Ensure user group exists** (ansible.builtin.group) - Conditional
 - **Ensure user exists** (ansible.builtin.user) - Conditional
 - **Include common tasks** (ansible.builtin.include_tasks)
+
+### zsh_setup_get_user_home.yml
+
+- **Gather available local users** (ansible.builtin.getent) - Conditional
+- **Gather available local users on macOS** (cowdogmoo.workstation.getent_passwd) - Conditional
+- **Set user home directory** (ansible.builtin.set_fact) - Conditional
+- **Set user home directory for macOS** (ansible.builtin.set_fact) - Conditional
 
 ## Example Playbook
 


### PR DESCRIPTION
**Changed:**

- Updated task list rendering in docsible template and all roles' README.md files to ensure tasks are listed in alphabetical order by their playbook filename.
- Moved task section ordering in README files for asdf, go_task, vnc_setup, and zsh_setup roles to match alphabetical sorting.
- This improves readability and ensures task documentation is consistent with the actual playbook file structure.