### PR TITLE
feat: optional GitHub token for authenticated API requests in go_task role

### DIFF
--- a/roles/go_task/defaults/main.yml
+++ b/roles/go_task/defaults/main.yml
@@ -1,15 +1,19 @@
 ---
 # Version of go-task to install
-go_task_version: "latest"
+go_task_version: latest
 
 # Installation directory for Unix-like systems
-go_task_install_dir: "/usr/local/bin"
+go_task_install_dir: /usr/local/bin
 
 # Installation directory for Windows systems
-go_task_windows_install_dir: "C:\\Program Files\\task"
+go_task_windows_install_dir: C:\\Program Files\\task
 
-# Whether to add to PATH on Windows
+# Add to PATH on Windows
 go_task_windows_add_to_path: true
+
+# GitHub token for API authentication (optional)
+# Can be set via environment variable GITHUB_TOKEN
+go_task_github_token: "{{ lookup('env', 'GITHUB_TOKEN') | default('') }}"
 
 # Architecture mapping
 go_task_arch_map:

--- a/roles/go_task/tasks/main.yml
+++ b/roles/go_task/tasks/main.yml
@@ -54,11 +54,11 @@
       ansible.builtin.uri:
         url: "{{ go_task_github_api_url }}/latest"
         method: GET
-        headers:
-          Accept: "application/vnd.github.v3+json"
+        headers: "{{ {'Accept': 'application/vnd.github.v3+json'} | combine((go_task_github_token | length > 0) | ternary({'Authorization': 'Bearer ' + go_task_github_token}, {})) }}"
       register: go_task_latest_release
       retries: 3
-      delay: 2
+      delay: 5
+      until: go_task_latest_release is not failed
 
     - name: Set version to latest
       ansible.builtin.set_fact:


### PR DESCRIPTION
**Added:**

- Support for setting an optional GitHub token via `go_task_github_token` variable,
  allowing use of the GITHUB_TOKEN environment variable for API authentication

**Changed:**

- Updated API request headers to include Authorization when a GitHub token is set,
  enabling authenticated requests to avoid rate limits
- Increased delay between API request retries from 2 to 5 seconds and added `until` condition to improve reliability of fetching the latest release
- Changed default variable formatting by removing unnecessary quotes for consistency in `main.yml`