### PR TITLE
docs: update commit and pr workflow instructions for clarity

### DIFF
--- a/roles/claude_code/files/CLAUDE.md
+++ b/roles/claude_code/files/CLAUDE.md
@@ -13,13 +13,11 @@
 
 ### Commits
 
-Always use fabric for commit messages:
+Always use `fabric_commit` for commit messages:
 
 ```bash
-git ds | fabric --pattern commit | git commit -F -
+fabric_commit
 ```
-
-**IMPORTANT**: Always remove code fences (```) from commit messages before committing. If a generated commit message contains code fences, strip them out completely.
 
 **NEVER EVER use --no-verify when committing or there will be dire consequences!**
 
@@ -54,7 +52,4 @@ The `fabric_pr` function should handle these automatically, but you must verify 
 
 ## Notes
 
-- `git ds` is an alias for `git diff --staged` (shows staged changes)
 - `git d main` shows the diff against the main branch
-- The fabric patterns will generate properly formatted commit messages and PR descriptions
-- Use `-F -` to read from stdin


### PR DESCRIPTION
**Key Changes:**

- Clarified commit workflow to explicitly use `fabric_commit`
- Removed outdated instructions about code fences and git aliases
- Simplified explanations to focus on current tooling and practices

**Changed:**

- Commit workflow documentation - Updated to instruct using `fabric_commit` instead of referencing a command pattern, and removed the step about stripping code fences from commit messages
- Additional notes section - Removed explanations about git aliases (`git ds`) and fabric usage patterns that are no longer relevant