### PR TITLE
fix: update awscli plugin version in asdf defaults

### DIFF
--- a/roles/asdf/defaults/main.yml
+++ b/roles/asdf/defaults/main.yml
@@ -36,5 +36,5 @@ asdf_plugins:
     version: "1.14.1"
     scope: "global"
   - name: awscli
-    version: "2.24.0"
+    version: "2.28.22"
     scope: "global"


### PR DESCRIPTION
**Changed:**

- Bump awscli version from 2.24.0 to 2.28.22 in asdf plugin defaults to provide latest features and fixes