### PR TITLE
feat: Improve asdf plugin and dependency version management

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -56,8 +56,9 @@
       matchStrings: [
         '- name: golang\\n\\s+version: "(?<currentValue>[0-9.]+)"'
       ],
-      datasourceTemplate: 'github-tags',
+      datasourceTemplate: 'go-version',
       depNameTemplate: 'golang/go',
+      versioningTemplate: 'semver'
     },
     {
       customType: 'regex',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -61,25 +61,7 @@
       groupName: 'ansible-dependencies',
     },
   ],
-  ansible: {
-    fileMatch: [
-      '/^requirements\\.yml$/',
-      '/^roles/[^/]+/meta/main\\.yml$/',
-      '/^galaxy\\.yml$/',
-    ],
-  },
   customManagers: [
-    {
-      customType: 'regex',
-      fileMatch: [
-        '/(^|/)requirements\\.ya?ml$/',
-        '/(^|/)galaxy\\.ya?ml$/',
-      ],
-      matchStrings: [
-        'name: (?<depName>[^\\s]+)\\n\\s+src: (?<packageName>[^\\s]+)\\n\\s+version: (?<currentValue>[^\\s]+)',
-      ],
-      datasourceTemplate: 'git-tags',
-    },
     {
       customType: 'regex',
       fileMatch: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,12 +50,11 @@
   customManagers: [
     {
       customType: "regex",
+      description: "Update asdf plugin versions",
       fileMatch: ["roles/asdf/defaults/main\\.yml"],
       matchStrings: [
-        "-\\s*name:\\s*golang\\s*\\n\\s*version:\\s*\"(?<currentValue>[0-9.]+)\""
+        "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>[\\w-]+?))?(?: packageName=(?<packageName>[\\w-/]+?))?(?: extractVersion=(?<extractVersion>.+?))?\\s*\\n\\s*-\\s*name:\\s*[\\w-]+\\s*\\n\\s*version:\\s*\"(?<currentValue>[0-9.]+)\""
       ],
-      datasourceTemplate: 'golang-version',
-      depNameTemplate: "golang/go",
     },
   ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -46,6 +46,9 @@
       matchManagers: ['ansible-galaxy'],
       groupName: 'ansible-dependencies',
     },
+    {
+      matchPackageNames: ['golang'],
+    },
   ],
   customManagers: [
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,12 +29,10 @@
   packageRules: [
     {
       description: 'Auto merge Galaxy dependencies',
-      matchDatasources: ['galaxy'],
+      matchManagers: ['ansible-galaxy'],
       automerge: true,
       automergeType: 'pr',
-      matchUpdateTypes: [
-        'digest',
-      ],
+      matchUpdateTypes: ['minor', 'patch']
     },
     {
       description: 'Auto-merge GitHub Actions',
@@ -42,10 +40,7 @@
       matchDatasources: ['github-tags'],
       automerge: true,
       automergeType: 'pr',
-      matchUpdateTypes: [
-        'minor',
-        'patch',
-      ],
+      matchUpdateTypes: ['minor', 'patch'],
     },
     {
       description: 'Group Ansible Galaxy dependencies',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -46,21 +46,17 @@
       matchManagers: ['ansible-galaxy'],
       groupName: 'ansible-dependencies',
     },
-    {
-      matchPackageNames: ['golang'],
-    },
   ],
   customManagers: [
     {
-      customType: 'regex',
-      fileMatch: [
-        '^roles/asdf/defaults/main\\.yml$',
-      ],
+      customType: "regex",
+      fileMatch: ["roles/asdf/defaults/main\\.yml"],
       matchStrings: [
-        '- name:\\s*golang\\s+version:\\s"(?<currentValue>[0-9.]+)"'
+        "- name:\\s*golang\\s+version:\\s*\"(?<currentValue>[0-9.]+)\""
       ],
-      datasourceTemplate: 'golang-version',
-      depNameTemplate: 'golang',
+      datasourceTemplate: "github-tags",
+      depNameTemplate: "golang/go",
+      extractVersionTemplate: "^go(?<version>.*)$"
     },
     {
       customType: 'regex',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -70,9 +70,8 @@
       matchStrings: [
         'name: (?<depName>golang)\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
-      datasourceTemplate: 'github-tags',
-      depNameTemplate: 'golang/go',
-      extractVersionTemplate: '^go(?<version>.*)$',
+      datasourceTemplate: 'golang-version',
+      depNameTemplate: 'golang',
       versioningTemplate: 'semver',
     },
     {
@@ -83,9 +82,8 @@
       matchStrings: [
         'name: (?<depName>python)\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
-      datasourceTemplate: 'github-tags',
+      datasourceTemplate: 'github-releases',
       depNameTemplate: 'python/cpython',
-      extractVersionTemplate: '^v(?<version>.*)$',
       versioningTemplate: 'semver',
     },
     {
@@ -96,9 +94,8 @@
       matchStrings: [
         'name: (?<depName>kubectl)\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
-      datasourceTemplate: 'github-tags',
+      datasourceTemplate: 'github-releases',
       depNameTemplate: 'kubernetes/kubernetes',
-      extractVersionTemplate: '^v(?<version>.*)$',
       versioningTemplate: 'semver',
     },
     {
@@ -109,9 +106,8 @@
       matchStrings: [
         'name: (?<depName>packer)\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
-      datasourceTemplate: 'github-tags',
+      datasourceTemplate: 'github-releases',
       depNameTemplate: 'hashicorp/packer',
-      extractVersionTemplate: '^v(?<version>.*)$',
       versioningTemplate: 'semver',
     },
     {
@@ -122,9 +118,8 @@
       matchStrings: [
         'name: (?<depName>ruby)\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
-      datasourceTemplate: 'github-tags',
+      datasourceTemplate: 'github-releases',
       depNameTemplate: 'ruby/ruby',
-      extractVersionTemplate: '^v(\\d+)_(\\d+)_(\\d+)$',
       versioningTemplate: 'semver',
     },
     {
@@ -135,9 +130,8 @@
       matchStrings: [
         'name: (?<depName>helm)\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
-      datasourceTemplate: 'github-tags',
+      datasourceTemplate: 'github-releases',
       depNameTemplate: 'helm/helm',
-      extractVersionTemplate: '^v(?<version>.*)$',
       versioningTemplate: 'semver',
     },
   ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -56,9 +56,8 @@
       matchStrings: [
         '- name: golang\\n\\s+version: "(?<currentValue>[0-9.]+)"'
       ],
-      datasourceTemplate: 'go-version',
-      depNameTemplate: 'golang/go',
-      versioningTemplate: 'semver'
+      datasourceTemplate: 'golang-version',
+      depNameTemplate: 'golang',
     },
     {
       customType: 'regex',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -61,9 +61,8 @@
       groupName: 'ansible-dependencies',
     },
   ],
-  customManagers: [
+  regexManagers: [
     {
-      customType: 'regex',
       fileMatch: [
         '^roles/asdf/defaults/main\\.yml$',
       ],
@@ -74,7 +73,6 @@
       depNameTemplate: 'golang',
     },
     {
-      customType: 'regex',
       fileMatch: [
         '^roles/asdf/defaults/main\\.yml$',
       ],
@@ -86,7 +84,6 @@
       extractVersionTemplate: '^v(?<version>.*)$',
     },
     {
-      customType: 'regex',
       fileMatch: [
         '^roles/asdf/defaults/main\\.yml$',
       ],
@@ -97,7 +94,6 @@
       depNameTemplate: 'kubernetes/kubernetes',
     },
     {
-      customType: 'regex',
       fileMatch: [
         '^roles/asdf/defaults/main\\.yml$',
       ],
@@ -108,7 +104,6 @@
       depNameTemplate: 'hashicorp/packer',
     },
     {
-      customType: 'regex',
       fileMatch: [
         '^roles/asdf/defaults/main\\.yml$',
       ],
@@ -121,7 +116,6 @@
       versioningTemplate: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$',
     },
     {
-      customType: 'regex',
       fileMatch: [
         '^roles/asdf/defaults/main\\.yml$',
       ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -54,7 +54,7 @@
         '^roles/asdf/defaults/main\\.yml$',
       ],
       matchStrings: [
-        '- name: golang\\n\\s+version: "(?<currentValue>[0-9.]+)"'
+        '- name:\\s*golang\\s+version:\\s"(?<currentValue>[0-9.]+)"'
       ],
       datasourceTemplate: 'golang-version',
       depNameTemplate: 'golang',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,60 +1,53 @@
 {
-  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  gitAuthor: 'cowdogmoo-renovate-bot <157187596+cowdogmoo-renovate-bot[bot]@users.noreply.github.com>',
-  extends: [
-    'config:recommended',
-    'docker:enableMajor',
-    ':disableRateLimiting',
-    ':dependencyDashboard',
-    ':semanticCommits',
-    ':enablePreCommit',
-    ':automergeDigest',
-    'helpers:pinGitHubActionDigests',
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "gitAuthor": "cowdogmoo-renovate-bot <157187596+cowdogmoo-renovate-bot[bot]@users.noreply.github.com>",
+  "extends": [
+    "config:recommended",
+    "docker:enableMajor",
+    ":disableRateLimiting",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":enablePreCommit",
+    ":automergeDigest",
+    "helpers:pinGitHubActionDigests"
   ],
-  dependencyDashboardLabels: [
-    'renovate-dashboard',
-  ],
-  dependencyDashboardTitle: 'Renovate Dashboard 🤖',
-  suppressNotifications: [
-    'prIgnoreNotification',
-  ],
-  rebaseWhen: 'conflicted',
-  commitBodyTable: true,
-  labels: [
-    'renovate',
-  ],
-  'pre-commit': {
-    enabled: true,
-  },
-  packageRules: [
+  "dependencyDashboardLabels": ["renovate-dashboard"],
+  "dependencyDashboardTitle": "Renovate Dashboard 🤖",
+  "suppressNotifications": ["prIgnoreNotification"],
+  "rebaseWhen": "conflicted",
+  "commitBodyTable": true,
+  "labels": ["renovate"],
+  "pre-commit": {"enabled": true},
+  "packageRules": [
     {
-      description: 'Auto merge Galaxy dependencies',
-      matchManagers: ['ansible-galaxy'],  
-      automerge: true,
-      automergeType: 'pr',
-      matchUpdateTypes: ['minor', 'patch'],  
+      "description": "Auto merge Galaxy dependencies",
+      "matchManagers": ["ansible-galaxy"],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["minor", "patch"]
     },
     {
-      description: 'Auto-merge GitHub Actions',
-      matchManagers: ['github-actions'],
-      automerge: true,
-      automergeType: 'pr',
-      matchUpdateTypes: ['minor', 'patch'],
+      "description": "Auto-merge GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["minor", "patch"]
     },
     {
-      description: 'Group Ansible Galaxy dependencies',
-      matchManagers: ['ansible-galaxy'],
-      groupName: 'ansible-dependencies',
-    },
+      "description": "Group Ansible Galaxy dependencies",
+      "matchManagers": ["ansible-galaxy"],
+      "groupName": "ansible-dependencies"
+    }
   ],
-  customManagers: [
+  "customManagers": [
     {
-      customType: "regex",
-      description: "Update asdf plugin versions",
-      fileMatch: ["roles/asdf/defaults/main\\.yml"],
-      matchStrings: [
-        "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>[\\w-]+?))?(?: packageName=(?<packageName>[\\w-/]+?))?(?: extractVersion=(?<extractVersion>.+?))?\\s*\\n\\s*-\\s*name:\\s*[\\w-]+\\s*\\n\\s*version:\\s*\"(?<currentValue>[0-9.]+)\""
+      "customType": "regex",
+      "description": "Update asdf plugin versions",
+      "managerFilePatterns": ["/^roles\\/asdf\\/defaults\\/main\\.yml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[\\w-]+)(?: packageName=(?<packageName>[\\w-/]+))?\\s*\\n\\s*-\\s*name:\\s*[\\w-]+\\s*\\n\\s*version:\\s*\"(?<currentValue>[0-9.]+)\""
       ],
-    },
-  ],
+      "extractVersionTemplate": "{{#if (equals depName 'golang')}}^go(?<version>.*)${{else if (equals depName 'kubectl')}}^v(?<version>.*)${{else if (equals depName 'helm')}}^v(?<version>.*)${{else if (equals depName 'packer')}}^v(?<version>.*)${{else if (equals depName 'python')}}^v(?<version>.*)${{else}}^v?(?<version>.*)${{/if}}"
+    }
+  ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -56,7 +56,8 @@
       ],
       datasourceTemplate: "github-tags",
       depNameTemplate: "golang/go",
-      extractVersionTemplate: "^go(?<version>.*)$"
+      extractVersionTemplate: "^go(.+)$",
+      versioningTemplate: "semver"
     },
     {
       customType: 'regex',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -124,7 +124,7 @@
       ],
       datasourceTemplate: 'github-tags',
       depNameTemplate: 'ruby/ruby',
-      extractVersionTemplate: '^v(?<version>.*)$',
+      extractVersionTemplate: '^v(\\d+)_(\\d+)_(\\d+)$',
       versioningTemplate: 'semver',
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -62,7 +62,7 @@
     },
   ],
   ansible: {
-    managerFilePatterns: [
+    fileMatch: [
       '/^requirements\\.yml$/',
       '/^roles/[^/]+/meta/main\\.yml$/',
       '/^galaxy\\.yml$/',
@@ -71,7 +71,7 @@
   customManagers: [
     {
       customType: 'regex',
-      managerFilePatterns: [
+      fileMatch: [
         '/(^|/)requirements\\.ya?ml$/',
         '/(^|/)galaxy\\.ya?ml$/',
       ],
@@ -82,7 +82,7 @@
     },
     {
       customType: 'regex',
-      managerFilePatterns: [
+      fileMatch: [
         '/^roles/asdf/defaults/main\\.yml$/',
       ],
       matchStrings: [
@@ -94,7 +94,7 @@
     },
     {
       customType: 'regex',
-      managerFilePatterns: [
+      fileMatch: [
         '/^roles/asdf/defaults/main\\.yml$/',
       ],
       matchStrings: [
@@ -106,7 +106,7 @@
     },
     {
       customType: 'regex',
-      managerFilePatterns: [
+      fileMatch: [
         '/^roles/asdf/defaults/main\\.yml$/',
       ],
       matchStrings: [
@@ -118,7 +118,7 @@
     },
     {
       customType: 'regex',
-      managerFilePatterns: [
+      fileMatch: [
         '/^roles/asdf/defaults/main\\.yml$/',
       ],
       matchStrings: [
@@ -130,7 +130,7 @@
     },
     {
       customType: 'regex',
-      managerFilePatterns: [
+      fileMatch: [
         '/^roles/asdf/defaults/main\\.yml$/',
       ],
       matchStrings: [
@@ -142,7 +142,7 @@
     },
     {
       customType: 'regex',
-      managerFilePatterns: [
+      fileMatch: [
         '/^roles/asdf/defaults/main\\.yml$/',
       ],
       matchStrings: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -56,9 +56,9 @@
       matchStrings: [
         '- name: golang\\n\\s+version: "(?<currentValue>[0-9.]+)"'
       ],
-      datasourceTemplate: 'golang-version',
+      datasourceTemplate: 'github-tags',
       depNameTemplate: 'golang/go',
-      versioningTemplate: 'semver'
+      extractVersionTemplate: '^go(?<version>.*)$',
     },
     {
       customType: 'regex',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -61,18 +61,21 @@
       groupName: 'ansible-dependencies',
     },
   ],
-  regexManagers: [
+  customManagers: [
     {
+      customType: 'regex',
       fileMatch: [
-        '^roles/asdf/defaults/main\\.yml$',
+        'roles/asdf/defaults/main.yml',
       ],
       matchStrings: [
-        'name: golang\\s+version: "(?<currentValue>[0-9.]+)"',
+        "-\\s*name:\\s*golang[\\s\\S]*?\\bversion:\\s*['\\\"]?(?<currentValue>\\d+\\.\\d+\\.\\d+)['\\\"]?"
       ],
       datasourceTemplate: 'golang-version',
-      depNameTemplate: 'golang',
+      depNameTemplate: 'golang/go',
+      versioningTemplate: 'semver'
     },
     {
+      customType: 'regex',
       fileMatch: [
         '^roles/asdf/defaults/main\\.yml$',
       ],
@@ -84,6 +87,7 @@
       extractVersionTemplate: '^v(?<version>.*)$',
     },
     {
+      customType: 'regex',
       fileMatch: [
         '^roles/asdf/defaults/main\\.yml$',
       ],
@@ -94,6 +98,7 @@
       depNameTemplate: 'kubernetes/kubernetes',
     },
     {
+      customType: 'regex',
       fileMatch: [
         '^roles/asdf/defaults/main\\.yml$',
       ],
@@ -104,6 +109,7 @@
       depNameTemplate: 'hashicorp/packer',
     },
     {
+      customType: 'regex',
       fileMatch: [
         '^roles/asdf/defaults/main\\.yml$',
       ],
@@ -116,6 +122,7 @@
       versioningTemplate: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$',
     },
     {
+      customType: 'regex',
       fileMatch: [
         '^roles/asdf/defaults/main\\.yml$',
       ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -47,7 +47,6 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[\\w-]+)(?: packageName=(?<packageName>[\\w-/]+))?\\s*\\n\\s*-\\s*name:\\s*[\\w-]+\\s*\\n\\s*version:\\s*\"(?<currentValue>[0-9.]+)\""
       ],
-      "extractVersionTemplate": "{{#if (equals depName 'golang')}}^go(?<version>.*)${{else if (equals depName 'kubectl')}}^v(?<version>.*)${{else if (equals depName 'helm')}}^v(?<version>.*)${{else if (equals depName 'packer')}}^v(?<version>.*)${{else if (equals depName 'python')}}^v(?<version>.*)${{else}}^v?(?<version>.*)${{/if}}"
     }
   ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -68,10 +68,10 @@
         '^roles/asdf/defaults/main\\.yml$',
       ],
       matchStrings: [
-        'name: (?<depName>golang)\\s+version: "(?<currentValue>[0-9.]+)"',
+        'name: golang\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
-      depNameTemplate: 'golang/go',
-      datasourceTemplate: 'github-releases',
+      datasourceTemplate: 'golang-version',
+      depNameTemplate: 'golang',
     },
     {
       customType: 'regex',
@@ -79,10 +79,11 @@
         '^roles/asdf/defaults/main\\.yml$',
       ],
       matchStrings: [
-        'name: (?<depName>python)\\s+version: "(?<currentValue>[0-9.]+)"',
+        'name: python\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
+      datasourceTemplate: 'github-tags',
       depNameTemplate: 'python/cpython',
-      datasourceTemplate: 'github-releases',
+      extractVersionTemplate: '^v(?<version>.*)$',
     },
     {
       customType: 'regex',
@@ -90,10 +91,10 @@
         '^roles/asdf/defaults/main\\.yml$',
       ],
       matchStrings: [
-        'name: (?<depName>kubectl)\\s+version: "(?<currentValue>[0-9.]+)"',
+        'name: kubectl\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
+      datasourceTemplate: 'github-releases',
       depNameTemplate: 'kubernetes/kubernetes',
-      datasourceTemplate: 'github-releases',
     },
     {
       customType: 'regex',
@@ -101,10 +102,10 @@
         '^roles/asdf/defaults/main\\.yml$',
       ],
       matchStrings: [
-        'name: (?<depName>packer)\\s+version: "(?<currentValue>[0-9.]+)"',
+        'name: packer\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
+      datasourceTemplate: 'github-releases',
       depNameTemplate: 'hashicorp/packer',
-      datasourceTemplate: 'github-releases',
     },
     {
       customType: 'regex',
@@ -112,10 +113,12 @@
         '^roles/asdf/defaults/main\\.yml$',
       ],
       matchStrings: [
-        'name: (?<depName>ruby)\\s+version: "(?<currentValue>[0-9.]+)"',
+        'name: ruby\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
+      datasourceTemplate: 'github-tags',
       depNameTemplate: 'ruby/ruby',
-      datasourceTemplate: 'github-releases',
+      extractVersionTemplate: '^v(\\d+)_(\\d+)_(\\d+)$',
+      versioningTemplate: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$',
     },
     {
       customType: 'regex',
@@ -123,10 +126,10 @@
         '^roles/asdf/defaults/main\\.yml$',
       ],
       matchStrings: [
-        'name: (?<depName>helm)\\s+version: "(?<currentValue>[0-9.]+)"',
+        'name: helm\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
-      depNameTemplate: 'helm/helm',
       datasourceTemplate: 'github-releases',
+      depNameTemplate: 'helm/helm',
     },
   ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -70,8 +70,9 @@
       matchStrings: [
         'name: (?<depName>golang)\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
-      datasourceTemplate: 'golang-version',
-      depNameTemplate: 'golang',
+      datasourceTemplate: 'github-tags',
+      packageNameTemplate: 'golang/go',
+      extractVersionTemplate: '^go(?<version>.*)$',
       versioningTemplate: 'semver',
     },
     {
@@ -82,8 +83,9 @@
       matchStrings: [
         'name: (?<depName>python)\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
-      datasourceTemplate: 'github-releases',
-      depNameTemplate: 'python/cpython',
+      datasourceTemplate: 'github-tags',
+      packageNameTemplate: 'python/cpython',
+      extractVersionTemplate: '^v(?<version>.*)$',
       versioningTemplate: 'semver',
     },
     {
@@ -94,8 +96,9 @@
       matchStrings: [
         'name: (?<depName>kubectl)\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
-      datasourceTemplate: 'github-releases',
-      depNameTemplate: 'kubernetes/kubernetes',
+      datasourceTemplate: 'github-tags',
+      packageNameTemplate: 'kubernetes/kubernetes',
+      extractVersionTemplate: '^v(?<version>.*)$',
       versioningTemplate: 'semver',
     },
     {
@@ -106,8 +109,9 @@
       matchStrings: [
         'name: (?<depName>packer)\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
-      datasourceTemplate: 'github-releases',
-      depNameTemplate: 'hashicorp/packer',
+      datasourceTemplate: 'github-tags',
+      packageNameTemplate: 'hashicorp/packer',
+      extractVersionTemplate: '^v(?<version>.*)$',
       versioningTemplate: 'semver',
     },
     {
@@ -118,9 +122,10 @@
       matchStrings: [
         'name: (?<depName>ruby)\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
-      datasourceTemplate: 'github-releases',
-      depNameTemplate: 'ruby/ruby',
-      versioningTemplate: 'semver',
+      datasourceTemplate: 'github-tags',
+      packageNameTemplate: 'ruby/ruby',
+      extractVersionTemplate: '^v(\\d+)_(\\d+)_(\\d+)$',
+      versioningTemplate: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$',
     },
     {
       customType: 'regex',
@@ -130,8 +135,9 @@
       matchStrings: [
         'name: (?<depName>helm)\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
-      datasourceTemplate: 'github-releases',
-      depNameTemplate: 'helm/helm',
+      datasourceTemplate: 'github-tags',
+      packageNameTemplate: 'helm/helm',
+      extractVersionTemplate: '^v(?<version>.*)$',
       versioningTemplate: 'semver',
     },
   ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,9 +29,7 @@
   packageRules: [
     {
       description: 'Auto merge Galaxy dependencies',
-      matchDatasources: [
-        'galaxy',
-      ],
+      matchDatasources: ['galaxy'],
       automerge: true,
       automergeType: 'pr',
       matchUpdateTypes: [
@@ -40,12 +38,8 @@
     },
     {
       description: 'Auto-merge GitHub Actions',
-      matchManagers: [
-        'github-actions',
-      ],
-      matchDatasources: [
-        'github-tags',
-      ],
+      matchManagers: ['github-actions'],
+      matchDatasources: ['github-tags'],
       automerge: true,
       automergeType: 'pr',
       matchUpdateTypes: [
@@ -55,11 +49,19 @@
     },
     {
       description: 'Group Ansible Galaxy dependencies',
-      matchManagers: [
-        'ansible-galaxy',
-      ],
+      matchManagers: ['ansible-galaxy'],
       groupName: 'ansible-dependencies',
     },
+    {
+      description: 'Auto-merge golang updates',
+      matchDepNames: ['golang/go'],
+      automerge: true,
+      automergeType: 'pr',
+      matchUpdateTypes: [
+        'minor',
+        'patch',
+      ],
+    }
   ],
   customManagers: [
     {
@@ -68,7 +70,7 @@
         'roles/asdf/defaults/main.yml',
       ],
       matchStrings: [
-        "-\\s*name:\\s*golang[\\s\\S]*?\\bversion:\\s*['\\\"]?(?<currentValue>\\d+\\.\\d+\\.\\d+)['\\\"]?"
+        "- name: golang\\s+version: [\"']?(?<currentValue>\\d+\\.\\d+\\.\\d+)[\"']?"
       ],
       datasourceTemplate: 'golang-version',
       depNameTemplate: 'golang/go',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -58,7 +58,6 @@
       ],
       datasourceTemplate: 'github-tags',
       depNameTemplate: 'golang/go',
-      extractVersionTemplate: '^go(?<version>.*)$',
     },
     {
       customType: 'regex',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,81 +52,10 @@
       customType: "regex",
       fileMatch: ["roles/asdf/defaults/main\\.yml"],
       matchStrings: [
-        "- name:\\s*golang\\s+version:\\s*\"(?<currentValue>[0-9.]+)\""
+        "-\\s*name:\\s*golang\\s*\\n\\s*version:\\s*\"(?<currentValue>[0-9.]+)\""
       ],
-      datasourceTemplate: "github-tags",
+      datasourceTemplate: 'golang-version',
       depNameTemplate: "golang/go",
-      extractVersionTemplate: "^go(.+)$",
-      versioningTemplate: "semver"
-    },
-    {
-      customType: 'regex',
-      fileMatch: [
-        '^roles/asdf/defaults/main\\.yml$',
-      ],
-      matchStrings: [
-        '- name: python\\n\\s+version: "(?<currentValue>[0-9.]+)"'
-      ],
-      datasourceTemplate: 'github-tags',
-      depNameTemplate: 'python/cpython',
-      extractVersionTemplate: '^v(?<version>.*)$',
-    },
-    {
-      customType: 'regex',
-      fileMatch: [
-        '^roles/asdf/defaults/main\\.yml$',
-      ],
-      matchStrings: [
-        '- name: kubectl\\n\\s+version: "(?<currentValue>[0-9.]+)"'
-      ],
-      datasourceTemplate: 'github-releases',
-      depNameTemplate: 'kubernetes/kubernetes',
-    },
-    {
-      customType: 'regex',
-      fileMatch: [
-        '^roles/asdf/defaults/main\\.yml$',
-      ],
-      matchStrings: [
-        '- name: packer\\n\\s+version: "(?<currentValue>[0-9.]+)"'
-      ],
-      datasourceTemplate: 'github-releases',
-      depNameTemplate: 'hashicorp/packer',
-    },
-    {
-      customType: 'regex',
-      fileMatch: [
-        '^roles/asdf/defaults/main\\.yml$',
-      ],
-      matchStrings: [
-        '- name: ruby\\n\\s+version: "(?<currentValue>[0-9.]+)"'
-      ],
-      datasourceTemplate: 'github-tags',
-      depNameTemplate: 'ruby/ruby',
-      extractVersionTemplate: '^v(?<major>\\d+)_(?<minor>\\d+)_(?<patch>\\d+)$',
-    },
-    {
-      customType: 'regex',
-      fileMatch: [
-        '^roles/asdf/defaults/main\\.yml$',
-      ],
-      matchStrings: [
-        '- name: helm\\n\\s+version: "(?<currentValue>[0-9.]+)"'
-      ],
-      datasourceTemplate: 'github-releases',
-      depNameTemplate: 'helm/helm',
-    },
-    {
-      customType: 'regex',
-      fileMatch: [
-        '^roles/asdf/defaults/main\\.yml$',
-      ],
-      matchStrings: [
-        '- name: awscli\\n\\s+version: "(?<currentValue>[0-9.]+)"'
-      ],
-      datasourceTemplate: 'github-tags',
-      depNameTemplate: 'aws/aws-cli',
-      extractVersionTemplate: '^(?<version>.*)$',  
     },
   ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -65,80 +65,68 @@
     {
       customType: 'regex',
       fileMatch: [
-        '/^roles/asdf/defaults/main\\.yml$/',
+        '^roles/asdf/defaults/main\\.yml$',
       ],
       matchStrings: [
         'name: (?<depName>golang)\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
-      datasourceTemplate: 'github-tags',
-      packageNameTemplate: 'golang/go',
-      extractVersionTemplate: '^go(?<version>.*)$',
-      versioningTemplate: 'semver',
+      depNameTemplate: 'golang/go',
+      datasourceTemplate: 'github-releases',
     },
     {
       customType: 'regex',
       fileMatch: [
-        '/^roles/asdf/defaults/main\\.yml$/',
+        '^roles/asdf/defaults/main\\.yml$',
       ],
       matchStrings: [
         'name: (?<depName>python)\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
-      datasourceTemplate: 'github-tags',
-      packageNameTemplate: 'python/cpython',
-      extractVersionTemplate: '^v(?<version>.*)$',
-      versioningTemplate: 'semver',
+      depNameTemplate: 'python/cpython',
+      datasourceTemplate: 'github-releases',
     },
     {
       customType: 'regex',
       fileMatch: [
-        '/^roles/asdf/defaults/main\\.yml$/',
+        '^roles/asdf/defaults/main\\.yml$',
       ],
       matchStrings: [
         'name: (?<depName>kubectl)\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
-      datasourceTemplate: 'github-tags',
-      packageNameTemplate: 'kubernetes/kubernetes',
-      extractVersionTemplate: '^v(?<version>.*)$',
-      versioningTemplate: 'semver',
+      depNameTemplate: 'kubernetes/kubernetes',
+      datasourceTemplate: 'github-releases',
     },
     {
       customType: 'regex',
       fileMatch: [
-        '/^roles/asdf/defaults/main\\.yml$/',
+        '^roles/asdf/defaults/main\\.yml$',
       ],
       matchStrings: [
         'name: (?<depName>packer)\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
-      datasourceTemplate: 'github-tags',
-      packageNameTemplate: 'hashicorp/packer',
-      extractVersionTemplate: '^v(?<version>.*)$',
-      versioningTemplate: 'semver',
+      depNameTemplate: 'hashicorp/packer',
+      datasourceTemplate: 'github-releases',
     },
     {
       customType: 'regex',
       fileMatch: [
-        '/^roles/asdf/defaults/main\\.yml$/',
+        '^roles/asdf/defaults/main\\.yml$',
       ],
       matchStrings: [
         'name: (?<depName>ruby)\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
-      datasourceTemplate: 'github-tags',
-      packageNameTemplate: 'ruby/ruby',
-      extractVersionTemplate: '^v(\\d+)_(\\d+)_(\\d+)$',
-      versioningTemplate: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$',
+      depNameTemplate: 'ruby/ruby',
+      datasourceTemplate: 'github-releases',
     },
     {
       customType: 'regex',
       fileMatch: [
-        '/^roles/asdf/defaults/main\\.yml$/',
+        '^roles/asdf/defaults/main\\.yml$',
       ],
       matchStrings: [
         'name: (?<depName>helm)\\s+version: "(?<currentValue>[0-9.]+)"',
       ],
-      datasourceTemplate: 'github-tags',
-      packageNameTemplate: 'helm/helm',
-      extractVersionTemplate: '^v(?<version>.*)$',
-      versioningTemplate: 'semver',
+      depNameTemplate: 'helm/helm',
+      datasourceTemplate: 'github-releases',
     },
   ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -72,6 +72,7 @@
       ],
       datasourceTemplate: 'github-tags',
       depNameTemplate: 'golang/go',
+      extractVersionTemplate: '^go(?<version>.*)$',
       versioningTemplate: 'semver',
     },
     {
@@ -84,6 +85,7 @@
       ],
       datasourceTemplate: 'github-tags',
       depNameTemplate: 'python/cpython',
+      extractVersionTemplate: '^v(?<version>.*)$',
       versioningTemplate: 'semver',
     },
     {
@@ -96,6 +98,7 @@
       ],
       datasourceTemplate: 'github-tags',
       depNameTemplate: 'kubernetes/kubernetes',
+      extractVersionTemplate: '^v(?<version>.*)$',
       versioningTemplate: 'semver',
     },
     {
@@ -108,6 +111,7 @@
       ],
       datasourceTemplate: 'github-tags',
       depNameTemplate: 'hashicorp/packer',
+      extractVersionTemplate: '^v(?<version>.*)$',
       versioningTemplate: 'semver',
     },
     {
@@ -120,6 +124,7 @@
       ],
       datasourceTemplate: 'github-tags',
       depNameTemplate: 'ruby/ruby',
+      extractVersionTemplate: '^v(?<version>.*)$',
       versioningTemplate: 'semver',
     },
     {
@@ -132,6 +137,7 @@
       ],
       datasourceTemplate: 'github-tags',
       depNameTemplate: 'helm/helm',
+      extractVersionTemplate: '^v(?<version>.*)$',
       versioningTemplate: 'semver',
     },
   ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,15 +29,14 @@
   packageRules: [
     {
       description: 'Auto merge Galaxy dependencies',
-      matchManagers: ['ansible-galaxy'],
+      matchManagers: ['ansible-galaxy'],  
       automerge: true,
       automergeType: 'pr',
-      matchUpdateTypes: ['minor', 'patch']
+      matchUpdateTypes: ['minor', 'patch'],  
     },
     {
       description: 'Auto-merge GitHub Actions',
       matchManagers: ['github-actions'],
-      matchDatasources: ['github-tags'],
       automerge: true,
       automergeType: 'pr',
       matchUpdateTypes: ['minor', 'patch'],
@@ -47,25 +46,15 @@
       matchManagers: ['ansible-galaxy'],
       groupName: 'ansible-dependencies',
     },
-    {
-      description: 'Auto-merge golang updates',
-      matchDepNames: ['golang/go'],
-      automerge: true,
-      automergeType: 'pr',
-      matchUpdateTypes: [
-        'minor',
-        'patch',
-      ],
-    }
   ],
   customManagers: [
     {
       customType: 'regex',
       fileMatch: [
-        'roles/asdf/defaults/main.yml',
+        '^roles/asdf/defaults/main\\.yml$',
       ],
       matchStrings: [
-        "- name: golang\\s+version: [\"']?(?<currentValue>\\d+\\.\\d+\\.\\d+)[\"']?"
+        '- name: golang\\n\\s+version: "(?<currentValue>[0-9.]+)"'
       ],
       datasourceTemplate: 'golang-version',
       depNameTemplate: 'golang/go',
@@ -77,7 +66,7 @@
         '^roles/asdf/defaults/main\\.yml$',
       ],
       matchStrings: [
-        'name: python\\s+version: "(?<currentValue>[0-9.]+)"',
+        '- name: python\\n\\s+version: "(?<currentValue>[0-9.]+)"'
       ],
       datasourceTemplate: 'github-tags',
       depNameTemplate: 'python/cpython',
@@ -89,7 +78,7 @@
         '^roles/asdf/defaults/main\\.yml$',
       ],
       matchStrings: [
-        'name: kubectl\\s+version: "(?<currentValue>[0-9.]+)"',
+        '- name: kubectl\\n\\s+version: "(?<currentValue>[0-9.]+)"'
       ],
       datasourceTemplate: 'github-releases',
       depNameTemplate: 'kubernetes/kubernetes',
@@ -100,7 +89,7 @@
         '^roles/asdf/defaults/main\\.yml$',
       ],
       matchStrings: [
-        'name: packer\\s+version: "(?<currentValue>[0-9.]+)"',
+        '- name: packer\\n\\s+version: "(?<currentValue>[0-9.]+)"'
       ],
       datasourceTemplate: 'github-releases',
       depNameTemplate: 'hashicorp/packer',
@@ -111,12 +100,11 @@
         '^roles/asdf/defaults/main\\.yml$',
       ],
       matchStrings: [
-        'name: ruby\\s+version: "(?<currentValue>[0-9.]+)"',
+        '- name: ruby\\n\\s+version: "(?<currentValue>[0-9.]+)"'
       ],
       datasourceTemplate: 'github-tags',
       depNameTemplate: 'ruby/ruby',
-      extractVersionTemplate: '^v(\\d+)_(\\d+)_(\\d+)$',
-      versioningTemplate: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$',
+      extractVersionTemplate: '^v(?<major>\\d+)_(?<minor>\\d+)_(?<patch>\\d+)$',
     },
     {
       customType: 'regex',
@@ -124,10 +112,22 @@
         '^roles/asdf/defaults/main\\.yml$',
       ],
       matchStrings: [
-        'name: helm\\s+version: "(?<currentValue>[0-9.]+)"',
+        '- name: helm\\n\\s+version: "(?<currentValue>[0-9.]+)"'
       ],
       datasourceTemplate: 'github-releases',
       depNameTemplate: 'helm/helm',
+    },
+    {
+      customType: 'regex',
+      fileMatch: [
+        '^roles/asdf/defaults/main\\.yml$',
+      ],
+      matchStrings: [
+        '- name: awscli\\n\\s+version: "(?<currentValue>[0-9.]+)"'
+      ],
+      datasourceTemplate: 'github-tags',
+      depNameTemplate: 'aws/aws-cli',
+      extractVersionTemplate: '^(?<version>.*)$',  
     },
   ],
 }

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ changelogs/.plugin-cache.yaml
 .task/
 .ansible
 *.tar.gz
+*.log

--- a/.hooks/requirements.txt
+++ b/.hooks/requirements.txt
@@ -1,7 +1,7 @@
-ansible-core
-docker
+ansible-core==10.5.0
+docker==7.1.0
 docsible==0.7.25
-molecule
-molecule-docker
-molecule-plugins[docker]
-pre-commit
+molecule==24.9.0
+molecule-docker==2.1.0
+molecule-plugins[docker]==23.5.3
+pre-commit==4.0.1

--- a/.hooks/requirements.txt
+++ b/.hooks/requirements.txt
@@ -1,7 +1,7 @@
-ansible-core==10.5.0
+ansible-core==2.18.8
 docker==7.1.0
 docsible==0.7.25
-molecule==24.9.0
+molecule==25.7.0
 molecule-docker==2.1.0
-molecule-plugins[docker]==23.5.3
-pre-commit==4.0.1
+molecule-plugins[docker]==25.8.12
+pre-commit==4.3.0

--- a/roles/asdf/defaults/main.yml
+++ b/roles/asdf/defaults/main.yml
@@ -19,7 +19,7 @@ asdf_shell: "{{ '/bin/zsh' if ansible_distribution == 'MacOSX' else '/bin/bash' 
 asdf_plugins:
   # renovate: datasource=github-tags depName=golang packageName=golang/go
   - name: golang
-    version: "1.22.0"
+    version: "1.25.0"
     scope: "global"
   # renovate: datasource=github-tags depName=python packageName=python/cpython
   - name: python

--- a/roles/asdf/defaults/main.yml
+++ b/roles/asdf/defaults/main.yml
@@ -17,31 +17,31 @@ asdf_shells:
 asdf_shell: "{{ '/bin/zsh' if ansible_distribution == 'MacOSX' else '/bin/bash' }}"
 
 asdf_plugins:
-  # renovate: datasource=github-tags depName=golang packageName=golang/go extractVersion=^go(?<version>.*)$
+  # renovate: datasource=github-tags depName=golang packageName=golang/go
   - name: golang
-    version: "1.25.0"
+    version: "1.22.0"
     scope: "global"
-  # renovate: datasource=github-tags depName=python packageName=python/cpython extractVersion=^v(?<version>.*)$
+  # renovate: datasource=github-tags depName=python packageName=python/cpython
   - name: python
     version: "3.13.7"
     scope: "global"
-  # renovate: datasource=ruby-version depName=ruby
+  # renovate: datasource=ruby-version depName=ruby packageName=ruby/ruby
   - name: ruby
     version: "3.4.5"
     scope: "global"
-  # renovate: datasource=github-releases depName=helm packageName=helm/helm extractVersion=^v(?<version>.*)$
+  # renovate: datasource=github-releases depName=helm packageName=helm/helm
   - name: helm
     version: "3.18.6"
     scope: "global"
-  # renovate: datasource=github-tags depName=kubectl packageName=kubernetes/kubernetes extractVersion=^v(?<version>.*)$
+  # renovate: datasource=github-tags depName=kubectl packageName=kubernetes/kubernetes
   - name: kubectl
     version: "1.34.0"
     scope: "global"
-  # renovate: datasource=github-releases depName=packer packageName=hashicorp/packer extractVersion=^v(?<version>.*)$
+  # renovate: datasource=github-releases depName=packer packageName=hashicorp/packer
   - name: packer
     version: "1.14.1"
     scope: "global"
-  # renovate: datasource=github-releases depName=awscli packageName=aws/aws-cli extractVersion=^(?<version>.*)$
+  # renovate: datasource=github-releases depName=awscli packageName=aws/aws-cli
   - name: awscli
     version: "2.28.22"
     scope: "global"

--- a/roles/asdf/defaults/main.yml
+++ b/roles/asdf/defaults/main.yml
@@ -17,6 +17,7 @@ asdf_shells:
 asdf_shell: "{{ '/bin/zsh' if ansible_distribution == 'MacOSX' else '/bin/bash' }}"
 
 asdf_plugins:
+  # renovate: datasource=golang-version depName=golang
   - name: golang
     version: "1.25.0"
     scope: "global"

--- a/roles/asdf/defaults/main.yml
+++ b/roles/asdf/defaults/main.yml
@@ -17,24 +17,31 @@ asdf_shells:
 asdf_shell: "{{ '/bin/zsh' if ansible_distribution == 'MacOSX' else '/bin/bash' }}"
 
 asdf_plugins:
+  # renovate: datasource=github-tags depName=golang packageName=golang/go extractVersion=^go(?<version>.*)$
   - name: golang
     version: "1.25.0"
     scope: "global"
+  # renovate: datasource=github-tags depName=python packageName=python/cpython extractVersion=^v(?<version>.*)$
   - name: python
     version: "3.13.7"
     scope: "global"
+  # renovate: datasource=ruby-version depName=ruby
   - name: ruby
     version: "3.4.5"
     scope: "global"
+  # renovate: datasource=github-releases depName=helm packageName=helm/helm extractVersion=^v(?<version>.*)$
   - name: helm
     version: "3.18.6"
     scope: "global"
+  # renovate: datasource=github-tags depName=kubectl packageName=kubernetes/kubernetes extractVersion=^v(?<version>.*)$
   - name: kubectl
     version: "1.34.0"
     scope: "global"
+  # renovate: datasource=github-releases depName=packer packageName=hashicorp/packer extractVersion=^v(?<version>.*)$
   - name: packer
     version: "1.14.1"
     scope: "global"
+  # renovate: datasource=github-releases depName=awscli packageName=aws/aws-cli extractVersion=^(?<version>.*)$
   - name: awscli
     version: "2.28.22"
     scope: "global"

--- a/roles/asdf/defaults/main.yml
+++ b/roles/asdf/defaults/main.yml
@@ -17,7 +17,6 @@ asdf_shells:
 asdf_shell: "{{ '/bin/zsh' if ansible_distribution == 'MacOSX' else '/bin/bash' }}"
 
 asdf_plugins:
-  # renovate: datasource=golang-version depName=golang
   - name: golang
     version: "1.25.0"
     scope: "global"

--- a/roles/logging/molecule/default/requirements.yml
+++ b/roles/logging/molecule/default/requirements.yml
@@ -1,3 +1,4 @@
 ---
 collections:
   - name: community.general
+    version: 11.2.1


### PR DESCRIPTION
**Key Changes:**

- Improved Renovate configuration for clarity and flexibility.
- Locked Python dependency versions in `.hooks/requirements.txt`.
- Added version to `community.general` in logging role requirements.
- Updated asdf plugin definitions to support automated updates.

**Added:**

- Renovate labels and PR notification suppression.
- Renovate dashboard title and better auto-merge rules.
- Renovate package rules for Ansible Galaxy and GitHub Actions.
- Regex-based Renovate custom manager for asdf plugins.
- Renovate comments to asdf plugin list for future automation.
- `.log` extension to `.gitignore`.

**Changed:**

- All config in `.github/renovate.json5` now uses JSON5 syntax.
- `pre-commit`, molecule, and docker dependencies in `.hooks/requirements.txt`
  now pinned to specific versions.
- Asdf plugin entries in `roles/asdf/defaults/main.yml` now annotated
  for Renovate bot compatibility.
- `.gitignore` expanded to exclude log files.

**Removed:**

- Old, unused Renovate custom managers and complex regex handlers.
- Extra Renovate manager patterns for deps replaced by a single dynamic regex.