### PR TITLE
ci: automerge major dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -41,6 +41,7 @@
       automerge: true,
       automergeType: 'pr',
       matchUpdateTypes: [
+        'major',
         'minor',
         'patch',
       ],


### PR DESCRIPTION
**Key Changes:**

- Enables Renovate automerge PRs for major dependency updates
- Aligns major update handling with existing minor and patch automerge behavior
- Keeps automerge configured as pull requests while expanding eligible update types

**Added:**

- Major dependency update eligibility - Included major in Renovate's automerge matchUpdateTypes in .github/renovate.json5

**Changed:**

- Dependency update automation policy - Expanded the existing Renovate automerge scope from minor and patch updates to include all update types