### PR TITLE
build: add hashicorp tap, terraform, kubectl and kubectx to brewfile

### DIFF
--- a/roles/package_management/files/Brewfile
+++ b/roles/package_management/files/Brewfile
@@ -1,5 +1,6 @@
 tap "homebrew/bundle"
 tap "common-fate/granted"
+tap "hashicorp/tap"
 
 ### Cloud Service Providers ###
 # AWS
@@ -23,10 +24,12 @@ brew "grep"
 brew "logrotate"
 brew "netcat"
 brew "p7zip"
+brew "pstree"
 brew "htop"
 brew "tree"
 brew "watch"
 brew "wget"
+brew "zip"
 brew "zsh-completions"
 
 ### Bash Scripting Utilities ###
@@ -37,6 +40,7 @@ brew "bats-core"
 
 ### Cloud Agnostic Infrastructure Management ###
 # These tools are used to build, change, and version infrastructure efficiently and safely across multiple providers
+brew "hashicorp/tap/terraform"
 brew "terraform-docs"
 brew "terragrunt"
 brew "tflint"
@@ -47,6 +51,10 @@ cask "docker"
 brew "helm"
 # Lightweight utility to set up k3s on any local or remote VM
 brew "k3sup"
+# Switch between kubectl contexts/namespaces (also installs kubens)
+brew "kubectx"
+# Kubernetes command-line tool
+brew "kubernetes-cli"
 # Template-free customization of Kubernetes YAML manifests
 brew "kustomize"
 # Create k8s test environments
@@ -86,6 +94,10 @@ brew "jadx"
 ### Compression Utility ###
 # General-purpose data compression software with high compression ratio
 brew "xz"
+
+### macOS System Utilities ###
+# Command-line interface for managing Bluetooth on macOS
+brew "blueutil"
 
 ### Web Browsers ###
 # Various web browsers


### PR DESCRIPTION
**Key Changes:**

- Add HashiCorp tap and install Terraform from the official tap for consistent versioning
- Expand Kubernetes tooling with kubectl and kubectx/kubens to streamline cluster operations
- Introduce new CLI utilities (pstree, zip) to improve process inspection and archiving
- Add macOS Bluetooth control via blueutil for scripting system settings

**Added:**

- Official HashiCorp distribution of Terraform - Added hashicorp/tap and hashicorp/tap/terraform to ensure reliable updates and provenance - roles/package_management/files/Brewfile
- Kubernetes tooling - Added kubernetes-cli (kubectl) and kubectx (also installs kubens) to manage clusters, contexts, and namespaces more efficiently - roles/package_management/files/Brewfile
- Process and archive utilities - Added pstree for process hierarchy visualization and zip for standard zip compression workflows - roles/package_management/files/Brewfile
- macOS system utility - Added blueutil for command-line Bluetooth management in automation scripts - roles/package_management/files/Brewfile