### PR TITLE
refactor: restructure advanced hooks to use keyed dict with override support

### DIFF
--- a/playbooks/workstation/host_vars/ouroboros.yml
+++ b/playbooks/workstation/host_vars/ouroboros.yml
@@ -30,69 +30,9 @@ claude_code_mcp_servers:
     args:
       - stdio
 
-claude_code_advanced_hooks:
-  # Hook 1: Block commits/PRs with forbidden content (emojis/branding)
-  - event: PreToolUse
-    tool: Bash
-    type: command
-    command: |
-      python3 -c "
-      import json, sys
-
-      data = json.load(sys.stdin)
-      cmd = data.get('tool_input', {}).get('command', '')
-
-      forbidden = ['🤖', 'Generated with', 'Co-Authored-By: Claude', 'claude.com/claude-code']
-
-      msg = ''
-      if 'git commit' in cmd and '-m' in cmd and any(f in cmd for f in forbidden):
-          msg = '❌ BLOCKED: Forbidden content (emojis/branding)\\n\\n✅ Use ONLY fabric output\\nGenerate: git diff --staged | fabric --pattern commit'
-      elif 'gh pr create' in cmd and '--body' in cmd and any(f in cmd for f in forbidden):
-          msg = '❌ BLOCKED: Forbidden content (emojis/branding)\\n\\n✅ Use ONLY fabric output\\nGenerate: git diff main...HEAD | fabric --pattern pr'
-
-      if msg:
-          sys.stderr.write(msg + '\n')
-          sys.exit(2)
-      sys.exit(0)
-      "
-
-  # Hook 2: Block dangerous git flags that bypass safety checks
-  - event: PreToolUse
-    tool: Bash
-    type: command
-    command: |
-      python3 -c "
-      import json, sys, re
-
-      data = json.load(sys.stdin)
-      cmd = data.get('tool_input', {}).get('command', '')
-
-      if 'git' not in cmd:
-          sys.exit(0)
-
-      # Check for dangerous flags (long flags use simple 'in', short flags use regex)
-      dangerous_long = ['--no-verify', '--no-gpg-sign', '--no-post-rewrite']
-      blocked_flag = next((f for f in dangerous_long if f in cmd), None)
-
-      # Check for -n flag as standalone only in git commit commands
-      if not blocked_flag and 'git commit' in cmd and re.search(r'(^|\s)-n(\s|$)', cmd):
-          blocked_flag = '-n'
-
-      if blocked_flag:
-          msg = f'❌ BLOCKED: Cannot use {blocked_flag} flag.\\n\\nThis flag bypasses important safety checks.\\nFix the underlying issues instead.'
-          sys.stderr.write(msg + '\\n')
-          sys.exit(2)
-      sys.exit(0)
-      "
-
-  # Hook 3: Sound notification when Claude finishes a task
-  - event: Stop
-    tool: ""
-    type: command
+# Override only the bits that differ from the role defaults (see
+# roles/claude_code/defaults/main.yml for the full hook map). Keys are merged
+# recursively into claude_code_advanced_hooks_default.
+claude_code_advanced_hooks_overrides:
+  stop_sound:
     command: "afplay \"$HOME/Jobs Done.mp3\""
-
-  # Hook 4: Sound notification when Claude needs input
-  - event: Notification
-    tool: ""
-    type: command
-    command: "osascript -e 'beep 1'"

--- a/roles/claude_code/README.md
+++ b/roles/claude_code/README.md
@@ -25,12 +25,14 @@ Manages Claude Code CLI configuration including hooks and settings
 | `claude_code_manage_settings` | bool | <code>True</code> | No description |
 | `claude_code_backup_settings` | bool | <code>True</code> | No description |
 | `claude_code_simple_hooks` | list | <code>&#91;&#93;</code> | No description |
-| `claude_code_advanced_hooks` | list | <code>&#91;&#93;</code> | No description |
-| `claude_code_advanced_hooks.0` | dict | <code>{}</code> | No description |
-| `claude_code_advanced_hooks.1` | dict | <code>{}</code> | No description |
-| `claude_code_advanced_hooks.2` | dict | <code>{}</code> | No description |
-| `claude_code_advanced_hooks.3` | dict | <code>{}</code> | No description |
-| `claude_code_advanced_hooks.4` | dict | <code>{}</code> | No description |
+| `claude_code_advanced_hooks_default` | dict | <code>{}</code> | No description |
+| `claude_code_advanced_hooks_default.forbidden_content` | dict | <code>{}</code> | No description |
+| `claude_code_advanced_hooks_default.dangerous_flags` | dict | <code>{}</code> | No description |
+| `claude_code_advanced_hooks_default.post_commit_check` | dict | <code>{}</code> | No description |
+| `claude_code_advanced_hooks_default.stop_sound` | dict | <code>{}</code> | No description |
+| `claude_code_advanced_hooks_default.notify_sound` | dict | <code>{}</code> | No description |
+| `claude_code_advanced_hooks_overrides` | dict | <code>{}</code> | No description |
+| `claude_code_advanced_hooks` | str | <code><multiline value: folded_strip></code> | No description |
 | `claude_code_additional_settings` | dict | <code>{}</code> | No description |
 | `claude_code_manage_mcp_servers` | bool | <code>True</code> | No description |
 | `claude_code_mcp_servers` | list | <code>&#91;&#93;</code> | No description |

--- a/roles/claude_code/defaults/main.yml
+++ b/roles/claude_code/defaults/main.yml
@@ -30,13 +30,26 @@ claude_code_backup_settings: true
 # Simple hooks - easy YAML configuration
 claude_code_simple_hooks: []
 
-# Advanced hooks - custom Python/shell scripts
-claude_code_advanced_hooks:
-  # Hook 1: Block commits/PRs with forbidden content (emojis/branding)
+# Advanced hooks — custom Python/shell scripts.
+#
+# Hooks are defined as a dict keyed by hook id (e.g. `forbidden_content`, `stop_sound`)
+# rather than a positional list. Consumers override individual hooks by setting
+# `claude_code_advanced_hooks_overrides` with the same key, no copy-paste needed:
+#
+#     claude_code_advanced_hooks_overrides:
+#       stop_sound:
+#         command: 'afplay "$HOME/Jobs Done.mp3"'
+#
+# To remove a default hook entirely on a specific host, set its value to `null`.
+# To add a host-specific hook, give it a new key.
+claude_code_advanced_hooks_default:
+
+  # forbidden_content: Block commits/PRs with forbidden content (emojis/branding).
   # Inspects the literal command string. Catches `git commit -m "...Co-Authored-By: Claude..."`
   # and `gh pr create --body "...🤖..."` style invocations. Cannot see content passed via
-  # `-F file`, stdin pipes, $variables, or editor commits — Hook 5 handles those post-hoc.
-  - event: PreToolUse
+  # `-F file`, stdin pipes, $variables, or editor commits — `post_commit_check` handles those.
+  forbidden_content:
+    event: PreToolUse
     tool: Bash
     type: command
     command: |
@@ -73,8 +86,9 @@ claude_code_advanced_hooks:
       sys.exit(0)
       "
 
-  # Hook 2: Block dangerous git flags that bypass safety checks
-  - event: PreToolUse
+  # dangerous_flags: Block dangerous git flags that bypass safety checks (--no-verify, etc.).
+  dangerous_flags:
+    event: PreToolUse
     tool: Bash
     type: command
     command: |
@@ -102,12 +116,14 @@ claude_code_advanced_hooks:
       sys.exit(0)
       "
 
-  # Hook 3: Post-commit safety net — catches forbidden content that slipped past Hook 1.
-  # Hook 1 only sees the literal command string, so it misses messages passed via `-F file`,
-  # stdin pipes (`fabric_commit` uses `git commit -F -`), $variables, editor commits, and
-  # squash-merges. This runs after any commit-creating command and inspects the resulting
-  # commit message. If forbidden content landed, it tells Claude to amend before pushing.
-  - event: PostToolUse
+  # post_commit_check: Post-commit safety net — catches forbidden content that slipped past
+  # `forbidden_content`. The PreToolUse hook only sees the literal command string, so it misses
+  # messages passed via `-F file`, stdin pipes (`fabric_commit` uses `git commit -F -`),
+  # $variables, editor commits, and squash-merges. This PostToolUse hook runs after any
+  # commit-creating command and inspects the resulting commit message; if forbidden content
+  # landed, it tells Claude to amend before pushing.
+  post_commit_check:
+    event: PostToolUse
     tool: Bash
     type: command
     command: |
@@ -160,17 +176,33 @@ claude_code_advanced_hooks:
       sys.exit(0)
       "
 
-  # Hook 4: Sound notification when Claude finishes a task
-  - event: Stop
+  # stop_sound: Sound notification when Claude finishes a task.
+  stop_sound:
+    event: Stop
     tool: ""
     type: command
     command: "osascript -e 'beep 2'"
 
-  # Hook 5: Sound notification when Claude needs input
-  - event: Notification
+  # notify_sound: Sound notification when Claude needs input.
+  notify_sound:
+    event: Notification
     tool: ""
     type: command
     command: "osascript -e 'beep 1'"
+
+# Per-host overrides for the dict above. Keys here are merged into
+# `claude_code_advanced_hooks_default` (recursive=True), so individual hooks can be
+# customized without copy-pasting the whole map.
+claude_code_advanced_hooks_overrides: {}
+
+# Final assembled list passed to the template. Built from defaults + overrides; entries
+# whose value is `null` (after merge) are filtered out so a host can disable a default hook
+# by setting `<key>: ~` in the overrides.
+claude_code_advanced_hooks: >-
+  {{
+    (claude_code_advanced_hooks_default | combine(claude_code_advanced_hooks_overrides, recursive=True))
+    | dict2items | rejectattr('value', 'none') | map(attribute='value') | list
+  }}
 
 # Additional settings (optional)
 claude_code_additional_settings: {}


### PR DESCRIPTION
**Key Changes:**

- Refactored advanced hooks structure from a positional list to a keyed dictionary for improved maintainability and per-host customization
- Introduced `claude_code_advanced_hooks_default` and `claude_code_advanced_hooks_overrides` for cleanly merging global and host-specific hook configurations
- Updated documentation to reflect new hook configuration approach and detailed hook keys
- Simplified per-host override by allowing single-key customization without full copy-paste

**Added:**

- Keyed advanced hook defaults - Introduced `claude_code_advanced_hooks_default` as a dictionary keyed by hook ID in `defaults/main.yml`
- Per-host advanced hook overrides - Added `claude_code_advanced_hooks_overrides` to allow targeted overrides or disabling of individual hooks
- Assembled hook list - Created logic to merge defaults and overrides, filter out disabled hooks, and expose the final list as `claude_code_advanced_hooks`

**Changed:**

- Advanced hooks structure - Switched from a YAML list of hooks to a dictionary keyed by logical hook names for easier merging and management in `defaults/main.yml` and per-host files
- Documentation - Updated `roles/claude_code/README.md` to document the new configuration variables and explain the keyed hook approach, replacing references to the old list-based structure
- Host variable configuration - Modified `playbooks/workstation/host_vars/ouroboros.yml` to use only the override mechanism for per-host hook changes, removing the full hook list

**Removed:**

- Old list-based advanced hooks - Eliminated the positional `claude_code_advanced_hooks` list from defaults and host vars in favor of the new keyed and override-based configuration