### PR TITLE
chore: ignore local workstation inventory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ changelogs/.plugin-cache.yaml
 *.log
 .tool-versions
 .backups
+playbooks/workstation/inventory

--- a/playbooks/workstation/inventory
+++ b/playbooks/workstation/inventory
@@ -1,2 +1,0 @@
-[workstation]
-ouroboros ansible_connection=local


### PR DESCRIPTION
**Key Changes:**

- Stops tracking machine-specific Ansible workstation inventory
- Adds ignore coverage to prevent local inventory files from being recommitted
- Keeps workstation playbook configuration environment-specific

**Added:**

- Local inventory ignore rule - Updated `.gitignore` to exclude the workstation inventory path from version control

**Removed:**

- Tracked workstation inventory - Removed `playbooks/workstation/inventory` because it contains local machine-specific Ansible configuration