### PR TITLE
fix: reclaim cached .asdf mount ownership for test user in molecule

### DIFF
--- a/roles/asdf/molecule/default/converge.yml
+++ b/roles/asdf/molecule/default/converge.yml
@@ -25,6 +25,18 @@
         mode: "0755"
       become: true
 
+    - name: Reclaim the cached .asdf mount for the test user
+      # The asdf cache is restored on the host by the runner user, whose UID
+      # does not match the container user's UID, so previously cached
+      # downloads/install dirs are unwritable inside the container.
+      ansible.builtin.file:
+        path: "{{ container_home }}/.asdf"
+        owner: "{{ container_user }}"
+        group: "{{ container_user }}"
+        state: directory
+        recurse: true
+      become: true
+
     - name: Set home directory fact  # noqa: var-naming[no-role-prefix]
       ansible.builtin.set_fact:
         ansible_env:


### PR DESCRIPTION
**Key Changes:**

- Added a Molecule converge task to fix ownership of the cached `.asdf` directory inside the test container
- Resolved permission conflicts caused by UID mismatch between the host runner user and the container user

**Added:**

- Ownership reclaim task - Introduced a new task in `roles/asdf/molecule/default/converge.yml` that recursively sets the owner and group of `{{ container_home }}/.asdf` to the container user, ensuring previously cached downloads and install directories are writable inside the container despite the host runner's differing UID