### PR TITLE
feat: add antigravity ansible role for cli configuration management

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -119,7 +119,7 @@ jobs:
             MATRIX_JSON="["
             FIRST=true
             for role_path in roles/*; do
-              if [ -d "$role_path" ]; then
+              if [ -d "$role_path" ] && [ -d "$role_path/molecule" ]; then
                 role=$(basename "$role_path")
                 if [[ "$FIRST" == "true" ]]; then
                   FIRST=false
@@ -130,7 +130,7 @@ jobs:
               fi
             done
             for pb_path in playbooks/*; do
-              if [ -d "$pb_path" ]; then
+              if [ -d "$pb_path" ] && [ -d "$pb_path/molecule" ]; then
                 pb=$(basename "$pb_path")
                 if [[ "$FIRST" == "true" ]]; then
                   FIRST=false
@@ -161,7 +161,7 @@ jobs:
 
             # Always add all playbooks
             for pb_path in playbooks/*; do
-              if [ -d "$pb_path" ]; then
+              if [ -d "$pb_path" ] && [ -d "$pb_path/molecule" ]; then
                 pb=$(basename "$pb_path")
                 if [[ "$FIRST" == "true" ]]; then
                   FIRST=false

--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -115,8 +115,32 @@ jobs:
         working-directory: ${{ env.COLLECTION_PATH }}
         run: |
           if [[ "${{ steps.check-event.outputs.test_all }}" == "true" ]]; then
-            # Test all roles and playbooks
-            MATRIX_JSON='[{"name":"Role Test - antigravity","path":"roles/antigravity"},{"name":"Role Test - asdf","path":"roles/asdf"},{"name":"Role Test - claude_code","path":"roles/claude_code"},{"name":"Role Test - fabric","path":"roles/fabric"},{"name":"Role Test - go_task","path":"roles/go_task"},{"name":"Role Test - logging","path":"roles/logging"},{"name":"Role Test - package_management","path":"roles/package_management"},{"name":"Role Test - user_setup","path":"roles/user_setup"},{"name":"Role Test - vnc_setup","path":"roles/vnc_setup"},{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"},{"name":"Playbook Test - workstation","path":"playbooks/workstation"},{"name":"Playbook Test - vnc_box","path":"playbooks/vnc_box"}]'
+            # Test all roles and playbooks dynamically
+            MATRIX_JSON="["
+            FIRST=true
+            for role_path in roles/*; do
+              if [ -d "$role_path" ]; then
+                role=$(basename "$role_path")
+                if [[ "$FIRST" == "true" ]]; then
+                  FIRST=false
+                else
+                  MATRIX_JSON+=","
+                fi
+                MATRIX_JSON+="{\"name\":\"Role Test - ${role}\",\"path\":\"roles/${role}\"}"
+              fi
+            done
+            for pb_path in playbooks/*; do
+              if [ -d "$pb_path" ]; then
+                pb=$(basename "$pb_path")
+                if [[ "$FIRST" == "true" ]]; then
+                  FIRST=false
+                else
+                  MATRIX_JSON+=","
+                fi
+                MATRIX_JSON+="{\"name\":\"Playbook Test - ${pb}\",\"path\":\"playbooks/${pb}\"}"
+              fi
+            done
+            MATRIX_JSON+="]"
           else
             # Test only changed roles + all playbooks
             ROLES="${{ steps.filter.outputs.roles }}"
@@ -136,10 +160,18 @@ jobs:
             fi
 
             # Always add all playbooks
-            if [[ "$FIRST" == "false" ]]; then
-              MATRIX_JSON+=","
-            fi
-            MATRIX_JSON+='{"name":"Playbook Test - workstation","path":"playbooks/workstation"},{"name":"Playbook Test - vnc_box","path":"playbooks/vnc_box"}]'
+            for pb_path in playbooks/*; do
+              if [ -d "$pb_path" ]; then
+                pb=$(basename "$pb_path")
+                if [[ "$FIRST" == "true" ]]; then
+                  FIRST=false
+                else
+                  MATRIX_JSON+=","
+                fi
+                MATRIX_JSON+="{\"name\":\"Playbook Test - ${pb}\",\"path\":\"playbooks/${pb}\"}"
+              fi
+            done
+            MATRIX_JSON+="]"
           fi
 
           echo "matrix=$MATRIX_JSON" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -116,7 +116,7 @@ jobs:
         run: |
           if [[ "${{ steps.check-event.outputs.test_all }}" == "true" ]]; then
             # Test all roles and playbooks
-            MATRIX_JSON='[{"name":"Role Test - asdf","path":"roles/asdf"},{"name":"Role Test - claude_code","path":"roles/claude_code"},{"name":"Role Test - fabric","path":"roles/fabric"},{"name":"Role Test - go_task","path":"roles/go_task"},{"name":"Role Test - logging","path":"roles/logging"},{"name":"Role Test - package_management","path":"roles/package_management"},{"name":"Role Test - user_setup","path":"roles/user_setup"},{"name":"Role Test - vnc_setup","path":"roles/vnc_setup"},{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"},{"name":"Playbook Test - workstation","path":"playbooks/workstation"},{"name":"Playbook Test - vnc_box","path":"playbooks/vnc_box"}]'
+            MATRIX_JSON='[{"name":"Role Test - antigravity","path":"roles/antigravity"},{"name":"Role Test - asdf","path":"roles/asdf"},{"name":"Role Test - claude_code","path":"roles/claude_code"},{"name":"Role Test - fabric","path":"roles/fabric"},{"name":"Role Test - go_task","path":"roles/go_task"},{"name":"Role Test - logging","path":"roles/logging"},{"name":"Role Test - package_management","path":"roles/package_management"},{"name":"Role Test - user_setup","path":"roles/user_setup"},{"name":"Role Test - vnc_setup","path":"roles/vnc_setup"},{"name":"Role Test - zsh_setup","path":"roles/zsh_setup"},{"name":"Playbook Test - workstation","path":"playbooks/workstation"},{"name":"Playbook Test - vnc_box","path":"playbooks/vnc_box"}]'
           else
             # Test only changed roles + all playbooks
             ROLES="${{ steps.filter.outputs.roles }}"

--- a/README.md
+++ b/README.md
@@ -21,20 +21,21 @@ graph TD
     Plugins --> P2[vnc_pw]
     Collection --> Roles[⚙️ Roles]
     Roles --> R0[ansible_bootstrap 🧪]
-    Roles --> R1[asdf 🧪]
-    Roles --> R2[build_cleanup 🧪]
-    Roles --> R3[claude_code 🧪]
-    Roles --> R4[fabric 🧪]
-    Roles --> R5[git_setup 🧪]
-    Roles --> R6[go_task 🧪]
-    Roles --> R7[logging 🧪]
-    Roles --> R8[mise 🧪]
-    Roles --> R9[package_management 🧪]
-    Roles --> R10[shell_functions 🧪]
-    Roles --> R11[tmux_setup 🧪]
-    Roles --> R12[user_setup 🧪]
-    Roles --> R13[vnc_setup 🧪]
-    Roles --> R14[zsh_setup 🧪]
+    Roles --> R1[antigravity 🧪]
+    Roles --> R2[asdf 🧪]
+    Roles --> R3[build_cleanup 🧪]
+    Roles --> R4[claude_code 🧪]
+    Roles --> R5[fabric 🧪]
+    Roles --> R6[git_setup 🧪]
+    Roles --> R7[go_task 🧪]
+    Roles --> R8[logging 🧪]
+    Roles --> R9[mise 🧪]
+    Roles --> R10[package_management 🧪]
+    Roles --> R11[shell_functions 🧪]
+    Roles --> R12[tmux_setup 🧪]
+    Roles --> R13[user_setup 🧪]
+    Roles --> R14[vnc_setup 🧪]
+    Roles --> R15[zsh_setup 🧪]
     Collection --> Playbooks[📚 Playbooks]
     Playbooks --> PB0[asdf]
     Playbooks --> PB1[mise]
@@ -74,6 +75,7 @@ by hand.
 | Role | Description |
 | ---- | ----------- |
 | [`ansible_bootstrap`](roles/ansible_bootstrap/README.md) | Templates ~/.ansible.cfg and creates the ~/.ansible directory tree (collections, roles, fact_cache) plus the remote tmp directory. |
+| [`antigravity`](roles/antigravity/README.md) | Manages Antigravity CLI configuration including hooks and settings |
 | [`asdf`](roles/asdf/README.md) | Installs the asdf version manager, wires it into the user's shell, and installs configured plugins. |
 | [`build_cleanup`](roles/build_cleanup/README.md) | General-purpose, parameterized cleanup role for build artifact minimization |
 | [`claude_code`](roles/claude_code/README.md) | Manages Claude Code CLI configuration including hooks and settings |

--- a/playbooks/workstation/workstation.yml
+++ b/playbooks/workstation/workstation.yml
@@ -222,6 +222,13 @@
       # For debugging
       # role: ../../roles/claude_code
 
+    - name: Install and configure Antigravity CLI
+      role: cowdogmoo.workstation.antigravity
+      tags:
+        - antigravity
+      # For debugging
+      # role: ../../roles/antigravity
+
     - name: Install Go Task
       role: cowdogmoo.workstation.go_task
       tags:

--- a/roles/antigravity/README.md
+++ b/roles/antigravity/README.md
@@ -1,0 +1,104 @@
+<!-- DOCSIBLE START -->
+# antigravity
+
+## Description
+
+Manages Antigravity CLI configuration including hooks and settings
+
+## Requirements
+
+- Ansible >= 2.15
+
+## Role Variables
+
+### Default Variables (main.yml)
+
+| Variable | Type | Default | Description |
+| -------- | ---- | ------- | ----------- |
+| `antigravity_username` | str | <code>{{ ansible_facts&#91;'user_id'&#93; &#124; default(ansible_facts&#91;'user'&#93;) }}</code> | No description |
+| `antigravity_usergroup` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary('staff', antigravity_username) }}</code> | No description |
+| `antigravity_user_home` | str | <code><multiline value: folded_strip></code> | No description |
+| `antigravity_config_dir` | str | <code>{{ antigravity_user_home }}/.gemini/config</code> | No description |
+| `antigravity_homebrew_prefix` | str | <code><multiline value: folded_strip></code> | No description |
+| `antigravity_path` | str | <code>{{ antigravity_homebrew_prefix }}/bin:{{ antigravity_user_home }}/.local/bin:/usr/local/bin:/usr/bin:/bin</code> | No description |
+| `antigravity_install` | bool | <code>True</code> | No description |
+| `antigravity_manage_settings` | bool | <code>True</code> | No description |
+| `antigravity_manage_plugins` | bool | <code>True</code> | No description |
+| `antigravity_plugins` | list | <code>&#91;&#93;</code> | No description |
+
+## Tasks
+
+### install-linux.yml
+
+
+- **Check if already installed** (ansible.builtin.command)
+- **Install via Homebrew** (community.general.homebrew) - Conditional
+- **Print manual install notice** (ansible.builtin.debug) - Conditional
+- **Verify installation** (ansible.builtin.command)
+- **Display version** (ansible.builtin.debug) - Conditional
+
+### install-macos.yml
+
+
+- **Check if already installed** (ansible.builtin.command)
+- **Install via Homebrew** (community.general.homebrew) - Conditional
+- **Verify installation** (ansible.builtin.command)
+- **Display version** (ansible.builtin.debug) - Conditional
+
+### install-windows.yml
+
+
+- **Check if already installed** (ansible.builtin.command)
+- **Print manual install notice** (ansible.builtin.debug) - Conditional
+- **Verify installation** (ansible.builtin.command)
+- **Display version** (ansible.builtin.debug) - Conditional
+
+### main.yml
+
+
+- **Set antigravity username for Kali systems** (ansible.builtin.set_fact) - Conditional
+- **Ensure antigravity user home directory exists** (ansible.builtin.stat)
+- **Fail if user home directory doesn't exist** (ansible.builtin.fail) - Conditional
+- **Install Antigravity on macOS** (ansible.builtin.include_tasks) - Conditional
+- **Install Antigravity on Linux** (ansible.builtin.include_tasks) - Conditional
+- **Install Antigravity on Windows** (ansible.builtin.include_tasks) - Conditional
+- **Create Antigravity configuration directory** (ansible.builtin.file)
+- **Install global AGENTS.md instructions** (ansible.builtin.copy) - Conditional
+- **Manage plugins** (ansible.builtin.include_tasks) - Conditional
+- **Display configuration status** (ansible.builtin.debug)
+
+### manage-plugin.yml
+
+
+- **Check if plugin exists - {{ plugin.name }}** (ansible.builtin.set_fact)
+- **Remove plugin - {{ plugin.name }}** (ansible.builtin.command) - Conditional
+- **Add plugin - {{ plugin.name }}** (ansible.builtin.command) - Conditional
+
+### manage-plugins.yml
+
+
+- **Get list of currently installed plugins** (ansible.builtin.command)
+- **Manage plugins** (ansible.builtin.include_tasks)
+
+## Example Playbook
+
+```yaml
+- hosts: servers
+  roles:
+    - antigravity
+```
+
+## Author Information
+
+- **Author**: Jayson Grace
+- **Company**: CowDogMoo
+- **License**: MIT
+
+## Platforms
+
+
+- Ubuntu: focal, jammy
+- Debian: bullseye, bookworm
+- EL: 8, 9
+- MacOSX: all
+<!-- DOCSIBLE END -->

--- a/roles/antigravity/defaults/main.yml
+++ b/roles/antigravity/defaults/main.yml
@@ -1,0 +1,35 @@
+---
+antigravity_username: "{{ ansible_facts['user_id'] | default(ansible_facts['user']) }}"
+antigravity_usergroup: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary('staff', antigravity_username) }}"
+antigravity_user_home: >-
+  {{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['env']['HOME'],
+     (antigravity_username == 'root') | ternary('/root', '/home/' + antigravity_username)) }}
+
+# Configuration directory for Agy
+antigravity_config_dir: "{{ antigravity_user_home }}/.gemini/config"
+
+# Homebrew prefix (varies by OS/architecture)
+antigravity_homebrew_prefix: >-
+  {{ (ansible_facts['os_family'] == 'Darwin') | ternary(
+       (ansible_facts['architecture'] == 'arm64') | ternary('/opt/homebrew', '/usr/local'),
+       '/home/linuxbrew/.linuxbrew') }}
+
+# PATH for agy CLI commands
+antigravity_path: "{{ antigravity_homebrew_prefix }}/bin:{{ antigravity_user_home }}/.local/bin:/usr/local/bin:/usr/bin:/bin"
+
+# Whether to install Antigravity CLI
+antigravity_install: true
+
+# Whether to manage Agy settings
+antigravity_manage_settings: true
+
+# Plugin Management
+antigravity_manage_plugins: true  # Whether to manage plugins
+
+# List of plugins to install
+# Each plugin supports: name, target, state
+antigravity_plugins: []
+# Example:
+#   - name: python_debugger
+#     target: python_debugger@latest
+#     state: present

--- a/roles/antigravity/files/AGENTS.md
+++ b/roles/antigravity/files/AGENTS.md
@@ -1,0 +1,68 @@
+# Global Agy Instructions
+
+## CRITICAL: .gemini Directory
+
+**NEVER EVER commit the .gemini directory or any of its contents to git!**
+
+- The `.gemini/` directory and its contents are personal/local configuration
+- Always ensure `.gemini/` is in `.gitignore`
+- Never add, stage, or commit any files from `.gemini/`
+- If `.gemini/` appears in git status as staged, immediately run `git restore --staged .gemini/`
+
+## Git Workflow
+
+### Commits
+
+Always use `fabric_commit` for commit messages:
+
+```bash
+fabric_commit
+```
+
+**NEVER EVER use --no-verify when committing or there will be dire consequences!**
+
+- Never skip pre-commit hooks with `--no-verify` or `-n`
+- Hooks are there for critical validation and security checks
+- If a commit fails due to hooks, fix the issue and create a NEW commit
+- Bypassing hooks can lead to broken builds, security vulnerabilities, and other serious problems
+
+### Pull Requests
+
+Always use the `fabric_pr` function to create pull requests:
+
+```bash
+fabric_pr
+```
+
+**CRITICAL POST-CREATION VERIFICATION**:
+
+After `fabric_pr` creates the PR, you MUST verify and fix if needed:
+
+1. **Check the created PR** using `gh pr view` to see the title and body
+2. **Verify requirements**:
+   - **No code fences (```)** in the title or body
+   - **No duplicate title** - the title text must NOT appear in the body
+3. **If violations found**, update the PR immediately using `gh pr edit`:
+
+   ```bash
+   gh pr edit --body "corrected body without code fences or duplicate title"
+   ```
+
+The `fabric_pr` function should handle these automatically, but you must verify and correct any issues in the created PR.
+
+## Modern CLI Tools
+
+Prefer these modern equivalents when installed — they are faster and have better defaults. They are **not** strict drop-ins; verify flags before substituting in scripts.
+
+- `rg` (ripgrep) over `grep` — respects `.gitignore`, parallel
+- `fd` over `find` — simpler positional syntax; for quick lookups, not complex `find -exec` chains
+- `bat -pp` over `cat` — `-pp` disables paging and decoration for tool-friendly output
+- `delta` for diffs — pipe `git diff` / `diff -u` through it for readable output
+- `dust` over `du` — tree-style disk usage
+- `duf` over `df` — clearer filesystem summary
+
+Fall back to the classic tool if the modern one is unavailable.
+
+## Notes
+
+- `git d main` shows the diff against the main branch

--- a/roles/antigravity/files/AGENTS.md
+++ b/roles/antigravity/files/AGENTS.md
@@ -1,4 +1,4 @@
-# Global Agy Instructions
+# Global Antigravity Instructions
 
 ## CRITICAL: .gemini Directory
 

--- a/roles/antigravity/meta/main.yml
+++ b/roles/antigravity/meta/main.yml
@@ -1,0 +1,33 @@
+---
+galaxy_info:
+  role_name: antigravity
+  namespace: cowdogmoo
+  author: Jayson Grace
+  description: Manages Antigravity CLI configuration including hooks and settings
+  company: CowDogMoo
+  license: MIT
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - focal
+        - jammy
+    - name: Debian
+      versions:
+        - bullseye
+        - bookworm
+    - name: EL
+      versions:
+        - "8"
+        - "9"
+    - name: MacOSX
+      versions:
+        - all
+  galaxy_tags:
+    - development
+    - claude
+    - ai
+    - configuration
+    - cli
+
+dependencies: []

--- a/roles/antigravity/molecule/default/README.md
+++ b/roles/antigravity/molecule/default/README.md
@@ -1,0 +1,130 @@
+# Molecule Tests for Antigravity Role
+
+This directory contains Molecule tests for the `antigravity` role, testing the installation and configuration of Antigravity CLI.
+
+## Test Scenarios
+
+### Multi-Platform Testing
+
+Tests are executed on multiple platforms:
+
+- **Ubuntu 22.04** (`ubuntu-agy-code`) - Ubuntu LTS
+- **Kali Linux** (`kali-agy-code`) - Debian-based security distribution
+
+## What is Tested
+
+### 1. Installation
+
+- ✅ Antigravity CLI is installed
+- ✅ Binary is accessible in PATH
+- ✅ Version command works correctly
+
+### 2. Configuration Directory
+
+- ✅ Config directory (`~/.gemini/config`) is created
+- ✅ Directory has correct permissions (0755)
+- ✅ Directory has correct ownership
+
+### 3. Settings Management
+
+- ✅ settings.json is created
+- ✅ File has correct permissions (0644)
+- ✅ File has correct ownership
+- ✅ Settings contain valid JSON
+
+### 4. Simple Hooks Configuration
+
+- ✅ Simple hooks are converted to proper Antigravity format
+- ✅ `command_contains` pattern matching works
+- ✅ `command_pattern` regex matching works
+- ✅ `exclude_pattern` filtering works
+- ✅ `action` (notify/block) is correctly converted to exit codes
+- ✅ Messages are properly embedded in Python commands
+- ✅ All hooks have correct structure (matcher, hooks array)
+
+### 5. Advanced Hooks Configuration
+
+- ✅ Advanced hooks are preserved as-is
+- ✅ Custom Python commands are included correctly
+- ✅ Mixed simple and advanced hooks work together
+- ✅ Hooks are properly grouped by event and tool
+
+### 6. Edge Cases
+
+- ✅ Empty hooks configuration (no hooks at all)
+- ✅ Simple hooks only (no advanced hooks)
+- ✅ Advanced hooks only (no simple hooks)
+- ✅ Mixed hooks (both simple and advanced)
+
+### 7. Backup Functionality
+
+- ✅ Backup files are created when settings exist
+- ✅ Backups use timestamped naming
+
+### 8. Idempotency
+
+- ✅ Role runs twice without changes on second run
+- ✅ Demonstrates proper Ansible idempotency
+
+## Running the Tests
+
+```bash
+# Run all tests
+cd roles/antigravity
+molecule test
+
+# Run individual steps
+molecule create      # Create test containers
+molecule prepare     # Install Node.js and npm
+molecule converge    # Apply the role
+molecule verify      # Run verification tests
+molecule destroy     # Clean up
+
+# Debug mode
+molecule converge -- -vvv
+
+# Test on specific platform
+molecule test -s default -- --platform-name ubuntu-agy-code
+```
+
+## Test Dependencies
+
+The prepare phase installs:
+
+- Node.js 18+
+- npm
+
+These are required for Antigravity CLI installation via npm.
+
+## Expected Outcomes
+
+All tests should pass, demonstrating that:
+
+1. Antigravity CLI is properly installed on both Ubuntu and Kali
+2. Configuration is correctly generated in `~/.gemini/config/settings.json`
+3. Simple hooks are converted to Antigravity JSON format correctly
+4. Advanced hooks are preserved and mixed with simple hooks
+5. All hook patterns (contains, regex, exclude) work correctly
+6. Edge cases (empty, simple-only, advanced-only) are handled
+7. Files have correct permissions and ownership
+8. The role is fully idempotent
+9. Backups are created when appropriate
+
+## Hook Testing Details
+
+Tests verify simple hooks are converted to Python commands with:
+
+- Proper `hooks.PreToolUse` JSON structure
+- Correct `matcher` field
+- Pattern matching logic embedded
+- Messages properly escaped
+- Correct exit codes (0=notify, 2=block)
+
+## Troubleshooting
+
+If tests fail:
+
+1. **Installation failures**: Check if npm is available in the container
+2. **Permission errors**: Verify user/group settings in converge.yml
+3. **Path issues**: Ensure PATH includes npm global bin directory
+4. **JSON parsing errors**: Validate settings.json template syntax

--- a/roles/antigravity/molecule/default/callback_plugins/profile_tasks.py
+++ b/roles/antigravity/molecule/default/callback_plugins/profile_tasks.py
@@ -1,0 +1,29 @@
+# molecule/default/callback_plugins/profile_tasks.py
+from ansible.plugins.callback import CallbackBase
+import time
+
+class CallbackModule(CallbackBase):
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'aggregate'
+    CALLBACK_NAME = 'profile_tasks'
+    CALLBACK_NEEDS_WHITELIST = False
+
+    def __init__(self):
+        super(CallbackModule, self).__init__()
+        self.stats = {}
+
+    def v2_runner_on_ok(self, result, **kwargs):
+        task_name = result._task.get_name()
+        task_time = time.time() - self.start_time
+        if task_name not in self.stats:
+            self.stats[task_name] = []
+        self.stats[task_name].append(task_time)
+
+    def v2_playbook_on_task_start(self, task, is_conditional):
+        self.start_time = time.time()
+
+    def v2_playbook_on_stats(self, stats):
+        for task_name, timings in self.stats.items():
+            total_time = sum(timings)
+            average_time = total_time / len(timings)
+            print(f"Task: {task_name} - Total Time: {total_time:.2f}s, Average Time: {average_time:.2f}s")

--- a/roles/antigravity/molecule/default/converge.yml
+++ b/roles/antigravity/molecule/default/converge.yml
@@ -1,0 +1,47 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    container_user: "{{ ansible_facts['distribution'] | lower }}"
+    container_home: "/home/{{ container_user }}"
+  tasks:
+    - name: Set home directory fact  # noqa: var-naming[no-role-prefix]
+      ansible.builtin.set_fact:
+        ansible_env:
+          HOME: "{{ container_home }}"
+
+    - name: Include default variables
+      ansible.builtin.include_vars:
+        file: "../../defaults/main.yml"
+
+    - name: Include role under test (first run)
+      ansible.builtin.include_role:
+        name: cowdogmoo.workstation.antigravity
+      vars:
+        antigravity_username: "{{ container_user }}"
+        antigravity_user_home: "{{ container_home }}"
+        antigravity_config_dir: "{{ container_home }}/.gemini/config"
+        antigravity_plugins:
+          - name: chrome-devtools
+            target: chrome-devtools-mcp@latest
+            state: present
+
+    - name: Include role under test (second run - idempotency test)
+      ansible.builtin.include_role:
+        name: cowdogmoo.workstation.antigravity
+      vars:
+        antigravity_username: "{{ container_user }}"
+        antigravity_user_home: "{{ container_home }}"
+        antigravity_config_dir: "{{ container_home }}/.gemini/config"
+        antigravity_plugins:
+          - name: chrome-devtools
+            target: chrome-devtools-mcp@latest
+            state: present
+      register: antigravity_second_run
+
+    - name: Assert second run is idempotent
+      ansible.builtin.assert:
+        that:
+          - antigravity_second_run is not changed
+        fail_msg: "Second run should not report changes (idempotency failed)"
+        success_msg: "Role is idempotent"

--- a/roles/antigravity/molecule/default/create.yml
+++ b/roles/antigravity/molecule/default/create.yml
@@ -1,0 +1,41 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  vars:
+    molecule_labels:
+      owner: molecule
+  tasks:
+    - name: Set async_dir for HOME env  # noqa: var-naming[no-role-prefix]
+      ansible.builtin.set_fact:
+        ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
+      when: lookup('env', 'HOME') | length > 0
+
+    - name: Create molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        hostname: "{{ item.hostname | default(item.name) }}"
+        image: "{{ item.image }}"
+        command: "{{ item.command | default('') }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        privileged: "{{ item.privileged | default(omit) }}"
+        cgroupns_mode: "{{ item.cgroupns_mode | default(omit) }}"
+        state: started
+        recreate: false
+        log_driver: json-file
+        labels: "{{ molecule_labels | combine(item.labels | default({})) }}"
+      register: antigravity_server
+      loop: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) creation to complete
+      ansible.builtin.async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: antigravity_docker_jobs
+      until: antigravity_docker_jobs.finished
+      retries: 300
+      delay: 1
+      loop: "{{ antigravity_server.results }}"

--- a/roles/antigravity/molecule/default/destroy.yml
+++ b/roles/antigravity/molecule/default/destroy.yml
@@ -1,0 +1,14 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  tasks:
+    - name: Destroy molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        state: absent
+        force_kill: "{{ item.force_kill | default(true) }}"
+      loop: "{{ molecule_yml.platforms }}"
+      when: molecule_yml.platforms is defined

--- a/roles/antigravity/molecule/default/inventory
+++ b/roles/antigravity/molecule/default/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/roles/antigravity/molecule/default/molecule.yml
+++ b/roles/antigravity/molecule/default/molecule.yml
@@ -1,0 +1,46 @@
+---
+# Use Ansible Galaxy to install dependencies
+dependency:
+  name: galaxy
+  options:
+    # Install required galaxy roles
+    role-file: ../../requirements.yml
+    # Install required collections
+    requirements-file: ../../requirements.yml
+
+# Run molecule inside of a docker container
+driver:
+  name: docker
+
+platforms:
+  - name: ubuntu-agy-code
+    image: "geerlingguy/docker-ubuntu2404-ansible:latest"
+    # Setting the command to this is necessary for systemd containers
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+
+  - name: kali-agy-code
+    image: cisagov/docker-kali-ansible:latest
+    # Setting the command to this is necessary for systemd containers
+    command: ""
+    pre_build_image: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+
+provisioner:
+  name: ansible
+  config_file: ${MOLECULE_PROJECT_DIRECTORY}/../../ansible.cfg
+  playbooks:
+    converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+    prepare: ${MOLECULE_PREPARE_PLAYBOOK:-prepare.yml}
+  # Uncomment for verbose output
+  # env:
+  #   ANSIBLE_VERBOSITY: 3
+
+verifier:
+  name: ansible

--- a/roles/antigravity/molecule/default/prepare.yml
+++ b/roles/antigravity/molecule/default/prepare.yml
@@ -62,3 +62,23 @@
         state: present
         update_cache: true
       become: true
+
+    - name: Create mock agy binary
+      ansible.builtin.copy:
+        dest: /usr/local/bin/agy
+        mode: "0755"
+        content: |
+          #!/bin/bash
+          case "$1" in
+            --version) echo "agy v1.0.0" ;;
+            plugin)
+              if [ "$2" = "list" ]; then
+                cat /tmp/agy_plugins 2>/dev/null || echo ""
+              elif [ "$2" = "install" ]; then
+                echo "$3" >> /tmp/agy_plugins
+              elif [ "$2" = "uninstall" ]; then
+                sed -i "/$3/d" /tmp/agy_plugins 2>/dev/null || true
+              fi
+              ;;
+          esac
+      become: true

--- a/roles/antigravity/molecule/default/prepare.yml
+++ b/roles/antigravity/molecule/default/prepare.yml
@@ -1,0 +1,64 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: true
+  vars:
+    container_user: "{{ ansible_facts['distribution'] | lower }}"
+    container_home: "/home/{{ container_user }}"
+  tasks:
+    - name: Create test user
+      ansible.builtin.user:
+        name: "{{ container_user }}"
+        shell: /bin/bash
+        create_home: true
+      become: true
+
+    - name: Set home directory fact  # noqa: var-naming[no-role-prefix]
+      ansible.builtin.set_fact:
+        ansible_env:
+          HOME: "{{ container_home }}"
+
+    # Install Node.js 18.x for testing (Antigravity requires >=18)
+    - name: Install prerequisites
+      ansible.builtin.apt:
+        name:
+          - curl
+          - ca-certificates
+          - gnupg
+        state: present
+        update_cache: true
+      become: true
+
+    - name: Create keyrings directory
+      ansible.builtin.file:
+        path: /etc/apt/keyrings
+        state: directory
+        mode: "0755"
+      become: true
+
+    - name: Download NodeSource GPG key
+      ansible.builtin.get_url:
+        url: https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
+        dest: /tmp/nodesource.gpg.key
+        mode: "0644"
+      become: true
+
+    - name: Dearmor NodeSource GPG key
+      ansible.builtin.command:
+        cmd: gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg /tmp/nodesource.gpg.key
+        creates: /etc/apt/keyrings/nodesource.gpg
+      become: true
+
+    - name: Add NodeSource repository
+      ansible.builtin.apt_repository:
+        repo: "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main"
+        state: present
+        filename: nodesource
+      become: true
+
+    - name: Install Node.js 18.x
+      ansible.builtin.apt:
+        name: nodejs
+        state: present
+        update_cache: true
+      become: true

--- a/roles/antigravity/molecule/default/side_effect.yml
+++ b/roles/antigravity/molecule/default/side_effect.yml
@@ -1,0 +1,62 @@
+---
+# side_effect.yml - Tests non-idempotent scenarios like plugin removal
+- name: Side Effect - Test plugin removal
+  hosts: all
+  tasks:
+    - name: Set container variables based on distribution  # noqa: var-naming[no-role-prefix]
+      ansible.builtin.set_fact:
+        container_user: "{{ ansible_facts['distribution'] | lower }}"
+
+    - name: Set container home  # noqa: var-naming[no-role-prefix]
+      ansible.builtin.set_fact:
+        container_home: "/home/{{ container_user }}"
+
+    - name: Ensure test user and home directory exist
+      ansible.builtin.user:
+        name: "{{ container_user }}"
+        shell: /bin/bash
+        create_home: true
+        home: "{{ container_home }}"
+      become: true
+
+    - name: Set home directory fact  # noqa: var-naming[no-role-prefix]
+      ansible.builtin.set_fact:
+        ansible_env:
+          HOME: "{{ container_home }}"
+
+    - name: Include default variables
+      ansible.builtin.include_vars:
+        file: "../../defaults/main.yml"
+
+    # Test plugin removal (state: absent)
+    - name: Test plugin removal
+      ansible.builtin.include_role:
+        name: cowdogmoo.workstation.antigravity
+      vars:
+        antigravity_username: "{{ container_user }}"
+        antigravity_user_home: "{{ container_home }}"
+        antigravity_config_dir: "{{ container_home }}/.gemini/config"
+        antigravity_manage_settings: false
+        antigravity_plugins:
+          - name: chrome-devtools
+            target: chrome-devtools-mcp@latest
+            state: absent
+
+    - name: Verify plugin was removed  # noqa: var-naming[no-role-prefix]
+      ansible.builtin.command:
+        cmd: agy plugin list
+      environment:
+        HOME: "{{ container_home }}"
+        PATH: "{{ container_home }}/.local/bin:/usr/local/bin:/usr/bin:/bin"
+      register: plugin_list_result
+      changed_when: false
+      failed_when: false
+      become: true
+      become_user: "{{ container_user }}"
+
+    - name: Assert plugin was removed
+      ansible.builtin.assert:
+        that:
+          - "'chrome-devtools' not in plugin_list_result.stdout"
+        fail_msg: "Plugin 'chrome-devtools' should have been removed but found in: {{ plugin_list_result.stdout }}"
+        success_msg: "Plugin 'chrome-devtools' was successfully removed (state: absent works)"

--- a/roles/antigravity/molecule/default/verify.yml
+++ b/roles/antigravity/molecule/default/verify.yml
@@ -1,0 +1,130 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: true
+  vars:
+    container_user: "{{ ansible_facts['distribution'] | lower }}"
+    container_home: "/home/{{ container_user }}"
+  tasks:
+    - name: Set home directory and config facts
+      ansible.builtin.set_fact:
+        antigravity_user_home: "{{ container_home }}"
+        antigravity_config_dir: "{{ container_home }}/.gemini/config"
+        antigravity_username: "{{ container_user }}"
+
+    - name: Include default variables
+      ansible.builtin.include_vars:
+        file: "../../defaults/main.yml"
+
+    - name: Check if agy binary is in PATH
+      ansible.builtin.command: which agy
+      environment:
+        PATH: "{{ antigravity_user_home }}/.local/bin:/usr/local/bin:/usr/bin:/bin"
+      register: antigravity_which_check
+      changed_when: false
+      failed_when: false
+      become: true
+      become_user: "{{ container_user }}"
+
+    - name: Debug agy location
+      ansible.builtin.debug:
+        msg: "Agy found at: {{ antigravity_which_check.stdout }}"
+      when: antigravity_which_check.rc == 0
+
+    - name: Assert agy is installed
+      ansible.builtin.assert:
+        that:
+          - antigravity_which_check.rc == 0
+          - antigravity_which_check.stdout | length > 0
+        fail_msg: "Antigravity CLI is not installed or not in PATH"
+        success_msg: "Antigravity CLI is installed at: {{ antigravity_which_check.stdout }}"
+
+    - name: Test agy command
+      ansible.builtin.command: agy --version
+      environment:
+        PATH: "{{ antigravity_user_home }}/.local/bin:/usr/local/bin:/usr/bin:/bin"
+      register: antigravity_version_output
+      changed_when: false
+      failed_when: false
+      become: true
+      become_user: "{{ container_user }}"
+
+    - name: Assert agy command works
+      ansible.builtin.assert:
+        that:
+          - antigravity_version_output.rc == 0
+          - >
+            ('agy' in antigravity_version_output.stdout.lower()) or
+            (antigravity_version_output.stdout | regex_search('v?[0-9]+\.[0-9]+\.[0-9]+') is not none)
+        fail_msg: "Agy command failed or version output not recognized. Output was: {{ antigravity_version_output.stdout }}"
+        success_msg: "Agy command works, version: {{ antigravity_version_output.stdout }}"
+
+    - name: Check if agy config directory exists
+      ansible.builtin.stat:
+        path: "{{ antigravity_config_dir }}"
+      register: antigravity_config_dir_stat
+      become: true
+      become_user: "{{ container_user }}"
+
+    - name: Assert agy config directory exists
+      ansible.builtin.assert:
+        that:
+          - antigravity_config_dir_stat.stat.exists
+          - antigravity_config_dir_stat.stat.isdir
+          - antigravity_config_dir_stat.stat.mode == '0755'
+        fail_msg: "Agy config directory does not exist or has wrong permissions"
+        success_msg: "Agy config directory exists with correct permissions"
+
+    - name: Check if AGENTS.md exists
+      ansible.builtin.stat:
+        path: "{{ antigravity_config_dir }}/AGENTS.md"
+      register: antigravity_agy_md_stat
+      become: true
+      become_user: "{{ container_user }}"
+
+    - name: Assert AGENTS.md exists with correct permissions
+      ansible.builtin.assert:
+        that:
+          - antigravity_agy_md_stat.stat.exists
+          - antigravity_agy_md_stat.stat.mode == '0644'
+          - antigravity_agy_md_stat.stat.pw_name == container_user
+        fail_msg: "AGENTS.md does not exist or has wrong permissions/ownership"
+        success_msg: "AGENTS.md exists with correct permissions and ownership"
+
+    - name: Read AGENTS.md content
+      ansible.builtin.slurp:
+        path: "{{ antigravity_config_dir }}/AGENTS.md"
+      register: antigravity_agy_md_content
+      become: true
+      become_user: "{{ container_user }}"
+
+    - name: Assert AGENTS.md contains expected content
+      ansible.builtin.assert:
+        that:
+          - "'Global Antigravity Instructions' in (antigravity_agy_md_content['content'] | b64decode)"
+          - "'CRITICAL: .gemini' in (antigravity_agy_md_content['content'] | b64decode)"
+        fail_msg: "AGENTS.md does not contain expected instructions"
+        success_msg: "AGENTS.md contains all expected global instructions"
+
+    - name: Verify plugin list after side_effect removal  # noqa: var-naming[no-role-prefix]
+      ansible.builtin.command:
+        cmd: agy plugin list
+      environment:
+        HOME: "{{ antigravity_user_home }}"
+        PATH: "{{ antigravity_user_home }}/.local/bin:/usr/local/bin:/usr/bin:/bin"
+      register: plugin_list_result
+      changed_when: false
+      failed_when: false
+      become: true
+      become_user: "{{ container_user }}"
+
+    - name: Display plugin list output for debugging
+      ansible.builtin.debug:
+        var: plugin_list_result.stdout
+
+    - name: Assert plugin was removed by side_effect
+      ansible.builtin.assert:
+        that:
+          - "'chrome-devtools' not in plugin_list_result.stdout"
+        fail_msg: "Plugin 'chrome-devtools' should have been removed by side_effect: {{ plugin_list_result.stdout }}"
+        success_msg: "Plugin 'chrome-devtools' was successfully removed (state: absent verified)"

--- a/roles/antigravity/tasks/install-linux.yml
+++ b/roles/antigravity/tasks/install-linux.yml
@@ -1,0 +1,34 @@
+---
+- name: Check if already installed
+  ansible.builtin.command: which agy
+  register: antigravity_check
+  changed_when: false
+  failed_when: false
+
+- name: Install via Homebrew
+  community.general.homebrew:
+    name: agy
+    state: present
+  when: antigravity_check.rc != 0
+  ignore_errors: true
+  register: antigravity_brew_install
+
+- name: Print manual install notice
+  ansible.builtin.debug:
+    msg: "Please install agy manually if homebrew is not available."
+  when:
+    - antigravity_check.rc != 0
+    - antigravity_brew_install.failed | default(false)
+
+- name: Verify installation
+  ansible.builtin.command: agy --version
+  register: antigravity_version
+  changed_when: false
+  failed_when: false
+  become: true
+  become_user: "{{ antigravity_username }}"
+
+- name: Display version
+  ansible.builtin.debug:
+    msg: "Antigravity installed: {{ antigravity_version.stdout }}"
+  when: antigravity_version.rc == 0

--- a/roles/antigravity/tasks/install-macos.yml
+++ b/roles/antigravity/tasks/install-macos.yml
@@ -1,0 +1,23 @@
+---
+- name: Check if already installed
+  ansible.builtin.command: which agy
+  register: antigravity_check
+  changed_when: false
+  failed_when: false
+
+- name: Install via Homebrew
+  community.general.homebrew:
+    name: agy
+    state: present
+  when: antigravity_check.rc != 0
+
+- name: Verify installation
+  ansible.builtin.command: agy --version
+  register: antigravity_version
+  changed_when: false
+  failed_when: false
+
+- name: Display version
+  ansible.builtin.debug:
+    msg: "Antigravity installed: {{ antigravity_version.stdout }}"
+  when: antigravity_version.rc == 0

--- a/roles/antigravity/tasks/install-windows.yml
+++ b/roles/antigravity/tasks/install-windows.yml
@@ -1,0 +1,22 @@
+---
+- name: Check if already installed
+  ansible.builtin.command: which agy
+  register: antigravity_check
+  changed_when: false
+  failed_when: false
+
+- name: Print manual install notice
+  ansible.builtin.debug:
+    msg: "Please install agy manually on Windows."
+  when: antigravity_check.rc != 0
+
+- name: Verify installation
+  ansible.builtin.command: agy --version
+  register: antigravity_version
+  changed_when: false
+  failed_when: false
+
+- name: Display version
+  ansible.builtin.debug:
+    msg: "Antigravity installed: {{ antigravity_version.stdout }}"
+  when: antigravity_version.rc == 0

--- a/roles/antigravity/tasks/main.yml
+++ b/roles/antigravity/tasks/main.yml
@@ -1,0 +1,66 @@
+---
+- name: Set antigravity username for Kali systems
+  ansible.builtin.set_fact:
+    antigravity_username: "kali"
+  when: ansible_facts['distribution_release'] == "kali-rolling" and antigravity_username is not defined
+
+- name: Ensure antigravity user home directory exists
+  ansible.builtin.stat:
+    path: "{{ antigravity_user_home }}"
+  register: antigravity_home_stat
+  changed_when: false
+
+- name: Fail if user home directory doesn't exist
+  ansible.builtin.fail:
+    msg: "User home directory {{ antigravity_user_home }} does not exist"
+  when: not antigravity_home_stat.stat.exists
+
+- name: Install Antigravity on macOS
+  ansible.builtin.include_tasks: install-macos.yml
+  when:
+    - ansible_facts['os_family'] == 'Darwin'
+    - antigravity_install | bool
+
+- name: Install Antigravity on Linux
+  ansible.builtin.include_tasks: install-linux.yml
+  when:
+    - ansible_facts['os_family'] != 'Darwin'
+    - ansible_facts['os_family'] != 'Windows'
+    - antigravity_install | bool
+
+- name: Install Antigravity on Windows
+  ansible.builtin.include_tasks: install-windows.yml
+  when:
+    - ansible_facts['os_family'] == 'Windows'
+    - antigravity_install | bool
+
+- name: Create Antigravity configuration directory
+  ansible.builtin.file:
+    path: "{{ antigravity_config_dir }}"
+    state: directory
+    owner: "{{ antigravity_username }}"
+    group: "{{ antigravity_usergroup }}"
+    mode: "0755"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+
+- name: Install global AGENTS.md instructions
+  ansible.builtin.copy:
+    src: AGENTS.md
+    dest: "{{ antigravity_config_dir }}/AGENTS.md"
+    owner: "{{ antigravity_username }}"
+    group: "{{ antigravity_usergroup }}"
+    mode: "0644"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  when: antigravity_manage_settings | bool
+
+- name: Manage plugins
+  ansible.builtin.include_tasks: manage-plugins.yml
+  when:
+    - antigravity_manage_plugins | bool
+    - antigravity_plugins | length > 0
+
+- name: Display configuration status
+  ansible.builtin.debug:
+    msg: >-
+      Config Dir: {{ antigravity_config_dir }} |
+      Plugins: {{ antigravity_plugins | length }}

--- a/roles/antigravity/tasks/manage-plugin.yml
+++ b/roles/antigravity/tasks/manage-plugin.yml
@@ -1,0 +1,32 @@
+---
+# tasks/manage-plugin.yml
+
+- name: Check if plugin exists - {{ plugin.name }}
+  ansible.builtin.set_fact:
+    antigravity_plugin_exists: "{{ plugin.name in antigravity_plugin_list.stdout }}"
+
+- name: Remove plugin - {{ plugin.name }}
+  ansible.builtin.command:
+    cmd: "agy plugin uninstall {{ plugin.name }}"
+  environment:
+    HOME: "{{ antigravity_user_home }}"
+    PATH: "{{ antigravity_path }}"
+  when:
+    - plugin.state | default('present') == 'absent'
+    - antigravity_plugin_exists | bool
+  changed_when: true
+  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become_user: "{{ antigravity_username }}"
+
+- name: Add plugin - {{ plugin.name }}
+  ansible.builtin.command:
+    cmd: "agy plugin install {{ plugin.target | default(plugin.name) }}"
+  environment:
+    HOME: "{{ antigravity_user_home }}"
+    PATH: "{{ antigravity_path }}"
+  when:
+    - plugin.state | default('present') == 'present'
+    - not antigravity_plugin_exists | bool
+  changed_when: true
+  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become_user: "{{ antigravity_username }}"

--- a/roles/antigravity/tasks/manage-plugins.yml
+++ b/roles/antigravity/tasks/manage-plugins.yml
@@ -1,0 +1,21 @@
+---
+# tasks/manage-plugins.yml
+
+- name: Get list of currently installed plugins
+  ansible.builtin.command:
+    cmd: agy plugin list
+  environment:
+    HOME: "{{ antigravity_user_home }}"
+    PATH: "{{ antigravity_path }}"
+  register: antigravity_plugin_list
+  changed_when: false
+  failed_when: false
+  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become_user: "{{ antigravity_username }}"
+
+- name: Manage plugins
+  ansible.builtin.include_tasks: manage-plugin.yml
+  loop: "{{ antigravity_plugins }}"
+  loop_control:
+    loop_var: plugin
+    label: "{{ plugin.name }}"


### PR DESCRIPTION
**Key Changes:**

- Introduced a full-featured `antigravity` Ansible role for installing and configuring the Antigravity CLI (`agy`) across Linux, macOS, and Windows
- Added cross-platform installation tasks using Homebrew with graceful fallback messaging for unsupported environments
- Included plugin lifecycle management (install/uninstall) with idempotency enforcement via Molecule tests
- Updated collection README and workstation playbook to register and invoke the new role

**Added:**

- Antigravity role core - `roles/antigravity/tasks/main.yml` orchestrates installation, config directory creation, AGENTS.md deployment, and plugin management with per-OS conditionals and Kali-specific username handling
- Platform-specific install tasks - `install-linux.yml`, `install-macos.yml`, and `install-windows.yml` each check for an existing `agy` binary, attempt Homebrew installation where applicable, and verify the installed version
- Plugin management tasks - `manage-plugins.yml` and `manage-plugin.yml` enumerate installed plugins and idempotently add or remove entries based on the `antigravity_plugins` list variable using `agy plugin install/uninstall`
- Default variables - `defaults/main.yml` defines username, usergroup, home directory, config directory (`~/.gemini/config`), Homebrew prefix, PATH, and feature flags (`antigravity_install`, `antigravity_manage_settings`, `antigravity_manage_plugins`) with sensible cross-platform defaults
- Global AGENTS.md instructions - `files/AGENTS.md` ships opinionated agent guidance covering `.gemini` directory gitignore enforcement, commit workflow via `fabric_commit`, PR creation via `fabric_pr`, and preferred modern CLI tool substitutions (`rg`, `fd`, `bat`, `delta`, `dust`, `duf`)
- Molecule test suite - `molecule/default/` provides full lifecycle testing (create, prepare, converge, verify, side_effect, destroy) on Ubuntu 22.04 and Kali Linux, covering installation, config directory permissions, AGENTS.md content, plugin install/remove, and idempotency assertions
- Role metadata and documentation - `meta/main.yml` declares Galaxy metadata targeting Ubuntu, Debian, EL, and macOS platforms; `README.md` documents all variables, tasks, and example playbook usage

**Changed:**

- Workstation playbook - added an `antigravity` role invocation block with the `antigravity` tag in `playbooks/workstation/workstation.yml`, positioned after the `claude_code` role entry
- Collection README diagram and role table - updated `README.md` to insert `antigravity` in alphabetical order within the Mermaid dependency graph and the role reference table, shifting all subsequent role node indices by one