### PR TITLE
feat: update asdf to 0.18.0 and improve plugin version handling

### DIFF
--- a/roles/asdf/README.md
+++ b/roles/asdf/README.md
@@ -43,7 +43,7 @@ Install asdf
 
 | Variable | Type | Value | Description |
 |----------|------|-------|-------------|
-| `asdf_version` | str | `0.16.7` | No description |
+| `asdf_version` | str | `0.18.0` | No description |
 | `asdf_arch` | str | `{{ 'arm64' if ansible_architecture in ['aarch64', 'arm64'] else 'amd64' if ansible_architecture == 'x86_64' else '386' }}` | No description |
 | `asdf_os` | str | `{{ 'darwin' if ansible_system == 'Darwin' else 'linux' }}` | No description |
 | `asdf_download_url` | str | `https://github.com/asdf-vm/asdf/releases/download/v{{ asdf_version }}/asdf-v{{ asdf_version }}-{{ asdf_os }}-{{ asdf_arch }}.tar.gz` | No description |
@@ -71,7 +71,8 @@ Install asdf
 - **Set available shell fact** (ansible.builtin.set_fact)
 - **Create bin directory if it doesn't exist** (ansible.builtin.file)
 - **Fetch and install ASDF binary** (block)
-- **Fetch ASDF MD5 checksum** (ansible.builtin.get_url)
+- **Check if checksum file exists** (ansible.builtin.stat)
+- **Fetch ASDF MD5 checksum** (ansible.builtin.get_url) - Conditional
 - **Extract ASDF MD5 checksum** (ansible.builtin.command)
 - **Download ASDF binary** (ansible.builtin.get_url)
 - **Extract ASDF binary** (ansible.builtin.unarchive)

--- a/roles/asdf/defaults/main.yml
+++ b/roles/asdf/defaults/main.yml
@@ -27,7 +27,7 @@ asdf_plugins:
     scope: "global"
   # renovate: datasource=ruby-version depName=ruby packageName=ruby/ruby
   - name: ruby
-    version: "3.4.5"
+    version: "3.4.2"
     scope: "global"
   # renovate: datasource=github-releases depName=helm packageName=helm/helm extractVersion=^v(?<version>.*)$
   - name: helm

--- a/roles/asdf/tasks/main.yml
+++ b/roles/asdf/tasks/main.yml
@@ -33,11 +33,17 @@
 - name: Fetch and install ASDF binary
   become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
   block:
+    - name: Check if checksum file exists
+      ansible.builtin.stat:
+        path: "/tmp/asdf-{{ asdf_version }}-{{ asdf_os }}-{{ asdf_arch }}.tar.gz.md5"
+      register: asdf_checksum_file_stat
+
     - name: Fetch ASDF MD5 checksum
       ansible.builtin.get_url:
         url: "{{ asdf_checksum_url }}"
         dest: "/tmp/asdf-{{ asdf_version }}-{{ asdf_os }}-{{ asdf_arch }}.tar.gz.md5"
         mode: "0644"
+      when: not asdf_checksum_file_stat.stat.exists
 
     - name: Extract ASDF MD5 checksum
       ansible.builtin.command: "cat /tmp/asdf-{{ asdf_version }}-{{ asdf_os }}-{{ asdf_arch }}.tar.gz.md5"

--- a/roles/asdf/templates/install_asdf_plugins.sh.j2
+++ b/roles/asdf/templates/install_asdf_plugins.sh.j2
@@ -71,10 +71,10 @@ if [ "$needs_changes" = true ]; then
     # Set version based on scope
     if [ "{{ plugin.scope | default('global') }}" = "global" ]; then
         echo "Setting global {{ plugin.name }} version to {{ plugin.version | default('latest') }}"
-        asdf set --home {{ plugin.name }} {{ plugin.version | default('latest') }}
+        asdf set -u {{ plugin.name }} {{ plugin.version }}
     else
         echo "Setting local {{ plugin.name }} version to {{ plugin.version | default('latest') }}"
-        asdf set {{ plugin.name }} {{ plugin.version | default('latest') }}
+        asdf set {{ plugin.name }} {{ plugin.version }}
     fi
 
     # Reshim the plugin

--- a/roles/asdf/vars/main.yml
+++ b/roles/asdf/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-asdf_version: "0.16.7"
+asdf_version: "0.18.0"
 asdf_arch: "{{ 'arm64' if ansible_architecture in ['aarch64', 'arm64'] else 'amd64' if ansible_architecture == 'x86_64' else '386' }}"
 asdf_os: "{{ 'darwin' if ansible_system == 'Darwin' else 'linux' }}"
 asdf_download_url: "https://github.com/asdf-vm/asdf/releases/download/v{{ asdf_version }}/asdf-v{{ asdf_version }}-{{ asdf_os }}-{{ asdf_arch }}.tar.gz"


### PR DESCRIPTION
**Added:**

- Add step to check for existing checksum file before downloading in install tasks for efficiency

**Changed:**

- Update default asdf version to 0.18.0 in role variables and documentation
- Change default ruby plugin version from 3.4.5 to 3.4.2 for consistency
- Improve ASDF binary installation: check if checksum file exists before downloading to avoid unnecessary fetches
- Update install script to set plugin versions directly without using `default('latest')` to ensure explicit version setting

**Removed:**

- Remove redundant use of `default('latest')` when setting plugin versions in install script