### PR TITLE
refactor: simplify zsh_setup role and improve privilege escalation logic

### DIFF
--- a/roles/zsh_setup/README.md
+++ b/roles/zsh_setup/README.md
@@ -9,11 +9,6 @@ Installs and configures zsh with oh-my-zsh.
 
 - Ansible >= 2.14
 
-## Dependencies
-
-
-- cowdogmoo.workstation.package_management
-
 ## Role Variables
 
 ### Default Variables (main.yml)
@@ -40,6 +35,7 @@ Installs and configures zsh with oh-my-zsh.
 | `zsh_setup_android_sdk_path` | str | <code>{{ zsh_setup_user_home }}/Library/Android/sdk/platform-tools</code> | No description |
 | `zsh_setup_source_shell_functions` | bool | <code>True</code> | No description |
 | `zsh_setup_shell_functions_dir` | str | <code>{{ zsh_setup_user_home }}/.dotfiles</code> | No description |
+| `zsh_setup_install_packages` | bool | <code>True</code> | No description |
 
 ### Role Variables (main.yml)
 
@@ -68,7 +64,7 @@ Installs and configures zsh with oh-my-zsh.
 
 
 - **Include tasks to get user home directory** (ansible.builtin.include_tasks)
-- **Install required packages for zsh** (ansible.builtin.include_role)
+- **Install required packages for zsh** (ansible.builtin.include_role) - Conditional
 - **Ensure user group exists** (ansible.builtin.group) - Conditional
 - **Ensure user exists** (ansible.builtin.user) - Conditional
 - **Include common tasks** (ansible.builtin.include_tasks)

--- a/roles/zsh_setup/defaults/main.yml
+++ b/roles/zsh_setup/defaults/main.yml
@@ -37,3 +37,6 @@ zsh_setup_android_sdk_path: "{{ zsh_setup_user_home }}/Library/Android/sdk/platf
 # cowdogmoo.workstation.shell_functions role to populate the directory.
 zsh_setup_source_shell_functions: true
 zsh_setup_shell_functions_dir: "{{ zsh_setup_user_home }}/.dotfiles"
+
+# Whether to run the package_management role to install packages
+zsh_setup_install_packages: true

--- a/roles/zsh_setup/meta/main.yml
+++ b/roles/zsh_setup/meta/main.yml
@@ -25,5 +25,4 @@ galaxy_info:
         - all
   galaxy_tags:
     - zsh
-dependencies:
-  - role: cowdogmoo.workstation.package_management
+dependencies: []

--- a/roles/zsh_setup/tasks/common.yml
+++ b/roles/zsh_setup/tasks/common.yml
@@ -3,7 +3,7 @@
   ansible.builtin.include_tasks: "../../mise/tasks/ensure_directory_exists.yml"
   args:
     apply:
-      become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+      become: "{{ ansible_facts['os_family'] != 'Darwin' and zsh_setup_username != ansible_facts['user_id'] }}"
   vars:
     directories:
       - path: "{{ zsh_setup_user_home }}"
@@ -22,7 +22,7 @@
     url: "{{ zsh_setup_omz_install_script_url }}"
     dest: "{{ zsh_setup_user_home }}/omz-installer.sh"
     mode: '0755'
-  become: true
+  become: "{{ zsh_setup_username != ansible_facts['user_id'] }}"
   become_user: "{{ zsh_setup_username }}"
   when: not zsh_setup_oh_my_zsh_installed.stat.exists
 
@@ -51,7 +51,7 @@
   environment:
     HOME: "{{ zsh_setup_user_home }}"
     ZSH: "{{ zsh_setup_user_home }}/.oh-my-zsh"
-  become: true
+  become: "{{ zsh_setup_username != ansible_facts['user_id'] }}"
   become_user: "{{ zsh_setup_username }}"
   when: not zsh_setup_oh_my_zsh_installed.stat.exists
 
@@ -59,7 +59,7 @@
   ansible.builtin.file:
     path: "{{ zsh_setup_user_home }}/omz-installer.sh"
     state: absent
-  become: true
+  become: "{{ zsh_setup_username != ansible_facts['user_id'] }}"
   become_user: "{{ zsh_setup_username }}"
   when: zsh_setup_oh_my_zsh_installed.stat.exists
   changed_when: false
@@ -71,6 +71,6 @@
     dest: "{{ zsh_setup_user_home }}/.zshrc"
     mode: "0644"
     backup: "{{ zsh_setup_backup_zshrc }}"
-  become: true
+  become: "{{ zsh_setup_username != ansible_facts['user_id'] }}"
   become_user: "{{ zsh_setup_username }}"
   when: zsh_setup_manage_zshrc | bool

--- a/roles/zsh_setup/tasks/main.yml
+++ b/roles/zsh_setup/tasks/main.yml
@@ -7,6 +7,7 @@
     name: cowdogmoo.workstation.package_management
   vars:
     package_management_common_install_packages: "{{ zsh_setup_common_install_packages }}"
+  when: zsh_setup_install_packages | default(true) | bool
 
 - name: Ensure user group exists
   ansible.builtin.group:

--- a/roles/zsh_setup/tasks/zsh_setup_get_user_home.yml
+++ b/roles/zsh_setup/tasks/zsh_setup_get_user_home.yml
@@ -15,7 +15,7 @@
 
 - name: Set user home directory
   ansible.builtin.set_fact:
-    zsh_setup_user_home: "{{ zsh_setup_getent_passwd[zsh_setup_username].home | default('/root' if zsh_setup_username == 'root' else '/home/' + zsh_setup_username) }}"
+    zsh_setup_user_home: "{{ ansible_facts.getent_passwd[zsh_setup_username][4] | default('/root' if zsh_setup_username == 'root' else '/home/' + zsh_setup_username) }}"
   when: ansible_facts['os_family'] != 'Darwin'
 
 - name: Set user home directory for macOS

--- a/roles/zsh_setup/templates/zshrc.j2
+++ b/roles/zsh_setup/templates/zshrc.j2
@@ -53,6 +53,10 @@ source_dotfiles() {
     [[ -d "$dir" ]] || return
     while IFS= read -r -d '' script; do
         if [[ -f "$script" && -r "$script" && ! "$script" =~ /files/ ]]; then
+            # Skip macOS specific scripts on non-Darwin platforms
+            if [[ "$script" =~ "macos.sh$" && "$(uname)" != "Darwin" ]]; then
+                continue
+            fi
             # shellcheck source=/dev/null
             source "$script"
         fi


### PR DESCRIPTION
**Key Changes:**

- Made `become` conditional throughout `zsh_setup` tasks so the role works correctly when running as the target user, avoiding unnecessary privilege escalation
- Decoupled `package_management` role dependency from `zsh_setup`, making package installation optional via a new `zsh_setup_install_packages` flag
- Added macOS-specific script filtering in `zshrc.j2` to skip `macos.sh` on non-Darwin platforms
- Fixed home directory lookup to use the correct `ansible_facts.getent_passwd` index access

**Added:**

- Optional package installation flag — `zsh_setup_install_packages: true` default in `defaults/main.yml`, giving callers control over whether the role triggers `package_management`
- macOS script guard in `zshrc.j2` to skip sourcing `macos.sh` on non-Darwin systems, preventing errors when the dotfiles directory contains platform-specific scripts

**Changed:**

- Replaced unconditional `become: true` with `become: "{{ zsh_setup_username != ansible_facts['user_id'] }}"` across all tasks in `common.yml`, and similarly conditioned the `ensure_directory_exists` include to avoid unnecessary privilege escalation when the target user matches the current user
- Added `when: zsh_setup_install_packages | default(true) | bool` to the `package_management` role inclusion in `main.yml`, allowing callers to skip package installation when already handled elsewhere
- Updated `zsh_setup_get_user_home.yml` to use `ansible_facts.getent_passwd[zsh_setup_username][4]` (standard index-based access) instead of the undefined `zsh_setup_getent_passwd.home` attribute

**Removed:**

- Hard `cowdogmoo.workstation.package_management` entry from `meta/main.yml` dependencies (and the corresponding `Dependencies` section from `README.md`), replacing the implicit dependency with the explicit `zsh_setup_install_packages` flag