### PR TITLE
feat: enhance logging role with multi-platform logrotate support

### DIFF
--- a/playbooks/workstation/workstation.yml
+++ b/playbooks/workstation/workstation.yml
@@ -2,6 +2,40 @@
 - name: Workstation
   hosts: all
   roles:
+    # Set up logging first to ensure log directories exist for other roles
+    - name: Configure logging and log rotation
+      role: cowdogmoo.workstation.logging
+      # For debugging
+      # role: ../../roles/logging
+      vars:
+        logging_directories:
+          - path: "~/ansible-logs"
+            mode: "0755"
+            owner: "{{ ansible_user_id }}"
+            group: "{{ ansible_user_gid | default(ansible_user_id) }}"
+          - path: "~/ansible-logs/hosts"  # For log_plays callback
+            mode: "0755"
+            owner: "{{ ansible_user_id }}"
+            group: "{{ ansible_user_gid | default(ansible_user_id) }}"
+
+        logging_rotation_configs:
+          - name: "ansible-hosts"
+            path: "~/ansible-logs/hosts/*.log"
+            rotate: 30
+            frequency: "daily"
+            compress: true
+            missingok: true
+            notifempty: true
+            create: true
+            dateext: true
+            maxsize: "100M"
+            owner: "{{ ansible_user_id }}"
+            group: "{{ ansible_user_gid | default(ansible_user_id) }}"
+
+        # Optional: Override default LaunchAgent settings for macOS
+        logging_launchagent_label: "com.ansible.logrotate"
+        logging_logrotate_log_path: "{{ ansible_env.HOME }}/ansible-logs/logrotate"
+
     - name: Setup users on workstation
       role: cowdogmoo.workstation.user_setup
       # For debugging

--- a/roles/logging/README.md
+++ b/roles/logging/README.md
@@ -3,7 +3,7 @@
 
 ## Description
 
-Provides logging directories and log rotation for other roles.
+Provides flexible logging directories and log rotation for any application or service.
 
 ## Requirements
 
@@ -16,25 +16,43 @@ Provides logging directories and log rotation for other roles.
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
 | `logging_directories` | list | `[]` | No description |
-| `logging_directories.0` | dict | `{}` | No description |
-| `logging_log_rotation_config` | dict | `{}` | No description |
-| `logging_log_rotation_config.path` | str | `/var/log/ansible/*.log` | No description |
-| `logging_log_rotation_config.rotate` | int | `4` | No description |
-| `logging_log_rotation_config.frequency` | str | `weekly` | No description |
-| `logging_log_rotation_config.compress` | bool | `True` | No description |
-| `logging_log_rotation_config.missingok` | bool | `True` | No description |
-| `logging_log_rotation_config.notifempty` | bool | `True` | No description |
-| `logging_log_rotation_config.create` | bool | `True` | No description |
-| `logging_log_rotation_config.dateext` | bool | `True` | No description |
-| `logging_log_rotation_config.owner` | str | `root` | No description |
-| `logging_log_rotation_config.group` | str | `root` | No description |
+| `logging_rotation_configs` | list | `[]` | No description |
+| `logging_launchagent_label` | str | `com.logging.logrotate` | No description |
+| `logging_launchagent_hour` | int | `3` | No description |
+| `logging_launchagent_minute` | int | `0` | No description |
+| `logging_logrotate_log_path` | str | `{{ ansible_env.HOME }}/logs/logrotate` | No description |
+
+### Role Variables (main.yml)
+
+| Variable | Type | Value | Description |
+|----------|------|-------|-------------|
+| `logging_logrotate_binary_darwin` | str | `/opt/homebrew/sbin/logrotate` | No description |
+| `logging_logrotate_binary_linux` | str | `/usr/sbin/logrotate` | No description |
+| `logging_logrotate_config_dir_darwin` | str | `{{ ansible_env.HOME }}/.config/logrotate.d` | No description |
+| `logging_logrotate_config_dir_linux` | str | `/etc/logrotate.d` | No description |
+| `logging_logrotate_state_file` | str | `{{ ansible_env.HOME + '/.config/logrotate.state' if ansible_os_family == 'Darwin' else '/var/lib/logrotate/status' }}` | No description |
 
 ## Tasks
 
 ### main.yml
 
-- **Ensure logging directories exist** (ansible.builtin.file)
-- **Setup log rotation** (ansible.builtin.template)
+- **Set OS-specific facts** (ansible.builtin.set_fact)
+- **Set logrotate paths based on OS** (ansible.builtin.set_fact)
+- **Check if logrotate binary exists** (ansible.builtin.stat)
+- **Install logrotate on macOS** (community.general.homebrew) - Conditional
+- **Install logrotate on Linux (Debian-based)** (ansible.builtin.apt) - Conditional
+- **Install logrotate on Linux (RedHat-based)** (ansible.builtin.dnf) - Conditional
+- **Ensure logging directories exist** (ansible.builtin.file) - Conditional
+- **Ensure parent directory for logrotate config exists on macOS** (ansible.builtin.file) - Conditional
+- **Ensure logrotate config directory exists** (ansible.builtin.file) - Conditional
+- **Setup log rotation configurations** (ansible.builtin.template) - Conditional
+- **Ensure logrotate state directory exists on macOS** (ansible.builtin.file) - Conditional
+- **Create logrotate state file on macOS** (ansible.builtin.file) - Conditional
+- **Create LaunchAgent directory on macOS** (ansible.builtin.file) - Conditional
+- **Create LaunchAgent for logrotate on macOS** (ansible.builtin.template) - Conditional
+- **Unload existing LaunchAgent if present** (ansible.builtin.command) - Conditional
+- **Load LaunchAgent for logrotate on macOS** (ansible.builtin.command) - Conditional
+- **Ensure logrotate's own log directory exists** (ansible.builtin.file) - Conditional
 
 ## Example Playbook
 

--- a/roles/logging/defaults/main.yml
+++ b/roles/logging/defaults/main.yml
@@ -1,15 +1,30 @@
 ---
-logging_directories:
-  - path: "/var/log/ansible"
+# Default logging directories
+logging_directories: []
+  # Example:
+  # - path: "{{ '~/logs/myapp' if ansible_os_family == 'Darwin' else '/var/log/myapp' }}"
+  #   mode: "0755"
+  #   owner: "{{ ansible_user_id if ansible_os_family == 'Darwin' else 'root' }}"
+  #   group: "{{ 'staff' if ansible_os_family == 'Darwin' else 'root' }}"
 
-logging_log_rotation_config:
-  path: "/var/log/ansible/*.log"
-  rotate: 4
-  frequency: "weekly"
-  compress: true
-  missingok: true
-  notifempty: true
-  create: true
-  dateext: true
-  owner: "root"
-  group: "root"
+# Default log rotation configurations - supports multiple configs
+logging_rotation_configs: []
+  # Example:
+  # - name: "myapp"  # Used for config filename
+  #   path: "{{ '~/logs/myapp/*.log' if ansible_os_family == 'Darwin' else '/var/log/myapp/*.log' }}"
+  #   rotate: 30
+  #   frequency: "daily"
+  #   compress: true
+  #   missingok: true
+  #   notifempty: true
+  #   create: true
+  #   dateext: true
+  #   maxsize: "100M"
+  #   owner: "{{ ansible_user_id if ansible_os_family == 'Darwin' else 'root' }}"
+  #   group: "{{ 'staff' if ansible_os_family == 'Darwin' else 'root' }}"
+
+# LaunchAgent configuration for macOS
+logging_launchagent_label: "com.logging.logrotate"
+logging_launchagent_hour: 3
+logging_launchagent_minute: 0
+logging_logrotate_log_path: "{{ ansible_env.HOME }}/logs/logrotate" # Where logrotate itself logs

--- a/roles/logging/meta/main.yml
+++ b/roles/logging/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   role_name: logging
   author: Jayson Grace
   namespace: cowdogmoo
-  description: Provides logging directories and log rotation for other roles.
+  description: Provides flexible logging directories and log rotation for any application or service.
   company: CowDogMoo
   license: MIT
   min_ansible_version: "2.14"
@@ -18,6 +18,8 @@ galaxy_info:
       versions:
         - all
   galaxy_tags:
-    - user
-    - setup
+    - logging
+    - logrotate
+    - logs
+    - monitoring
 dependencies: []

--- a/roles/logging/molecule/default/converge.yml
+++ b/roles/logging/molecule/default/converge.yml
@@ -2,6 +2,27 @@
 - name: Converge
   hosts: all
   tasks:
-    - name: Include role under test
+    - name: Include role under test with test variables
       ansible.builtin.include_role:
         name: cowdogmoo.workstation.logging
+      vars:
+        logging_directories:
+          - path: /var/log/test-app
+            mode: "0755"
+            owner: root
+            group: root
+        logging_rotation_configs:
+          - name: test-app
+            path: /var/log/test-app/*.log
+            rotate: 7
+            frequency: daily
+            compress: true
+            missingok: true
+            notifempty: true
+            create: true
+            owner: root
+            group: root
+            dateext: true
+            maxsize: 100M
+        logging_logrotate_log_path: /var/log/logrotate
+        logging_logrotate_state_file: /var/lib/logrotate.state

--- a/roles/logging/molecule/default/molecule.yml
+++ b/roles/logging/molecule/default/molecule.yml
@@ -2,6 +2,8 @@
 # Use Ansible Galaxy to install dependencies
 dependency:
   name: galaxy
+  options:
+    requirements-file: requirements.yml
 
 # Run molecule inside of a docker container
 driver:

--- a/roles/logging/molecule/default/requirements.yml
+++ b/roles/logging/molecule/default/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: community.general

--- a/roles/logging/molecule/default/verify.yml
+++ b/roles/logging/molecule/default/verify.yml
@@ -3,32 +3,65 @@
   hosts: all
   gather_facts: true
   tasks:
-    - name: Include default variables for logging role
-      ansible.builtin.include_vars:
-        file: "../../defaults/main.yml"
+    - name: Set test variables
+      ansible.builtin.set_fact:
+        test_directories:
+          - path: /var/log/test-app
+            mode: "0755"
+        test_rotation_config:
+          name: test-app
+          path: /var/log/test-app/*.log
 
-    - name: Check logging directories' existence and permissions
+    - name: Check logging directories exist
       ansible.builtin.stat:
         path: "{{ item.path }}"
-      loop: "{{ logging_directories }}"
-      register: logging_dir_stats
+      loop: "{{ test_directories }}"
+      register: dir_stats
 
-    - name: Assert logging directories exist with correct permissions
+    - name: Assert directories exist with correct permissions
       ansible.builtin.assert:
         that:
-          - "item.stat.exists and item.stat.isdir"
-          - "item.stat.mode == '0755'"
+          - item.stat.exists
+          - item.stat.isdir
+          - item.stat.mode == item.item.mode
         quiet: true
-      loop: "{{ logging_dir_stats.results }}"
-      loop_control:
-        loop_var: item
+      loop: "{{ dir_stats.results }}"
 
-    - name: Check logrotate configuration
+    - name: Check logrotate configuration file
       ansible.builtin.stat:
-        path: "/etc/logrotate.d/{{ logging_log_rotation_config.path.split('/')[-1].split('.')[0] }}"
+        path: "/etc/logrotate.d/{{ test_rotation_config.name }}"
       register: logrotate_config
 
     - name: Assert logrotate configuration exists
       ansible.builtin.assert:
         that:
-          - "logrotate_config.stat.exists"
+          - logrotate_config.stat.exists
+          - logrotate_config.stat.mode == "0644"
+
+    - name: Check logrotate binary exists (Linux)
+      ansible.builtin.command:
+        cmd: which logrotate
+      register: logrotate_which
+      changed_when: false
+      failed_when: false
+
+    - name: Assert logrotate binary exists
+      ansible.builtin.assert:
+        that:
+          - logrotate_which.rc == 0
+        fail_msg: "Logrotate binary not found"
+        success_msg: "Logrotate binary found at {{ logrotate_which.stdout }}"
+
+    - name: Validate logrotate configuration syntax
+      ansible.builtin.command:
+        cmd: logrotate -d /etc/logrotate.d/{{ test_rotation_config.name }}
+      register: logrotate_debug
+      changed_when: false
+      failed_when: false
+
+    - name: Assert logrotate configuration is valid
+      ansible.builtin.assert:
+        that:
+          - logrotate_debug.rc == 0
+        fail_msg: "Logrotate configuration is invalid"
+        success_msg: "Logrotate configuration is valid"

--- a/roles/logging/tasks/main.yml
+++ b/roles/logging/tasks/main.yml
@@ -1,19 +1,145 @@
 ---
-- name: Ensure logging directories exist
+- name: Set OS-specific facts
+  ansible.builtin.set_fact:
+    logging_is_macos: "{{ ansible_os_family == 'Darwin' }}"
+    logging_is_linux: "{{ ansible_os_family in ['Debian', 'RedHat'] }}"
+
+- name: Set logrotate paths based on OS
+  ansible.builtin.set_fact:
+    logging_logrotate_binary: "{{ logging_logrotate_binary_darwin if logging_is_macos else logging_logrotate_binary_linux }}"
+    logging_logrotate_config_dir: "{{ logging_logrotate_config_dir_darwin if logging_is_macos else logging_logrotate_config_dir_linux }}"
+
+- name: Check if logrotate binary exists
+  ansible.builtin.stat:
+    path: "{{ logging_logrotate_binary }}"
+  register: logging_logrotate_check
+
+- name: Install logrotate on macOS
+  community.general.homebrew:
+    name: logrotate
+    state: present
+  when:
+    - logging_is_macos
+    - not (logging_logrotate_check.stat.exists | default(false))
+
+- name: Install logrotate on Linux (Debian-based)
+  ansible.builtin.apt:
+    name: logrotate
+    state: present
+    update_cache: true
   become: true
+  when:
+    - logging_is_linux
+    - ansible_os_family == "Debian"
+
+- name: Install logrotate on Linux (RedHat-based)
+  ansible.builtin.dnf:
+    name: logrotate
+    state: present
+  become: true
+  when:
+    - logging_is_linux
+    - ansible_os_family == "RedHat"
+
+- name: Ensure logging directories exist
   ansible.builtin.file:
-    path: "{{ item.path }}"
+    path: "{{ item.path | expanduser }}"
     state: directory
     mode: "{{ item.mode | default('0755') }}"
-    owner: "{{ item.owner | default('root') }}"
-    group: "{{ item.group | default('root') }}"
+    owner: "{{ item.owner | default(ansible_user_id) }}"
+    group: "{{ item.group | default(ansible_user_gid | default(ansible_user_id)) }}"
   loop: "{{ logging_directories }}"
+  become: "{{ logging_is_linux and item.path.startswith('/var') | default(false) }}"
+  when: logging_directories | length > 0
 
-- name: Setup log rotation
-  become: true
+- name: Ensure parent directory for logrotate config exists on macOS
+  ansible.builtin.file:
+    path: "{{ logging_logrotate_config_dir | dirname }}"
+    state: directory
+    mode: "0755"
+  when:
+    - logging_is_macos
+    - logging_rotation_configs | length > 0
+
+- name: Ensure logrotate config directory exists
+  ansible.builtin.file:
+    path: "{{ logging_logrotate_config_dir }}"
+    state: directory
+    mode: "0755"
+  become: "{{ logging_is_linux }}"
+  when: logging_rotation_configs | length > 0
+
+# Handle multiple log rotation configurations
+- name: Setup log rotation configurations
   ansible.builtin.template:
     src: logrotate.j2
-    dest: "/etc/logrotate.d/{{ logging_log_rotation_config.path.split('/')[-1].split('.')[0] }}"
+    dest: "{{ logging_logrotate_config_dir }}/{{ item.name | default(item.path.split('/')[-2]) }}"
     mode: "0644"
+  become: "{{ logging_is_linux }}"
+  loop: "{{ logging_rotation_configs }}"
   vars:
-    log_rotation_config: "{{ logging_log_rotation_config }}"
+    log_rotation_config: "{{ item }}"
+  when: logging_rotation_configs | length > 0
+
+- name: Ensure logrotate state directory exists on macOS
+  ansible.builtin.file:
+    path: "{{ logging_logrotate_state_file | dirname }}"
+    state: directory
+    mode: "0755"
+  when:
+    - logging_is_macos
+    - logging_rotation_configs | length > 0
+
+- name: Create logrotate state file on macOS
+  ansible.builtin.file:
+    path: "{{ logging_logrotate_state_file }}"
+    state: touch
+    mode: "0644"
+  when:
+    - logging_is_macos
+    - logging_rotation_configs | length > 0
+  changed_when: false
+
+- name: Create LaunchAgent directory on macOS
+  ansible.builtin.file:
+    path: "{{ ansible_env.HOME }}/Library/LaunchAgents"
+    state: directory
+    mode: "0755"
+  when:
+    - logging_is_macos
+    - logging_rotation_configs | length > 0
+
+- name: Create LaunchAgent for logrotate on macOS
+  ansible.builtin.template:
+    src: com.logging.logrotate.plist.j2
+    dest: "{{ ansible_env.HOME }}/Library/LaunchAgents/{{ logging_launchagent_label }}.plist"
+    mode: "0644"
+  when:
+    - logging_is_macos
+    - logging_rotation_configs | length > 0
+
+- name: Unload existing LaunchAgent if present
+  ansible.builtin.command:
+    cmd: launchctl unload {{ ansible_env.HOME }}/Library/LaunchAgents/{{ logging_launchagent_label }}.plist
+  when:
+    - logging_is_macos
+    - logging_rotation_configs | length > 0
+  failed_when: false
+  changed_when: false
+
+- name: Load LaunchAgent for logrotate on macOS
+  ansible.builtin.command:
+    cmd: launchctl load -w {{ ansible_env.HOME }}/Library/LaunchAgents/{{ logging_launchagent_label }}.plist
+  when:
+    - logging_is_macos
+    - logging_rotation_configs | length > 0
+  changed_when: false
+
+- name: Ensure logrotate's own log directory exists
+  ansible.builtin.file:
+    path: "{{ logging_logrotate_log_path }}"
+    state: directory
+    mode: "0755"
+  when:
+    - logging_is_macos
+    - logging_rotation_configs | length > 0

--- a/roles/logging/templates/com.logging.logrotate.plist.j2
+++ b/roles/logging/templates/com.logging.logrotate.plist.j2
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{{ logging_launchagent_label }}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{ logrotate_binary }}</string>
+        <string>-s</string>
+        <string>{{ logging_logrotate_state_file }}</string>
+        <string>{{ logrotate_config_dir }}/*</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>{{ logging_launchagent_hour }}</integer>
+        <key>Minute</key>
+        <integer>{{ logging_launchagent_minute }}</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{{ logging_logrotate_log_path }}/logrotate.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{ logging_logrotate_log_path }}/logrotate.error</string>
+</dict>
+</plist>

--- a/roles/logging/templates/logrotate.j2
+++ b/roles/logging/templates/logrotate.j2
@@ -1,12 +1,14 @@
----
-{{ log_rotation_config.path }} {
+{{ log_rotation_config.path | expanduser }} {
     rotate {{ log_rotation_config.rotate }}
     {{ log_rotation_config.frequency }}
     {% if log_rotation_config.compress %}compress{% endif %}
     {% if log_rotation_config.missingok %}missingok{% endif %}
     {% if log_rotation_config.notifempty %}notifempty{% endif %}
     {% if log_rotation_config.create %}
-    create 0644 {{ log_rotation_config.owner }} {{ log_rotation_config.group }}
+    create 0644 {{ log_rotation_config.owner }} {{ log_rotation_config.group | default(log_rotation_config.owner) }}
     {% endif %}
     {% if log_rotation_config.dateext %}dateext{% endif %}
+    {% if log_rotation_config.maxsize is defined %}
+    maxsize {{ log_rotation_config.maxsize }}
+    {% endif %}
 }

--- a/roles/logging/vars/main.yml
+++ b/roles/logging/vars/main.yml
@@ -1,0 +1,7 @@
+---
+# System-specific paths
+logging_logrotate_binary_darwin: "/opt/homebrew/sbin/logrotate"
+logging_logrotate_binary_linux: "/usr/sbin/logrotate"
+logging_logrotate_config_dir_darwin: "{{ ansible_env.HOME }}/.config/logrotate.d"
+logging_logrotate_config_dir_linux: "/etc/logrotate.d"
+logging_logrotate_state_file: "{{ ansible_env.HOME + '/.config/logrotate.state' if ansible_os_family == 'Darwin' else '/var/lib/logrotate/status' }}"


### PR DESCRIPTION
**Added:**

- Added support for multiple log rotation configurations, enabling flexible management of logs for any application or service
- Introduced macOS LaunchAgent automation for scheduled logrotate runs via a new `com.logging.logrotate.plist.j2` template
- Provided OS-specific variables for logrotate paths and state files in a new `vars/main.yml`
- Added Molecule test dependencies via `requirements.yml` for community.general collection
- Extended Molecule test scenarios to verify directory creation, logrotate configuration, and binary presence

**Changed:**

- Refactored logging tasks to dynamically handle macOS and Linux differences, including installation, directory management, and config locations
- Updated default variables to use lists for both directories and rotation configs, supporting multiple log targets
- Improved documentation in README and meta files to clarify new role flexibility
  and multi-platform capabilities
- Enhanced logrotate configuration template to support optional `maxsize` and group fallback logic
- Updated test and verification tasks to align with new flexible structure and OS-specific paths

**Removed:**

- Deprecated single `logging_log_rotation_config` in favor of `logging_rotation_configs` list for broader use cases
- Removed hardcoded logrotate paths and states from defaults, now handled via OS-specific variables