### PR TITLE
feat: add configurable tmux scrollback history limit

### DIFF
--- a/roles/tmux_setup/README.md
+++ b/roles/tmux_setup/README.md
@@ -18,6 +18,7 @@ Renders ~/.tmux.conf with mouse-friendly bindings and OSC52 clipboard
 | `tmux_setup_user_home` | str | <code>{{ ansible_facts&#91;'env'&#93;&#91;'HOME'&#93; }}</code> | No description |
 | `tmux_setup_conf_path` | str | <code>{{ tmux_setup_user_home }}/.tmux.conf</code> | No description |
 | `tmux_setup_default_terminal` | str | <code>screen-256color</code> | No description |
+| `tmux_setup_history_limit` | int | <code>100000</code> | No description |
 | `tmux_setup_clipboard_command` | str | <code>pbcopy</code> | No description |
 | `tmux_setup_backup` | bool | <code>True</code> | No description |
 | `tmux_setup_local_overrides_path` | str | <code>{{ tmux_setup_user_home }}/.tmux.conf.local</code> | No description |

--- a/roles/tmux_setup/defaults/main.yml
+++ b/roles/tmux_setup/defaults/main.yml
@@ -7,6 +7,9 @@ tmux_setup_conf_path: "{{ tmux_setup_user_home }}/.tmux.conf"
 # Terminal type advertised inside tmux.
 tmux_setup_default_terminal: "screen-256color"
 
+# Scrollback buffer size (lines retained per pane). Tmux default is 2000.
+tmux_setup_history_limit: 100000
+
 # Command used by `bind C` to copy the pane buffer to the system clipboard.
 # Defaults to macOS pbcopy; override for Linux (e.g. "xclip -selection clipboard").
 tmux_setup_clipboard_command: "pbcopy"

--- a/roles/tmux_setup/molecule/default/verify.yml
+++ b/roles/tmux_setup/molecule/default/verify.yml
@@ -27,6 +27,7 @@
       ansible.builtin.assert:
         that:
           - "'set -g default-terminal \"screen-256color\"' in cfg"
+          - "'set -g history-limit 100000' in cfg"
           - "'setw -g mouse on' in cfg"
           - "'set -g set-clipboard on' in cfg"
           - "'setw -g mode-keys vi' in cfg"

--- a/roles/tmux_setup/templates/tmux.conf.j2
+++ b/roles/tmux_setup/templates/tmux.conf.j2
@@ -2,6 +2,9 @@
 
 set -g default-terminal "{{ tmux_setup_default_terminal }}"
 
+# Scrollback buffer size
+set -g history-limit {{ tmux_setup_history_limit }}
+
 # Enable mouse support
 setw -g mouse on
 


### PR DESCRIPTION
**Key Changes:**

- Introduced a configurable scrollback buffer size for tmux panes, defaulting to 100000 lines (up from tmux's default of 2000)
- Wired the new setting through the role's template, defaults, and verification tests
- Documented the new variable in the role README

**Added:**

- Scrollback history variable - Added `tmux_setup_history_limit` (default `100000`) in `defaults/main.yml` to control lines retained per pane
- History-limit directive - Rendered `set -g history-limit` in `templates/tmux.conf.j2` using the new variable
- Verification coverage - Added a Molecule assertion in `molecule/default/verify.yml` to confirm the history-limit line appears in the generated config
- Documentation entry - Documented `tmux_setup_history_limit` in `README.md`