### PR TITLE
feat: Automated documentation & go_task role, various improvements

### DIFF
--- a/changelogs/CHANGELOG.rst
+++ b/changelogs/CHANGELOG.rst
@@ -1,8 +1,60 @@
 ============================================================
-CowDogMoo Workstation Ansible Collection 2.0.6 Release Notes
+CowDogMoo Workstation Ansible Collection 2.0.7 Release Notes
 ============================================================
 
 .. contents:: Topics
+
+v2.0.7
+======
+
+Release Summary
+---------------
+
+Major update featuring automated documentation generation with docsible, addition of go_task role for Task runner installation, improved renovate configuration, and comprehensive variable namespacing improvements across all roles. Migrated from Ruby-based to JavaScript-based markdown linting and updated numerous dependencies to their latest versions.
+
+Added
+-----
+
+- Added Molecule create/destroy playbooks for all roles to improve test infrastructure
+- Added docsible documentation generation via pre-commit hooks with custom templates
+- Added go_task role for installing Task runner (go-task) on Unix-like and Windows systems
+- Added markdownlint configuration to replace mdl Ruby-based linting
+- Added renovate dashboard labels configuration
+- Added support for Go 1.24.4 and Python 3.13.5 in ASDF defaults
+
+Changed
+-------
+
+- Fixed VNC setup role with improved systemd handling and process cleanup
+- Fixed shell detection and profile updates in ASDF role
+- Improved variable namespacing across all roles to prevent conflicts
+- Migrated from Ruby-based mdl to markdownlint-cli for markdown linting
+- Refactored renovate configuration to JSON5 format with improved bot configuration
+- Replaced manual documentation generation with automated docsible integration
+- Updated ASDF role to version 0.16.7 with improved architecture detection
+- Updated GitHub Actions workflows with improved environment variable handling
+- Updated all role README files with standardized docsible-generated documentation
+- Updated amazon.aws from 9.4.0 to 10.1.0
+- Updated ansible.windows from 3.0.0 to 3.2.0
+- Updated ansible/ansible-lint from v25.4.0 to v25.7.0
+- Updated community.docker from 4.6.0 to 4.7.0
+- Updated community.general from 10.6.0 to 11.1.2
+- Updated golang/go from 1.24.0 to 1.24.4
+- Updated helm/helm from 3.17.3 to 3.18.4
+- Updated kubectl from 1.33.0 to 1.33.3
+- Updated packer from 1.12.0 to 1.14.1
+- Updated pre-commit configuration to use docsible for documentation generation
+- Updated python/cpython from 3.13.3 to 3.13.5
+- Updated renovatebot/github-action from v42.0.1 to v43.0.5
+- Updated template sync workflow to use latest action versions
+- Updated workstation playbook to include new go_task role
+
+Removed
+-------
+
+- Removed Ruby-based mdstyle.rb linter configuration
+- Removed manual Python-based documentation generator (generate_docs.py)
+- Removed renovate-bot.json5 in favor of consolidated renovate.json5
 
 v2.0.6
 ======

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -578,3 +578,47 @@ releases:
         for Kali Linux package verification and simplified VNC service management.
         Several dependencies were also updated to their latest versions.
     release_date: '2025-05-08'
+  2.0.7:
+    changes:
+      added:
+      - Added Molecule create/destroy playbooks for all roles to improve test infrastructure
+      - Added docsible documentation generation via pre-commit hooks with custom templates
+      - Added go_task role for installing Task runner (go-task) on Unix-like and Windows
+        systems
+      - Added markdownlint configuration to replace mdl Ruby-based linting
+      - Added renovate dashboard labels configuration
+      - Added support for Go 1.24.4 and Python 3.13.5 in ASDF defaults
+      changed:
+      - Fixed VNC setup role with improved systemd handling and process cleanup
+      - Fixed shell detection and profile updates in ASDF role
+      - Improved variable namespacing across all roles to prevent conflicts
+      - Migrated from Ruby-based mdl to markdownlint-cli for markdown linting
+      - Refactored renovate configuration to JSON5 format with improved bot configuration
+      - Replaced manual documentation generation with automated docsible integration
+      - Updated ASDF role to version 0.16.7 with improved architecture detection
+      - Updated GitHub Actions workflows with improved environment variable handling
+      - Updated all role README files with standardized docsible-generated documentation
+      - Updated amazon.aws from 9.4.0 to 10.1.0
+      - Updated ansible.windows from 3.0.0 to 3.2.0
+      - Updated ansible/ansible-lint from v25.4.0 to v25.7.0
+      - Updated community.docker from 4.6.0 to 4.7.0
+      - Updated community.general from 10.6.0 to 11.1.2
+      - Updated golang/go from 1.24.0 to 1.24.4
+      - Updated helm/helm from 3.17.3 to 3.18.4
+      - Updated kubectl from 1.33.0 to 1.33.3
+      - Updated packer from 1.12.0 to 1.14.1
+      - Updated pre-commit configuration to use docsible for documentation generation
+      - Updated python/cpython from 3.13.3 to 3.13.5
+      - Updated renovatebot/github-action from v42.0.1 to v43.0.5
+      - Updated template sync workflow to use latest action versions
+      - Updated workstation playbook to include new go_task role
+      release_summary: Major update featuring automated documentation generation with
+        docsible, addition of go_task role for Task runner installation, improved
+        renovate configuration, and comprehensive variable namespacing improvements
+        across all roles. Migrated from Ruby-based to JavaScript-based markdown linting
+        and updated numerous dependencies to their latest versions.
+      removed:
+      - Removed Ruby-based mdstyle.rb linter configuration
+      - Removed manual Python-based documentation generator (generate_docs.py)
+      - Removed renovate-bot.json5 in favor of consolidated renovate.json5
+    release_date: '2025-08-05'

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -61,7 +61,7 @@ Before creating a release, you should perform these preparation steps:
    task -y ansible:lint-ansible
    ```
 
-   This runs ansible-lint with the configuration file at .hooks/linters/ansible-lint.yaml.
+   This runs ansible-lint with the configuration file at `.hooks/linters/ansible-lint.yaml`.
 
 1. **Update Collection Dependencies and Versions**
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: cowdogmoo
 name: workstation
-version: 2.0.6
+version: 2.0.7
 readme: README.md
 authors:
   - Jayson Grace <techvomit.net>


### PR DESCRIPTION
**Key Changes:**

- Added automated docs generation via docsible and pre-commit hooks.
- Introduced `go_task` role for Task runner (go-task) installation.
- Migrated markdown linting from Ruby-based mdl to markdownlint-cli.
- Improved variable namespacing for all roles to avoid conflicts.
- Updated and refactored Renovate configuration to JSON5 format.
- Updated numerous dependencies and GitHub Actions for greater stability.

**Added:**

- Molecule create/destroy playbooks for all roles for test infra.
- docsible automatic docs generation with custom templates.
- `go_task` role for Task runner install (Unix & Windows).
- markdownlint configuration for JS-based MD linting.
- Renovate bot dashboard label configuration.
- ASDF defaults for Go 1.24.4 & Python 3.13.5.

**Changed:**

- Fixed VNC setup role (systemd & cleanup).
- Fixed shell detection/profile in ASDF role.
- Improved variable namespacing across roles.
- Switched MD lint from mdl to markdownlint-cli.
- Renovate config migrated to JSON5, improved bot config.
- Docs now generated by docsible, not manually.
- Updated ASDF role: v0.16.7, improved arch detection.
- Updated all README files with docsible-generated docs.
- Bumped dependencies:
  - amazon.aws 9.4.0 → 10.1.0
  - ansible.windows 3.0.0 → 3.2.0
  - ansible-lint v25.4.0 → v25.7.0
  - community.docker 4.6.0 → 4.7.0
  - community.general 10.6.0 → 11.1.2
  - golang/go 1.24.0 → 1.24.4
  - helm/helm 3.17.3 → 3.18.4
  - kubectl 1.33.0 → 1.33.3
  - packer 1.12.0 → 1.14.1
  - python/cpython 3.13.3 → 3.13.5
  - renovatebot/github-action v42.0.1 → v43.0.5
- Updated pre-commit to use docsible for docs generation.
- Updated template sync workflow to latest actions.
- Workstation playbook now includes `go_task` role.

**Removed:**

- Ruby-based mdstyle.rb MD linter config.
- Manual Python doc generator (`generate_docs.py`).
- Old renovate-bot.json5 file (now using renovate.json5).