### PR TITLE
chore: drop broken goplay from mise defaults

### DIFF
--- a/roles/mise/defaults/main.yml
+++ b/roles/mise/defaults/main.yml
@@ -58,8 +58,6 @@ mise_plugins:
         version: "latest"
       - name: "go:github.com/josharian/impl"
         version: "latest"
-      - name: "go:github.com/haya14busa/goplay/cmd/goplay"
-        version: "latest"
       - name: "go:github.com/go-delve/delve/cmd/dlv"
         version: "latest"
       - name: "go:github.com/fzipp/gocyclo/cmd/gocyclo"


### PR DESCRIPTION
**Key Changes:**

- Removed the broken `go:github.com/haya14busa/goplay/cmd/goplay` entry from the default mise plugin set so workstations no longer show it as `(missing)` after the playbook runs

**Removed:**

- goplay from mise defaults — Upstream package is broken (`go.mod` references `skratchdot/open-golang` without declaring the dependency, build fails under `-mod=readonly`, no `v1.0.0` tag) and has been unmaintained for years; modern VSCode Go no longer uses it