### PR TITLE
fix: improve asdf plugin install error handling and cache key versioning

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -266,9 +266,9 @@ jobs:
           path: |
             /tmp/asdf-cache-ubuntu
             /tmp/asdf-cache-kali
-          key: ${{ runner.os }}-asdf-${{ hashFiles('**/roles/asdf/defaults/main.yml') }}
+          key: ${{ runner.os }}-asdf-v2-${{ hashFiles('**/roles/asdf/defaults/main.yml', '**/roles/asdf/templates/install_asdf_plugins.sh.j2') }}
           restore-keys: |
-            ${{ runner.os }}-asdf-
+            ${{ runner.os }}-asdf-v2-
 
       - name: Run molecule test
         working-directory: ${{ env.COLLECTION_PATH }}/${{ matrix.path }}
@@ -385,9 +385,9 @@ jobs:
           path: |
             /tmp/asdf-cache-ubuntu
             /tmp/asdf-cache-kali
-          key: ${{ runner.os }}-asdf-${{ hashFiles('**/roles/asdf/defaults/main.yml') }}
+          key: ${{ runner.os }}-asdf-v2-${{ hashFiles('**/roles/asdf/defaults/main.yml', '**/roles/asdf/templates/install_asdf_plugins.sh.j2') }}
           restore-keys: |
-            ${{ runner.os }}-asdf-
+            ${{ runner.os }}-asdf-v2-
 
       - name: Run molecule test
         working-directory: ${{ env.COLLECTION_PATH }}/${{ matrix.path }}
@@ -498,9 +498,9 @@ jobs:
           path: |
             /tmp/asdf-cache-ubuntu
             /tmp/asdf-cache-kali
-          key: ${{ runner.os }}-asdf-${{ hashFiles('**/roles/asdf/defaults/main.yml') }}
+          key: ${{ runner.os }}-asdf-v2-${{ hashFiles('**/roles/asdf/defaults/main.yml', '**/roles/asdf/templates/install_asdf_plugins.sh.j2') }}
           restore-keys: |
-            ${{ runner.os }}-asdf-
+            ${{ runner.os }}-asdf-v2-
 
       - name: Run molecule test
         working-directory: ${{ env.COLLECTION_PATH }}/${{ matrix.path }}

--- a/roles/asdf/templates/install_asdf_plugins.sh.j2
+++ b/roles/asdf/templates/install_asdf_plugins.sh.j2
@@ -51,7 +51,12 @@ install_version() {
 
     echo "Installing ${plugin} version ${version}"
     if ! asdf install "$plugin" "$version" > "$logfile" 2>&1; then
-        echo "WARNING: Failed to install ${plugin} ${version}, see ${logfile}" >&2
+        {
+            echo "ERROR: Failed to install ${plugin} ${version}"
+            echo "----- ${logfile} -----"
+            cat "$logfile" || true
+            echo "----- end ${logfile} -----"
+        } >&2
         return 1
     fi
     rm -f "$logfile"
@@ -74,11 +79,14 @@ if [ "$needs_changes" = true ]; then
     # Wait for all background installs to complete
     failed=0
     for job in $(jobs -p); do
-        wait "$job" || ((failed++))
+        if ! wait "$job"; then
+            failed=$((failed + 1))
+        fi
     done
 
     if [ "$failed" -gt 0 ]; then
-        echo "WARNING: ${failed} plugin install(s) had issues" >&2
+        echo "ERROR: ${failed} plugin install(s) failed (see logs above)" >&2
+        exit 1
     fi
 
     echo "CHANGED: Updates were applied"


### PR DESCRIPTION
**Key Changes:**

- Enhanced error logging for asdf plugin installation failures
- Updated GitHub Actions asdf cache keys to include template changes and versioning
- Improved job failure reporting and exit behavior on plugin install errors

**Changed:**

- Error handling in asdf plugin installation script now prints log file contents when a plugin install fails, providing more visibility into errors - roles/asdf/templates/install_asdf_plugins.sh.j2
- Failure summary in the install script now exits with an error if any plugin installs fail, and uses clearer messaging for failed installs - roles/asdf/templates/install_asdf_plugins.sh.j2
- GitHub Actions workflow asdf cache keys now include both the defaults file and the install script template in the hash, and use a new "v2" key prefix to prevent cache collisions after script changes - .github/workflows/molecule.yaml
- Restore key prefixes in the workflow updated to match the new cache key versioning - .github/workflows/molecule.yaml