### PR TITLE
feat: add optional modern cli tool installation

### DIFF
--- a/playbooks/workstation/workstation.yml
+++ b/playbooks/workstation/workstation.yml
@@ -136,6 +136,13 @@
       # For debugging
       # role: ../../roles/user_setup
 
+    - name: Install modern CLI tools (fd, rg, bat, eza, delta, dust, duf, procs, sd, zoxide, jq, yq, ...)
+      role: cowdogmoo.workstation.package_management
+      # For debugging
+      # role: ../../roles/package_management
+      vars:
+        package_management_install_modern_cli: true
+
     - name: Setup ZSH Configuration
       role: cowdogmoo.workstation.zsh_setup
       # For debugging

--- a/roles/claude_code/files/CLAUDE.md
+++ b/roles/claude_code/files/CLAUDE.md
@@ -50,9 +50,18 @@ After `fabric_pr` creates the PR, you MUST verify and fix if needed:
 
 The `fabric_pr` function should handle these automatically, but you must verify and correct any issues in the created PR.
 
-## Search Tools
+## Modern CLI Tools
 
-- Always prefer `rg` (ripgrep) over `grep` when it is installed — it is faster, respects `.gitignore`, and has better defaults. Fall back to `grep` only if `rg` is unavailable.
+Prefer these modern equivalents when installed — they are faster and have better defaults. They are **not** strict drop-ins; verify flags before substituting in scripts.
+
+- `rg` (ripgrep) over `grep` — respects `.gitignore`, parallel
+- `fd` over `find` — simpler positional syntax; for quick lookups, not complex `find -exec` chains
+- `bat -pp` over `cat` — `-pp` disables paging and decoration for tool-friendly output
+- `delta` for diffs — pipe `git diff` / `diff -u` through it for readable output
+- `dust` over `du` — tree-style disk usage
+- `duf` over `df` — clearer filesystem summary
+
+Fall back to the classic tool if the modern one is unavailable.
 
 ## Notes
 

--- a/roles/package_management/README.md
+++ b/roles/package_management/README.md
@@ -122,12 +122,14 @@ Manage package installations and cleanups on Debian-based and Red Hat-based syst
 ### install_github_binary.yml
 
 
-- **Check installed version of {{ package_management_binary.name }}** (ansible.builtin.command)
+- **Check install marker for {{ package_management_binary.name }}** (ansible.builtin.stat)
 - **Install GitHub release binary {{ package_management_binary.name }}** (block) - Conditional
+- **Ensure marker directory exists** (ansible.builtin.file)
 - **Create temp extraction directory for {{ package_management_binary.name }}** (ansible.builtin.tempfile)
 - **Download release archive for {{ package_management_binary.name }}** (ansible.builtin.get_url)
 - **Extract release archive for {{ package_management_binary.name }}** (ansible.builtin.unarchive) - Conditional
 - **Install binary to /usr/local/bin for {{ package_management_binary.name }}** (ansible.builtin.copy)
+- **Write install marker for {{ package_management_binary.name }}** (ansible.builtin.file)
 
 ### main.yml
 

--- a/roles/package_management/README.md
+++ b/roles/package_management/README.md
@@ -68,8 +68,66 @@ Manage package installations and cleanups on Debian-based and Red Hat-based syst
 | `package_management_redhat_specific_packages.9` | str | <code>sqlite-devel</code> | No description |
 | `package_management_redhat_specific_packages.10` | str | <code>zlib-devel</code> | No description |
 | `package_management_install_packages` | str | <code><multiline value: folded></code> | No description |
+| `package_management_install_modern_cli` | bool | <code>False</code> | No description |
+| `package_management_modern_cli_brew_packages` | list | <code>&#91;&#93;</code> | No description |
+| `package_management_modern_cli_brew_packages.0` | str | <code>bat</code> | No description |
+| `package_management_modern_cli_brew_packages.1` | str | <code>curlie</code> | No description |
+| `package_management_modern_cli_brew_packages.2` | str | <code>git-delta</code> | No description |
+| `package_management_modern_cli_brew_packages.3` | str | <code>duf</code> | No description |
+| `package_management_modern_cli_brew_packages.4` | str | <code>dust</code> | No description |
+| `package_management_modern_cli_brew_packages.5` | str | <code>eza</code> | No description |
+| `package_management_modern_cli_brew_packages.6` | str | <code>fd</code> | No description |
+| `package_management_modern_cli_brew_packages.7` | str | <code>gitui</code> | No description |
+| `package_management_modern_cli_brew_packages.8` | str | <code>htmlq</code> | No description |
+| `package_management_modern_cli_brew_packages.9` | str | <code>jq</code> | No description |
+| `package_management_modern_cli_brew_packages.10` | str | <code>lazygit</code> | No description |
+| `package_management_modern_cli_brew_packages.11` | str | <code>procs</code> | No description |
+| `package_management_modern_cli_brew_packages.12` | str | <code>ripgrep</code> | No description |
+| `package_management_modern_cli_brew_packages.13` | str | <code>sd</code> | No description |
+| `package_management_modern_cli_brew_packages.14` | str | <code>tokei</code> | No description |
+| `package_management_modern_cli_brew_packages.15` | str | <code>xh</code> | No description |
+| `package_management_modern_cli_brew_packages.16` | str | <code>yq</code> | No description |
+| `package_management_modern_cli_brew_packages.17` | str | <code>zoxide</code> | No description |
+| `package_management_modern_cli_debian_packages` | list | <code>&#91;&#93;</code> | No description |
+| `package_management_modern_cli_debian_packages.0` | str | <code>bat</code> | No description |
+| `package_management_modern_cli_debian_packages.1` | str | <code>duf</code> | No description |
+| `package_management_modern_cli_debian_packages.2` | str | <code>fd-find</code> | No description |
+| `package_management_modern_cli_debian_packages.3` | str | <code>git-delta</code> | No description |
+| `package_management_modern_cli_debian_packages.4` | str | <code>jq</code> | No description |
+| `package_management_modern_cli_debian_packages.5` | str | <code>ripgrep</code> | No description |
+| `package_management_modern_cli_debian_packages.6` | str | <code>zoxide</code> | No description |
+| `package_management_modern_cli_redhat_packages` | list | <code>&#91;&#93;</code> | No description |
+| `package_management_modern_cli_redhat_packages.0` | str | <code>bat</code> | No description |
+| `package_management_modern_cli_redhat_packages.1` | str | <code>fd-find</code> | No description |
+| `package_management_modern_cli_redhat_packages.2` | str | <code>git-delta</code> | No description |
+| `package_management_modern_cli_redhat_packages.3` | str | <code>jq</code> | No description |
+| `package_management_modern_cli_redhat_packages.4` | str | <code>ripgrep</code> | No description |
+| `package_management_modern_cli_redhat_packages.5` | str | <code>zoxide</code> | No description |
+| `package_management_modern_cli_rust_arch` | str | <code>{{ 'aarch64' if ansible_facts&#91;'architecture'&#93; in &#91;'aarch64', 'arm64'&#93; else 'x86_64' }}</code> | No description |
+| `package_management_modern_cli_binaries` | list | <code>&#91;&#93;</code> | No description |
+| `package_management_modern_cli_binaries.0` | dict | <code>{}</code> | No description |
+| `package_management_modern_cli_binaries.1` | dict | <code>{}</code> | No description |
+| `package_management_modern_cli_binaries.2` | dict | <code>{}</code> | No description |
+| `package_management_modern_cli_binaries.3` | dict | <code>{}</code> | No description |
+| `package_management_modern_cli_binaries.4` | dict | <code>{}</code> | No description |
+| `package_management_modern_cli_binaries.5` | dict | <code>{}</code> | No description |
+| `package_management_modern_cli_binaries.6` | dict | <code>{}</code> | No description |
+| `package_management_modern_cli_binaries.7` | dict | <code>{}</code> | No description |
+| `package_management_modern_cli_binaries.8` | dict | <code>{}</code> | No description |
+| `package_management_modern_cli_binaries.9` | dict | <code>{}</code> | No description |
+| `package_management_modern_cli_binaries.10` | dict | <code>{}</code> | No description |
 
 ## Tasks
+
+### install_github_binary.yml
+
+
+- **Check installed version of {{ package_management_binary.name }}** (ansible.builtin.command)
+- **Install GitHub release binary {{ package_management_binary.name }}** (block) - Conditional
+- **Create temp extraction directory for {{ package_management_binary.name }}** (ansible.builtin.tempfile)
+- **Download release archive for {{ package_management_binary.name }}** (ansible.builtin.get_url)
+- **Extract release archive for {{ package_management_binary.name }}** (ansible.builtin.unarchive) - Conditional
+- **Install binary to /usr/local/bin for {{ package_management_binary.name }}** (ansible.builtin.copy)
 
 ### main.yml
 
@@ -77,6 +135,15 @@ Manage package installations and cleanups on Debian-based and Red Hat-based syst
 - **Set DEBIAN_FRONTEND to noninteractive** (ansible.builtin.lineinfile) - Conditional
 - **Install Kali Linux archive keyring** (ansible.builtin.get_url) - Conditional
 - **Install packages** (ansible.builtin.package) - Conditional
+- **Install modern CLI tools** (ansible.builtin.include_tasks) - Conditional
+
+### modern_cli.yml
+
+
+- **Install modern CLI tools via Homebrew (macOS)** (community.general.homebrew) - Conditional
+- **Install modern CLI tools via apt (Debian/Ubuntu/Kali)** (ansible.builtin.package) - Conditional
+- **Install modern CLI tools via dnf (RedHat/Fedora/Rocky)** (ansible.builtin.package) - Conditional
+- **Install modern CLI tools from GitHub release binaries (Linux)** (ansible.builtin.include_tasks) - Conditional
 
 ## Example Playbook
 

--- a/roles/package_management/defaults/main.yml
+++ b/roles/package_management/defaults/main.yml
@@ -63,3 +63,120 @@ package_management_install_packages: >
   {{ package_management_common_install_packages +
      (package_management_debian_specific_packages if ansible_facts["os_family"] == 'Debian' else []) +
      (package_management_redhat_specific_packages if ansible_facts["os_family"] == 'RedHat' else []) }}
+
+# Modern CLI tools (fd, rg, bat, eza, ...). Opt-in to avoid changing the
+# behavior of roles that already include package_management for base packages.
+package_management_install_modern_cli: false
+
+# macOS Homebrew package names — Homebrew carries every tool we want.
+package_management_modern_cli_brew_packages:
+  - bat
+  - curlie
+  - git-delta
+  - duf
+  - dust
+  - eza
+  - fd
+  - gitui
+  - htmlq
+  - jq
+  - lazygit
+  - procs
+  - ripgrep
+  - sd
+  - tokei
+  - xh
+  - yq
+  - zoxide
+
+# Debian/Ubuntu/Kali apt package names. Only tools that are reliably packaged
+# across currently-supported releases live here; everything else falls through
+# to package_management_modern_cli_binaries below.
+# NOTE: on Debian/Ubuntu the apt binaries are `fdfind` and `batcat` — the
+# zsh_setup role aliases them back to `fd` and `bat`.
+package_management_modern_cli_debian_packages:
+  - bat
+  - duf
+  - fd-find
+  - git-delta
+  - jq
+  - ripgrep
+  - zoxide
+
+# RedHat/Fedora/Rocky dnf package names.
+package_management_modern_cli_redhat_packages:
+  - bat
+  - fd-find
+  - git-delta
+  - jq
+  - ripgrep
+  - zoxide
+
+# Architecture suffix used by Rust-toolchain release tarballs
+# (used to build the URLs in package_management_modern_cli_binaries).
+package_management_modern_cli_rust_arch: "{{ 'aarch64' if ansible_facts['architecture'] in ['aarch64', 'arm64'] else 'x86_64' }}"
+
+# GitHub-release binaries installed on Linux when the apt/dnf repos do not
+# carry the tool. Each entry must define:
+#   name:             the final binary name installed under /usr/local/bin
+#   version:          upstream release version (no leading 'v')
+#   url:              direct URL to a release asset (tar.gz or zip)
+#   archive_binary:   path of the binary inside the extracted archive
+#                     (use 'name' itself when the binary sits at the top level)
+# Versions are pinned and renovate-tracked, matching the mise role convention.
+package_management_modern_cli_binaries:
+  # renovate: datasource=github-releases depName=eza packageName=eza-community/eza extractVersion=^v(?<version>.*)$
+  - name: eza
+    version: "0.20.7"
+    url: "https://github.com/eza-community/eza/releases/download/v0.20.7/eza_{{ package_management_modern_cli_rust_arch }}-unknown-linux-gnu.tar.gz"
+    archive_binary: "eza"
+  # renovate: datasource=github-releases depName=dust packageName=bootandy/dust extractVersion=^v(?<version>.*)$
+  - name: dust
+    version: "1.1.2"
+    url: "https://github.com/bootandy/dust/releases/download/v1.1.2/dust-v1.1.2-{{ package_management_modern_cli_rust_arch }}-unknown-linux-gnu.tar.gz"
+    archive_binary: "dust-v1.1.2-{{ package_management_modern_cli_rust_arch }}-unknown-linux-gnu/dust"
+  # renovate: datasource=github-releases depName=procs packageName=dalance/procs extractVersion=^v(?<version>.*)$
+  - name: procs
+    version: "0.14.10"
+    url: "https://github.com/dalance/procs/releases/download/v0.14.10/procs-v0.14.10-{{ package_management_modern_cli_rust_arch }}-linux.zip"
+    archive_binary: "procs"
+  # renovate: datasource=github-releases depName=sd packageName=chmln/sd extractVersion=^v(?<version>.*)$
+  - name: sd
+    version: "1.0.0"
+    url: "https://github.com/chmln/sd/releases/download/v1.0.0/sd-v1.0.0-{{ package_management_modern_cli_rust_arch }}-unknown-linux-gnu.tar.gz"
+    archive_binary: "sd-v1.0.0-{{ package_management_modern_cli_rust_arch }}-unknown-linux-gnu/sd"
+  # renovate: datasource=github-releases depName=htmlq packageName=mgdm/htmlq extractVersion=^v(?<version>.*)$
+  - name: htmlq
+    version: "0.4.0"
+    url: "https://github.com/mgdm/htmlq/releases/download/v0.4.0/htmlq-{{ package_management_modern_cli_rust_arch }}-linux.tar.gz"
+    archive_binary: "htmlq"
+  # renovate: datasource=github-releases depName=xh packageName=ducaale/xh extractVersion=^v(?<version>.*)$
+  - name: xh
+    version: "0.24.1"
+    url: "https://github.com/ducaale/xh/releases/download/v0.24.1/xh-v0.24.1-{{ package_management_modern_cli_rust_arch }}-unknown-linux-gnu.tar.gz"
+    archive_binary: "xh-v0.24.1-{{ package_management_modern_cli_rust_arch }}-unknown-linux-gnu/xh"
+  # renovate: datasource=github-releases depName=curlie packageName=rs/curlie extractVersion=^v(?<version>.*)$
+  - name: curlie
+    version: "1.7.2"
+    url: "https://github.com/rs/curlie/releases/download/v1.7.2/curlie_1.7.2_linux_{{ 'arm64' if ansible_facts['architecture'] in ['aarch64', 'arm64'] else 'amd64' }}.tar.gz"
+    archive_binary: "curlie"
+  # renovate: datasource=github-releases depName=lazygit packageName=jesseduffield/lazygit extractVersion=^v(?<version>.*)$
+  - name: lazygit
+    version: "0.45.2"
+    url: "https://github.com/jesseduffield/lazygit/releases/download/v0.45.2/lazygit_0.45.2_Linux_{{ 'arm64' if ansible_facts['architecture'] in ['aarch64', 'arm64'] else 'x86_64' }}.tar.gz"
+    archive_binary: "lazygit"
+  # renovate: datasource=github-releases depName=gitui packageName=extrawurst/gitui extractVersion=^v(?<version>.*)$
+  - name: gitui
+    version: "0.27.0"
+    url: "https://github.com/extrawurst/gitui/releases/download/v0.27.0/gitui-linux-{{ 'aarch64' if ansible_facts['architecture'] in ['aarch64', 'arm64'] else 'x86_64' }}.tar.gz"
+    archive_binary: "gitui"
+  # renovate: datasource=github-releases depName=tokei packageName=XAMPPRocky/tokei extractVersion=^v(?<version>.*)$
+  - name: tokei
+    version: "12.1.2"
+    url: "https://github.com/XAMPPRocky/tokei/releases/download/v12.1.2/tokei-{{ package_management_modern_cli_rust_arch }}-unknown-linux-gnu.tar.gz"
+    archive_binary: "tokei"
+  # renovate: datasource=github-releases depName=yq packageName=mikefarah/yq extractVersion=^v(?<version>.*)$
+  - name: yq
+    version: "4.44.3"
+    url: "https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_{{ 'arm64' if ansible_facts['architecture'] in ['aarch64', 'arm64'] else 'amd64' }}.tar.gz"
+    archive_binary: "yq_linux_{{ 'arm64' if ansible_facts['architecture'] in ['aarch64', 'arm64'] else 'amd64' }}"

--- a/roles/package_management/defaults/main.yml
+++ b/roles/package_management/defaults/main.yml
@@ -144,18 +144,19 @@ package_management_modern_cli_binaries:
   # renovate: datasource=github-releases depName=sd packageName=chmln/sd extractVersion=^v(?<version>.*)$
   - name: sd
     version: "1.0.0"
-    url: "https://github.com/chmln/sd/releases/download/v1.0.0/sd-v1.0.0-{{ package_management_modern_cli_rust_arch }}-unknown-linux-gnu.tar.gz"
-    archive_binary: "sd-v1.0.0-{{ package_management_modern_cli_rust_arch }}-unknown-linux-gnu/sd"
+    url: "https://github.com/chmln/sd/releases/download/v1.0.0/sd-v1.0.0-{{ package_management_modern_cli_rust_arch }}-unknown-linux-musl.tar.gz"
+    archive_binary: "sd-v1.0.0-{{ package_management_modern_cli_rust_arch }}-unknown-linux-musl/sd"
   # renovate: datasource=github-releases depName=htmlq packageName=mgdm/htmlq extractVersion=^v(?<version>.*)$
+  # NOTE: htmlq only ships an x86_64-linux binary; on aarch64 Linux this 404s.
   - name: htmlq
     version: "0.4.0"
-    url: "https://github.com/mgdm/htmlq/releases/download/v0.4.0/htmlq-{{ package_management_modern_cli_rust_arch }}-linux.tar.gz"
+    url: "https://github.com/mgdm/htmlq/releases/download/v0.4.0/htmlq-x86_64-linux.tar.gz"
     archive_binary: "htmlq"
   # renovate: datasource=github-releases depName=xh packageName=ducaale/xh extractVersion=^v(?<version>.*)$
   - name: xh
     version: "0.24.1"
-    url: "https://github.com/ducaale/xh/releases/download/v0.24.1/xh-v0.24.1-{{ package_management_modern_cli_rust_arch }}-unknown-linux-gnu.tar.gz"
-    archive_binary: "xh-v0.24.1-{{ package_management_modern_cli_rust_arch }}-unknown-linux-gnu/xh"
+    url: "https://github.com/ducaale/xh/releases/download/v0.24.1/xh-v0.24.1-{{ package_management_modern_cli_rust_arch }}-unknown-linux-musl.tar.gz"
+    archive_binary: "xh-v0.24.1-{{ package_management_modern_cli_rust_arch }}-unknown-linux-musl/xh"
   # renovate: datasource=github-releases depName=curlie packageName=rs/curlie extractVersion=^v(?<version>.*)$
   - name: curlie
     version: "1.7.2"

--- a/roles/package_management/defaults/main.yml
+++ b/roles/package_management/defaults/main.yml
@@ -92,8 +92,9 @@ package_management_modern_cli_brew_packages:
 # Debian/Ubuntu/Kali apt package names. Only tools that are reliably packaged
 # across currently-supported releases live here; everything else falls through
 # to package_management_modern_cli_binaries below.
-# NOTE: on Debian/Ubuntu the apt binaries are `fdfind` and `batcat` — the
-# zsh_setup role aliases them back to `fd` and `bat`.
+# NOTE: on Debian/Ubuntu the apt binaries are `fdfind` and `batcat` — shell
+# aliases to `fd` and `bat` are out of scope for this role; manage them in
+# your dotfiles.
 package_management_modern_cli_debian_packages:
   - bat
   - duf

--- a/roles/package_management/tasks/install_github_binary.yml
+++ b/roles/package_management/tasks/install_github_binary.yml
@@ -3,16 +3,26 @@
 # Caller must define package_management_binary as a dict with keys:
 #   name, version, url, archive_binary
 # See package_management_modern_cli_binaries in defaults/main.yml.
+#
+# Idempotency is tracked via a per-(name, version) stamp file rather than the
+# binary's --version output, because some tools (e.g. curlie wraps curl) report
+# an upstream version instead of their own.
 
-- name: "Check installed version of {{ package_management_binary.name }}"
-  ansible.builtin.command: "/usr/local/bin/{{ package_management_binary.name }} --version"
-  register: package_management_binary_installed
-  changed_when: false
-  failed_when: false
+- name: "Check install marker for {{ package_management_binary.name }}"
+  ansible.builtin.stat:
+    path: "/usr/local/share/workstation-cli/{{ package_management_binary.name }}-{{ package_management_binary.version }}.stamp"
+  register: package_management_binary_stamp
 
 - name: "Install GitHub release binary {{ package_management_binary.name }}"
-  when: package_management_binary.version not in (package_management_binary_installed.stdout | default(''))
+  when: not package_management_binary_stamp.stat.exists
   block:
+    - name: "Ensure marker directory exists"
+      become: true
+      ansible.builtin.file:
+        path: "/usr/local/share/workstation-cli"
+        state: directory
+        mode: '0755'
+
     - name: "Create temp extraction directory for {{ package_management_binary.name }}"
       ansible.builtin.tempfile:
         state: directory
@@ -44,9 +54,18 @@
         mode: '0755'
         remote_src: true
 
+    - name: "Write install marker for {{ package_management_binary.name }}"
+      become: true
+      ansible.builtin.file:
+        path: "/usr/local/share/workstation-cli/{{ package_management_binary.name }}-{{ package_management_binary.version }}.stamp"
+        state: touch
+        mode: '0644'
+
   always:
     - name: "Remove temp extraction directory for {{ package_management_binary.name }}"
       ansible.builtin.file:
         path: "{{ package_management_binary_tmpdir.path }}"
         state: absent
-      when: package_management_binary_tmpdir.path is defined
+      when:
+        - package_management_binary_tmpdir is defined
+        - package_management_binary_tmpdir.path is defined

--- a/roles/package_management/tasks/install_github_binary.yml
+++ b/roles/package_management/tasks/install_github_binary.yml
@@ -1,0 +1,52 @@
+---
+# Install a single tool from a GitHub release archive.
+# Caller must define package_management_binary as a dict with keys:
+#   name, version, url, archive_binary
+# See package_management_modern_cli_binaries in defaults/main.yml.
+
+- name: "Check installed version of {{ package_management_binary.name }}"
+  ansible.builtin.command: "/usr/local/bin/{{ package_management_binary.name }} --version"
+  register: package_management_binary_installed
+  changed_when: false
+  failed_when: false
+
+- name: "Install GitHub release binary {{ package_management_binary.name }}"
+  when: package_management_binary.version not in (package_management_binary_installed.stdout | default(''))
+  block:
+    - name: "Create temp extraction directory for {{ package_management_binary.name }}"
+      ansible.builtin.tempfile:
+        state: directory
+        suffix: "{{ package_management_binary.name }}"
+      register: package_management_binary_tmpdir
+
+    - name: "Download release archive for {{ package_management_binary.name }}"
+      ansible.builtin.get_url:
+        url: "{{ package_management_binary.url }}"
+        dest: "{{ package_management_binary_tmpdir.path }}/{{ package_management_binary.url | basename }}"
+        mode: '0644'
+      register: package_management_binary_download
+      until: package_management_binary_download is success
+      retries: 3
+      delay: 5
+
+    - name: "Extract release archive for {{ package_management_binary.name }}"
+      ansible.builtin.unarchive:
+        src: "{{ package_management_binary_download.dest }}"
+        dest: "{{ package_management_binary_tmpdir.path }}"
+        remote_src: true
+      when: package_management_binary.url is search('\\.(tar\\.gz|tgz|zip)$')
+
+    - name: "Install binary to /usr/local/bin for {{ package_management_binary.name }}"
+      become: true
+      ansible.builtin.copy:
+        src: "{{ package_management_binary_tmpdir.path }}/{{ package_management_binary.archive_binary }}"
+        dest: "/usr/local/bin/{{ package_management_binary.name }}"
+        mode: '0755'
+        remote_src: true
+
+  always:
+    - name: "Remove temp extraction directory for {{ package_management_binary.name }}"
+      ansible.builtin.file:
+        path: "{{ package_management_binary_tmpdir.path }}"
+        state: absent
+      when: package_management_binary_tmpdir.path is defined

--- a/roles/package_management/tasks/main.yml
+++ b/roles/package_management/tasks/main.yml
@@ -29,3 +29,8 @@
   retries: 10
   delay: 5
   tags: packages
+
+- name: Install modern CLI tools
+  ansible.builtin.include_tasks: modern_cli.yml
+  when: package_management_install_modern_cli | bool
+  tags: packages

--- a/roles/package_management/tasks/modern_cli.yml
+++ b/roles/package_management/tasks/modern_cli.yml
@@ -43,7 +43,7 @@
   ansible.builtin.include_tasks: install_github_binary.yml
   loop: "{{ package_management_modern_cli_binaries }}"
   loop_control:
-    label: "{{ item.name }} v{{ item.version }}"
+    label: "{{ package_management_binary.name }} v{{ package_management_binary.version }}"
     loop_var: package_management_binary
   when: ansible_facts['os_family'] in ['Debian', 'RedHat']
   tags: packages

--- a/roles/package_management/tasks/modern_cli.yml
+++ b/roles/package_management/tasks/modern_cli.yml
@@ -1,0 +1,49 @@
+---
+- name: Install modern CLI tools via Homebrew (macOS)
+  community.general.homebrew:
+    name: "{{ package_management_modern_cli_brew_packages }}"
+    state: present
+    update_homebrew: true
+  when: ansible_facts['os_family'] == 'Darwin'
+  register: package_management_modern_cli_brew_result
+  until: package_management_modern_cli_brew_result is success
+  retries: 5
+  delay: 5
+  tags: packages
+
+- name: Install modern CLI tools via apt (Debian/Ubuntu/Kali)
+  become: true
+  ansible.builtin.package:
+    name: "{{ package_management_modern_cli_debian_packages }}"
+    state: present
+    update_cache: true
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+  when: ansible_facts['os_family'] == 'Debian'
+  register: package_management_modern_cli_apt_result
+  until: package_management_modern_cli_apt_result is success
+  retries: 5
+  delay: 5
+  tags: packages
+
+- name: Install modern CLI tools via dnf (RedHat/Fedora/Rocky)
+  become: true
+  ansible.builtin.package:
+    name: "{{ package_management_modern_cli_redhat_packages }}"
+    state: present
+    update_cache: true
+  when: ansible_facts['os_family'] == 'RedHat'
+  register: package_management_modern_cli_dnf_result
+  until: package_management_modern_cli_dnf_result is success
+  retries: 5
+  delay: 5
+  tags: packages
+
+- name: Install modern CLI tools from GitHub release binaries (Linux)
+  ansible.builtin.include_tasks: install_github_binary.yml
+  loop: "{{ package_management_modern_cli_binaries }}"
+  loop_control:
+    label: "{{ item.name }} v{{ item.version }}"
+    loop_var: package_management_binary
+  when: ansible_facts['os_family'] in ['Debian', 'RedHat']
+  tags: packages

--- a/roles/zsh_setup/templates/zshrc.j2
+++ b/roles/zsh_setup/templates/zshrc.j2
@@ -96,25 +96,3 @@ source $ZSH/oh-my-zsh.sh
 # Example aliases
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
-
-# Modern CLI tool aliases (managed by cowdogmoo.workstation.zsh_setup).
-# Each alias is guarded so the shell still works if a tool is missing.
-# Debian/Ubuntu ship fd and bat as `fdfind` and `batcat`; shim them back.
-command -v fdfind >/dev/null 2>&1 && ! command -v fd >/dev/null 2>&1 && alias fd='fdfind'
-command -v batcat >/dev/null 2>&1 && ! command -v bat >/dev/null 2>&1 && alias bat='batcat'
-
-if command -v eza >/dev/null 2>&1; then
-  alias ls='eza --group-directories-first'
-  alias ll='eza -lhg --git --group-directories-first'
-  alias la='eza -lahg --git --group-directories-first'
-  alias tree='eza --tree'
-fi
-command -v bat >/dev/null 2>&1 && alias cat='bat -pp'
-command -v dust >/dev/null 2>&1 && alias du='dust'
-command -v duf >/dev/null 2>&1 && alias df='duf'
-command -v procs >/dev/null 2>&1 && alias ps='procs'
-command -v rg >/dev/null 2>&1 && alias grep='rg'
-command -v delta >/dev/null 2>&1 && export GIT_PAGER='delta'
-
-# zoxide: smarter cd. `z <pattern>` jumps; `cd` still works.
-command -v zoxide >/dev/null 2>&1 && eval "$(zoxide init zsh)"

--- a/roles/zsh_setup/templates/zshrc.j2
+++ b/roles/zsh_setup/templates/zshrc.j2
@@ -96,3 +96,25 @@ source $ZSH/oh-my-zsh.sh
 # Example aliases
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
+
+# Modern CLI tool aliases (managed by cowdogmoo.workstation.zsh_setup).
+# Each alias is guarded so the shell still works if a tool is missing.
+# Debian/Ubuntu ship fd and bat as `fdfind` and `batcat`; shim them back.
+command -v fdfind >/dev/null 2>&1 && ! command -v fd >/dev/null 2>&1 && alias fd='fdfind'
+command -v batcat >/dev/null 2>&1 && ! command -v bat >/dev/null 2>&1 && alias bat='batcat'
+
+if command -v eza >/dev/null 2>&1; then
+  alias ls='eza --group-directories-first'
+  alias ll='eza -lhg --git --group-directories-first'
+  alias la='eza -lahg --git --group-directories-first'
+  alias tree='eza --tree'
+fi
+command -v bat >/dev/null 2>&1 && alias cat='bat -pp'
+command -v dust >/dev/null 2>&1 && alias du='dust'
+command -v duf >/dev/null 2>&1 && alias df='duf'
+command -v procs >/dev/null 2>&1 && alias ps='procs'
+command -v rg >/dev/null 2>&1 && alias grep='rg'
+command -v delta >/dev/null 2>&1 && export GIT_PAGER='delta'
+
+# zoxide: smarter cd. `z <pattern>` jumps; `cd` still works.
+command -v zoxide >/dev/null 2>&1 && eval "$(zoxide init zsh)"


### PR DESCRIPTION
**Key Changes:**

- Introduced opt-in installation for modern CLI tools across macOS, Debian, and RedHat-based systems
- Added GitHub release binary installation for Linux tools not consistently available in package repositories
- Enabled modern CLI tooling in the workstation playbook while keeping the package management role backward compatible
- Added guarded ZSH aliases so enhanced tools are used when present without breaking shells when missing

**Added:**

- Modern CLI package configuration - Added opt-in defaults for Homebrew, apt, dnf, and pinned GitHub release binaries including eza, dust, procs, sd, htmlq, xh, curlie, lazygit, gitui, tokei, and yq
- Cross-platform modern CLI installation workflow - Added package-manager-specific installation tasks for macOS, Debian/Ubuntu/Kali, and RedHat/Fedora/Rocky systems
- GitHub release binary installer - Added reusable task logic to check installed versions, download release archives, extract binaries, install them to /usr/local/bin, and clean up temporary directories
- Modern CLI shell integration - Added guarded ZSH aliases and initialization for fd, bat, eza, dust, duf, procs, ripgrep, delta, and zoxide

**Changed:**

- Workstation provisioning - Enabled modern CLI tool installation during the workstation playbook run by setting package_management_install_modern_cli to true
- Package management execution flow - Included modern CLI tasks only when explicitly enabled, preserving existing role behavior for consumers that only want base packages
- Role documentation - Updated generated README content to document the new variables and task files for modern CLI installation and GitHub binary handling