### PR TITLE
docs: auto-generate roles table in README from role metadata

### DIFF
--- a/.hooks/gen-arch-diagram.py
+++ b/.hooks/gen-arch-diagram.py
@@ -28,7 +28,8 @@ class AnsibleCollectionAnalyzer:
                 if role_dir.is_dir() and not role_dir.name.startswith('.'):
                     self.structure['roles'].append({
                         'name': role_dir.name,
-                        'has_molecule': (role_dir / 'molecule').exists()
+                        'has_molecule': (role_dir / 'molecule').exists(),
+                        'description': self._read_role_description(role_dir),
                     })
 
         # Analyze plugins
@@ -49,6 +50,28 @@ class AnsibleCollectionAnalyzer:
                     })
 
         return self.structure
+
+    @staticmethod
+    def _read_role_description(role_dir: Path) -> str:
+        """Extract galaxy_info.description from a role's meta/main.yml.
+
+        Uses a simple regex so we don't pull in PyYAML as a hook dep.
+        """
+        meta_path = role_dir / 'meta' / 'main.yml'
+        if not meta_path.exists():
+            return ''
+        try:
+            text = meta_path.read_text()
+        except OSError:
+            return ''
+        match = re.search(r'^\s+description:\s*(.+)$', text, re.MULTILINE)
+        if not match:
+            return ''
+        desc = match.group(1).strip()
+        # Strip surrounding quotes if present
+        if len(desc) >= 2 and desc[0] == desc[-1] and desc[0] in ('"', "'"):
+            desc = desc[1:-1]
+        return desc
 
 def generate_mermaid(structure):
     """Generate Mermaid diagram"""
@@ -81,6 +104,35 @@ def generate_mermaid(structure):
 
     lines.append("```")
     return '\n'.join(lines)
+
+def generate_roles_table(structure):
+    """Generate a markdown table linking to each role's README."""
+    lines = [
+        "| Role | Description |",
+        "| ---- | ----------- |",
+    ]
+    for role in structure['roles']:
+        name = role['name']
+        desc = role.get('description') or '_No description_'
+        # Escape pipes in descriptions so they don't break the table
+        desc = desc.replace('|', '\\|')
+        lines.append(f"| [`{name}`](roles/{name}/README.md) | {desc} |")
+    return '\n'.join(lines)
+
+def update_readme_section(content, start_marker, end_marker, replacement):
+    """Replace text between two marker lines in README content.
+
+    Returns the new content, or None if either marker is missing.
+    """
+    start_pos = content.find(start_marker)
+    end_pos = content.find(end_marker)
+    if start_pos == -1 or end_pos == -1 or end_pos < start_pos:
+        return None
+    return (
+        content[:start_pos + len(start_marker)]
+        + '\n\n' + replacement + '\n\n'
+        + content[end_pos:]
+    )
 
 def update_readme(mermaid_content):
     """Update README.md with the generated Mermaid diagram"""
@@ -124,18 +176,42 @@ def update_readme(mermaid_content):
 
     return True
 
+def update_readme_roles_table(roles_table):
+    """Replace the auto-generated roles table block in README.md."""
+    readme_path = Path('README.md')
+    if not readme_path.exists():
+        print("❌ README.md not found")
+        return False
+
+    content = readme_path.read_text()
+    new_content = update_readme_section(
+        content,
+        '<!-- ROLES TABLE START -->',
+        '<!-- ROLES TABLE END -->',
+        roles_table,
+    )
+    if new_content is None:
+        print("❌ Could not find roles table markers in README.md")
+        return False
+
+    readme_path.write_text(new_content)
+    return True
+
 def main():
     """Main function for pre-commit hook"""
     # Analyze collection from current directory
     analyzer = AnsibleCollectionAnalyzer('.')
     structure = analyzer.analyze()
 
-    # Generate Mermaid diagram
+    # Generate Mermaid diagram and roles table
     mermaid_content = generate_mermaid(structure)
+    roles_table = generate_roles_table(structure)
 
     # Update README.md
-    if update_readme(mermaid_content):
-        print("✅ Architecture diagram updated in README.md")
+    diagram_ok = update_readme(mermaid_content)
+    table_ok = update_readme_roles_table(roles_table)
+    if diagram_ok and table_ok:
+        print("✅ Architecture diagram and roles table updated in README.md")
         print(f"\nCollection summary:")
         print(f"  • Roles: {len(structure['roles'])}")
         print(f"  • Plugins: {len(structure['plugins'])}")

--- a/README.md
+++ b/README.md
@@ -64,57 +64,32 @@ ansible-galaxy collection build --force && \
 
 ## Roles
 
-### ASDF
+Each role has its own README under `roles/<name>/README.md` with full variable
+docs and examples. The table below is regenerated from each role's
+`meta/main.yml` by `.hooks/gen-arch-diagram.py` on pre-commit — don't edit it
+by hand.
 
-Installs and configures [ASDF](https://asdf-vm.com/), a version manager for
-multiple language runtimes.
+<!-- ROLES TABLE START -->
 
-### Mise
+| Role | Description |
+| ---- | ----------- |
+| [`ansible_bootstrap`](roles/ansible_bootstrap/README.md) | Templates ~/.ansible.cfg and creates the ~/.ansible directory tree (collections, roles, fact_cache) plus the remote tmp directory. |
+| [`asdf`](roles/asdf/README.md) | Install asdf |
+| [`build_cleanup`](roles/build_cleanup/README.md) | General-purpose, parameterized cleanup role for build artifact minimization |
+| [`claude_code`](roles/claude_code/README.md) | Manages Claude Code CLI configuration including hooks and settings |
+| [`fabric`](roles/fabric/README.md) | Installs and configures Daniel Miessler's Fabric AI framework |
+| [`git_setup`](roles/git_setup/README.md) | Renders ~/.gitconfig with aliases and sane defaults |
+| [`go_task`](roles/go_task/README.md) | Installs go-task (Task runner) on Unix-like and Windows systems |
+| [`logging`](roles/logging/README.md) | Provides flexible logging directories and log rotation for any application or service. |
+| [`mise`](roles/mise/README.md) | Install mise |
+| [`package_management`](roles/package_management/README.md) | Manage package installations and cleanups on Debian-based and Red Hat-based systems |
+| [`shell_functions`](roles/shell_functions/README.md) | Deploys the user's dotfiles shell-function library to ~/.dotfiles |
+| [`tmux_setup`](roles/tmux_setup/README.md) | Renders ~/.tmux.conf with mouse-friendly bindings and OSC52 clipboard |
+| [`user_setup`](roles/user_setup/README.md) | Sets up user accounts with optional sudo privileges for Unix-like and Windows systems. |
+| [`vnc_setup`](roles/vnc_setup/README.md) | Installs and configures TigerVNC servers with per-user passwords and optional systemd units. |
+| [`zsh_setup`](roles/zsh_setup/README.md) | Installs and configures zsh with oh-my-zsh. |
 
-Installs and configures [mise](https://mise.jdx.dev/), a polyglot tool version
-manager and dev environment setup tool.
-
-### User Setup
-
-Sets up user accounts with optional sudo privileges on Unix-like systems.
-
-### Package Management
-
-Manages package installations and cleanups on Debian-based and Red Hat-based systems.
-
-### Zsh Setup
-
-Installs and configures Zsh with Oh-My-Zsh, setting up a robust shell environment.
-
-### VNC Setup
-
-Configures VNC services for remote desktop access, including password
-management and service setup.
-
-### Logging
-
-Creates logging directories and log rotation configurations for a provided path.
-
-### Fabric
-
-Installs and configures [Fabric](https://github.com/danielmiessler/fabric),
-an open-source AI framework for augmenting humans using AI.
-
-### Claude Code
-
-Installs and manages [Claude Code](https://docs.claude.com/en/docs/claude-code)
-CLI, including installation, configuration, hooks, and settings.
-
-### Go Task
-
-Installs and configures [go-task](https://taskfile.dev/), a task runner and
-build tool written in Go, providing a simpler alternative to Make.
-
-### Build Cleanup
-
-A general-purpose, parameterized cleanup role for build artifact minimization.
-Optimizes container images and build environments by removing unnecessary files,
-caches, and temporary artifacts.
+<!-- ROLES TABLE END -->
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -74,14 +74,14 @@ by hand.
 | Role | Description |
 | ---- | ----------- |
 | [`ansible_bootstrap`](roles/ansible_bootstrap/README.md) | Templates ~/.ansible.cfg and creates the ~/.ansible directory tree (collections, roles, fact_cache) plus the remote tmp directory. |
-| [`asdf`](roles/asdf/README.md) | Install asdf |
+| [`asdf`](roles/asdf/README.md) | Installs the asdf version manager, wires it into the user's shell, and installs configured plugins. |
 | [`build_cleanup`](roles/build_cleanup/README.md) | General-purpose, parameterized cleanup role for build artifact minimization |
 | [`claude_code`](roles/claude_code/README.md) | Manages Claude Code CLI configuration including hooks and settings |
 | [`fabric`](roles/fabric/README.md) | Installs and configures Daniel Miessler's Fabric AI framework |
 | [`git_setup`](roles/git_setup/README.md) | Renders ~/.gitconfig with aliases and sane defaults |
 | [`go_task`](roles/go_task/README.md) | Installs go-task (Task runner) on Unix-like and Windows systems |
 | [`logging`](roles/logging/README.md) | Provides flexible logging directories and log rotation for any application or service. |
-| [`mise`](roles/mise/README.md) | Install mise |
+| [`mise`](roles/mise/README.md) | Installs the mise polyglot tool version manager, wires it into the user's shell, and installs configured default tools. |
 | [`package_management`](roles/package_management/README.md) | Manage package installations and cleanups on Debian-based and Red Hat-based systems |
 | [`shell_functions`](roles/shell_functions/README.md) | Deploys the user's dotfiles shell-function library to ~/.dotfiles |
 | [`tmux_setup`](roles/tmux_setup/README.md) | Renders ~/.tmux.conf with mouse-friendly bindings and OSC52 clipboard |

--- a/roles/asdf/README.md
+++ b/roles/asdf/README.md
@@ -3,7 +3,7 @@
 
 ## Description
 
-Install asdf
+Installs the asdf version manager, wires it into the user's shell, and installs configured plugins.
 
 ## Requirements
 
@@ -117,6 +117,6 @@ Install asdf
 
 
 - Ubuntu: all
-- macOS: all
+- MacOSX: all
 - EL: all
 <!-- DOCSIBLE END -->

--- a/roles/asdf/meta/main.yml
+++ b/roles/asdf/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   role_name: asdf
   namespace: cowdogmoo
   author: Jayson Grace
-  description: Install asdf
+  description: Installs the asdf version manager, wires it into the user's shell, and installs configured plugins.
   company: CowDogMoo
   license: MIT
   min_ansible_version: "2.14"
@@ -11,7 +11,7 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - all
-    - name: macOS
+    - name: MacOSX
       versions:
         - all
     - name: EL

--- a/roles/build_cleanup/README.md
+++ b/roles/build_cleanup/README.md
@@ -231,7 +231,7 @@ General-purpose, parameterized cleanup role for build artifact minimization
 
 ## Author Information
 
-- **Author**: CowDogMoo
+- **Author**: Jayson Grace
 - **Company**: CowDogMoo
 - **License**: MIT
 

--- a/roles/build_cleanup/meta/main.yml
+++ b/roles/build_cleanup/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   role_name: build_cleanup
   namespace: cowdogmoo
-  author: CowDogMoo
+  author: Jayson Grace
   description: General-purpose, parameterized cleanup role for build artifact minimization
   company: CowDogMoo
 

--- a/roles/build_cleanup/molecule/deep_cleanup/molecule.yml
+++ b/roles/build_cleanup/molecule/deep_cleanup/molecule.yml
@@ -13,6 +13,7 @@ platforms:
   - name: ubuntu-deep-cleanup-test
     image: "geerlingguy/docker-ubuntu2404-ansible:latest"
     command: ""
+    pre_build_image: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host

--- a/roles/build_cleanup/molecule/deep_cleanup_preserve/molecule.yml
+++ b/roles/build_cleanup/molecule/deep_cleanup_preserve/molecule.yml
@@ -13,6 +13,7 @@ platforms:
   - name: ubuntu-deep-cleanup-preserve-test
     image: "geerlingguy/docker-ubuntu2404-ansible:latest"
     command: ""
+    pre_build_image: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host

--- a/roles/build_cleanup/molecule/default/molecule.yml
+++ b/roles/build_cleanup/molecule/default/molecule.yml
@@ -17,6 +17,7 @@ platforms:
     image: "geerlingguy/docker-ubuntu2404-ansible:latest"
     # Setting the command to this is necessary for systemd containers
     command: ""
+    pre_build_image: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host

--- a/roles/build_cleanup/molecule/version_managers/molecule.yml
+++ b/roles/build_cleanup/molecule/version_managers/molecule.yml
@@ -13,6 +13,7 @@ platforms:
   - name: ubuntu-version-managers-test
     image: "geerlingguy/docker-ubuntu2404-ansible:latest"
     command: ""
+    pre_build_image: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host

--- a/roles/claude_code/README.md
+++ b/roles/claude_code/README.md
@@ -113,7 +113,7 @@ Manages Claude Code CLI configuration including hooks and settings
 
 ## Author Information
 
-- **Author**: CowDogMoo
+- **Author**: Jayson Grace
 - **Company**: CowDogMoo
 - **License**: MIT
 

--- a/roles/claude_code/meta/main.yml
+++ b/roles/claude_code/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   role_name: claude_code
   namespace: cowdogmoo
-  author: CowDogMoo
+  author: Jayson Grace
   description: Manages Claude Code CLI configuration including hooks and settings
   company: CowDogMoo
   license: MIT

--- a/roles/fabric/README.md
+++ b/roles/fabric/README.md
@@ -125,7 +125,7 @@ Installs and configures Daniel Miessler's Fabric AI framework
 
 ## Author Information
 
-- **Author**: CowDogMoo
+- **Author**: Jayson Grace
 - **Company**: CowDogMoo
 - **License**: MIT
 

--- a/roles/fabric/meta/main.yml
+++ b/roles/fabric/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   role_name: fabric
   namespace: cowdogmoo
-  author: CowDogMoo
+  author: Jayson Grace
   description: Installs and configures Daniel Miessler's Fabric AI framework
   company: CowDogMoo
   license: MIT

--- a/roles/mise/README.md
+++ b/roles/mise/README.md
@@ -3,7 +3,7 @@
 
 ## Description
 
-Install mise
+Installs the mise polyglot tool version manager, wires it into the user's shell, and installs configured default tools.
 
 ## Requirements
 
@@ -137,6 +137,6 @@ Install mise
 
 
 - Ubuntu: all
-- macOS: all
+- MacOSX: all
 - EL: all
 <!-- DOCSIBLE END -->

--- a/roles/mise/meta/main.yml
+++ b/roles/mise/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   role_name: mise
   namespace: cowdogmoo
   author: Jayson Grace
-  description: Install mise
+  description: Installs the mise polyglot tool version manager, wires it into the user's shell, and installs configured default tools.
   company: CowDogMoo
   license: MIT
   min_ansible_version: "2.14"
@@ -11,7 +11,7 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - all
-    - name: macOS
+    - name: MacOSX
       versions:
         - all
     - name: EL

--- a/roles/package_management/meta/main.yml
+++ b/roles/package_management/meta/main.yml
@@ -29,3 +29,5 @@ galaxy_info:
     - kali
     - redhat
     - centos
+
+dependencies: []

--- a/roles/vnc_setup/README.md
+++ b/roles/vnc_setup/README.md
@@ -3,7 +3,7 @@
 
 ## Description
 
-Provides logging directories and log rotation for other roles.
+Installs and configures TigerVNC servers with per-user passwords and optional systemd units.
 
 ## Requirements
 

--- a/roles/vnc_setup/meta/main.yml
+++ b/roles/vnc_setup/meta/main.yml
@@ -1,9 +1,9 @@
 ---
 galaxy_info:
-  role_name: logging
+  role_name: vnc_setup
   author: Jayson Grace
   namespace: cowdogmoo
-  description: Provides logging directories and log rotation for other roles.
+  description: Installs and configures TigerVNC servers with per-user passwords and optional systemd units.
   company: CowDogMoo
   license: MIT
   min_ansible_version: "2.14"
@@ -18,8 +18,11 @@ galaxy_info:
       versions:
         - all
   galaxy_tags:
-    - user
-    - setup
+    - vnc
+    - tigervnc
+    - remote
+    - desktop
+    - workstation
 
 dependencies:
   - role: cowdogmoo.workstation.user_setup

--- a/roles/zsh_setup/README.md
+++ b/roles/zsh_setup/README.md
@@ -99,5 +99,8 @@ Installs and configures zsh with oh-my-zsh.
 
 
 - Ubuntu: all
-- macOS: all
+- Debian: all
+- Kali: all
+- EL: all
+- MacOSX: all
 <!-- DOCSIBLE END -->

--- a/roles/zsh_setup/meta/main.yml
+++ b/roles/zsh_setup/meta/main.yml
@@ -11,7 +11,16 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - all
-    - name: macOS
+    - name: Debian
+      versions:
+        - all
+    - name: Kali
+      versions:
+        - all
+    - name: EL
+      versions:
+        - all
+    - name: MacOSX
       versions:
         - all
   galaxy_tags:


### PR DESCRIPTION
**Key Changes:**

- Added an auto-generated roles table to the README that links to each role's README and is regenerated from `meta/main.yml` on pre-commit
- Extended the pre-commit hook to parse role descriptions and replace a marker-delimited table block in the README
- Corrected role metadata across the collection, including fixing the mislabeled `vnc_setup` role and standardizing author and platform names

**Added:**

- Roles table generation - Added `generate_roles_table`, `update_readme_section`, and `update_readme_roles_table` functions to `.hooks/gen-arch-diagram.py` to build a markdown table linking each role to its README and inject it between `<!-- ROLES TABLE START -->` and `<!-- ROLES TABLE END -->` markers
- Role description extraction - Added `_read_role_description` helper that parses `galaxy_info.description` from each role's `meta/main.yml` via regex to avoid a PyYAML hook dependency
- Empty dependencies declaration - Added `dependencies: []` to `package_management/meta/main.yml`

**Changed:**

- README roles section - Replaced the hand-maintained role descriptions with a single auto-generated table and explanatory note about regeneration on pre-commit
- Hook main flow - Updated `main()` to generate both the Mermaid diagram and roles table, tracking success of each update independently
- Role descriptions - Expanded vague descriptions (e.g. "Install asdf", "Install mise") into fuller summaries across `asdf`, `mise`, and `vnc_setup` metadata and READMEs
- Role metadata corrections - Fixed the `vnc_setup` role's `role_name`, description, and tags which were incorrectly set to logging values, and standardized the author from "CowDogMoo" to "Jayson Grace" in `build_cleanup`, `claude_code`, and `fabric`
- Platform naming - Standardized the macOS platform identifier to `MacOSX` in `asdf`, `mise`, and `zsh_setup`, and expanded `zsh_setup` supported platforms to include Debian, Kali, and EL