### PR TITLE
chore: update renovate configuration for improved version extraction

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -91,11 +91,12 @@
       datasourceTemplate: 'github-tags',
       depNameTemplate: 'golang/go',
       versioningTemplate: 'semver',
+      extractVersionTemplate: '^go(?<version>.*)$',
     },
     {
       customType: 'regex',
       managerFilePatterns: [
-        '/^roles/asdf/defaults/main\\.yml$/',
+        '/^roles/asdf/defaults/main\\.yml$/'
       ],
       matchStrings: [
         'name: (?<depName>python)\\s+version: "(?<currentValue>[0-9.]+)"',
@@ -103,6 +104,7 @@
       datasourceTemplate: 'github-tags',
       depNameTemplate: 'python/cpython',
       versioningTemplate: 'semver',
+      extractVersionTemplate: '^v?(?<version>.*)$',
     },
     {
       customType: 'regex',
@@ -139,6 +141,7 @@
       datasourceTemplate: 'github-tags',
       depNameTemplate: 'ruby/ruby',
       versioningTemplate: 'semver',
+      extractVersionTemplate: '^v?(?<version>\\d+)_(?<version>\\d+)_(?<version>\\d+)$',
     },
     {
       customType: 'regex',

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: 🤖 Renovate
 on:
   push:
@@ -75,4 +76,4 @@ jobs:
         with:
           configurationFile: "${{ env.RENOVATE_ONBOARDING_CONFIG_FILE_NAME }}"
           token: "${{ steps.app-token.outputs.token }}"
-          renovate-version: "${{ inputs.version || 'full' }}"
+          renovate-version: "${{ inputs.version || 'latest' }}"


### PR DESCRIPTION
**Added:**

- Add `extractVersionTemplate` fields for golang, python, and ruby regex dependencies in renovate config to improve version parsing
- Add YAML language server schema directive to Renovate GitHub Actions workflow for better editor support

**Changed:**

- Update renovate-version input default from 'full' to 'latest' in workflow to ensure the latest Renovate version is used

**Removed:**

- Remove unnecessary trailing whitespace in renovate config