### PR TITLE
feat: add fabric tag to workstation playbook for targeted runs

### DIFF
--- a/playbooks/workstation/workstation.yml
+++ b/playbooks/workstation/workstation.yml
@@ -177,6 +177,8 @@
 
     - name: Install and configure Fabric AI framework
       role: cowdogmoo.workstation.fabric
+      tags:
+        - fabric
       # For debugging
       # role: ../../roles/fabric
       vars:


### PR DESCRIPTION
**Key Changes:**

- Enable targeted execution of the Fabric setup via the fabric tag
- Improve playbook flexibility for partial runs and faster debugging with --tags fabric
- Preserve default behavior when running the full play without tags

**Added:**

- fabric tag to the Fabric AI framework role to allow selective execution - playbooks/workstation/workstation.yml