### PR TITLE
feat: skip op:// mcp servers when 1password cli missing; add enforcement toggle

### DIFF
--- a/roles/antigravity/README.md
+++ b/roles/antigravity/README.md
@@ -38,6 +38,7 @@ Manages Antigravity CLI configuration including hooks and settings
 | `antigravity_hooks_overrides` | dict | <code>{}</code> | No description |
 | `antigravity_hooks` | str | <code><multiline value: folded_strip></code> | No description |
 | `antigravity_manage_mcp_servers` | bool | <code>True</code> | No description |
+| `antigravity_mcp_op_required` | bool | <code>False</code> | No description |
 | `antigravity_mcp_servers` | list | <code>&#91;&#93;</code> | No description |
 
 ## Tasks
@@ -94,7 +95,9 @@ Manages Antigravity CLI configuration including hooks and settings
 - **Parse existing MCP servers** (ansible.builtin.set_fact)
 - **Determine whether 1Password resolution is needed** (ansible.builtin.set_fact)
 - **Check for the 1Password CLI** (ansible.builtin.command) - Conditional
-- **Fail with guidance when op:// references cannot be resolved** (ansible.builtin.fail) - Conditional
+- **Fail with guidance when op:// references are required but unresolvable** (ansible.builtin.fail) - Conditional
+- **Warn that servers carrying op:// references are being skipped** (ansible.builtin.debug) - Conditional
+- **Skip the servers whose op:// references cannot be resolved** (ansible.builtin.set_fact) - Conditional
 - **Create a staging file for 1Password resolution** (ansible.builtin.tempfile) - Conditional
 - **Write MCP configuration for resolution** (ansible.builtin.template) - Conditional
 - **Resolve 1Password references** (ansible.builtin.command) - Conditional

--- a/roles/antigravity/defaults/main.yml
+++ b/roles/antigravity/defaults/main.yml
@@ -245,6 +245,12 @@ antigravity_hooks: >-
 # MCP Server Management
 antigravity_manage_mcp_servers: true  # Whether to manage MCP servers
 
+# Whether a missing 1Password CLI is fatal. Off by default so a host without `op` still
+# gets every server that carries no op:// reference; the ones that do are skipped with a
+# warning rather than aborting the play. Turn on where a silently absent server is worse
+# than a failed run.
+antigravity_mcp_op_required: false
+
 # List of MCP servers to install
 # Each server supports: name, command, args, env, state
 #

--- a/roles/antigravity/molecule/default/converge.yml
+++ b/roles/antigravity/molecule/default/converge.yml
@@ -14,6 +14,13 @@
       - name: doomed
         command: /bin/true
         state: present
+    # Nothing installs the 1Password CLI in the container, so this reference is
+    # deliberately unresolvable — see the third role invocation below.
+    test_mcp_op_servers:
+      - name: needs-op
+        command: /bin/true
+        env:
+          TOKEN: "op://vault/item/token"
     test_hooks_overrides:
       stop_sound:
         command: "true"
@@ -62,3 +69,38 @@
           - antigravity_second_run is not changed
         fail_msg: "Second run should not report changes (idempotency failed)"
         success_msg: "Role is idempotent"
+
+    # A missing 1Password CLI used to abort the play, which broke every host that does not
+    # use 1Password rather than just the servers needing it. Run last so the unresolvable
+    # server cannot disturb the idempotency check above.
+    - name: Include role under test (unresolvable op:// reference)
+      ansible.builtin.include_role:
+        name: cowdogmoo.workstation.antigravity
+      vars:
+        antigravity_username: "{{ container_user }}"
+        antigravity_user_home: "{{ container_home }}"
+        antigravity_config_dir: "{{ container_home }}/.gemini/config"
+        antigravity_manage_settings: false
+        antigravity_manage_hooks: false
+        antigravity_mcp_servers: "{{ test_mcp_servers + test_mcp_op_servers }}"
+
+    - name: Read mcp_config.json written without the 1Password CLI
+      ansible.builtin.slurp:
+        src: "{{ container_home }}/.gemini/config/mcp_config.json"
+      register: antigravity_mcp_without_op
+      become: true
+      become_user: "{{ container_user }}"
+
+    - name: Assert the unresolvable server was skipped and the others survived
+      ansible.builtin.assert:
+        that:
+          - "'needs-op' not in antigravity_mcp_without_op_servers"
+          - "'chrome-devtools' in antigravity_mcp_without_op_servers"
+        fail_msg: >-
+          Without `op`, 'needs-op' must be dropped rather than written with a literal
+          op:// value, and the servers needing no resolution must still be configured:
+          {{ antigravity_mcp_without_op_servers }}
+        success_msg: "Unresolvable op:// server skipped; the rest were still written"
+      vars:
+        antigravity_mcp_without_op_servers: >-
+          {{ (antigravity_mcp_without_op['content'] | b64decode | from_json)['mcpServers'] }}

--- a/roles/antigravity/tasks/manage-mcp-servers.yml
+++ b/roles/antigravity/tasks/manage-mcp-servers.yml
@@ -56,12 +56,39 @@
   failed_when: false
   when: antigravity_mcp_needs_op | bool
 
-- name: Fail with guidance when op:// references cannot be resolved
+- name: Fail with guidance when op:// references are required but unresolvable
   ansible.builtin.fail:
     msg: >-
       antigravity_mcp_servers contains op:// references but the 1Password CLI is not on
       PATH. Install it (brew install 1password-cli) and run `op signin`, or replace the
       references with literal values.
+  when:
+    - antigravity_mcp_needs_op | bool
+    - antigravity_op_check.rc != 0
+    - antigravity_mcp_op_required | bool
+
+# Every op:// reference is site-specific by design, so a host without the CLI is an
+# ordinary case (CI, a fresh box, anyone not using 1Password) rather than a misconfigured
+# one — hence a warning instead of a failed play. Writing the references verbatim is not
+# an option either: agy would get a server whose URL or token is the literal string
+# "op://…", which fails at connect time and gives no hint why.
+- name: Warn that servers carrying op:// references are being skipped
+  ansible.builtin.debug:
+    msg: >-
+      1Password CLI not found; skipping the MCP servers that carry op:// references.
+      Install it (brew install 1password-cli) and run `op signin` to configure them, or
+      set antigravity_mcp_op_required=true to make this fatal instead.
+  when:
+    - antigravity_mcp_needs_op | bool
+    - antigravity_op_check.rc != 0
+
+# Clearing needs_op routes the rest of the file down the plain-template path, skipping the
+# staging file and the `op inject` call. Servers already in mcp_config.json are left alone,
+# so an entry resolved by an earlier run survives a run made without 1Password to hand.
+- name: Skip the servers whose op:// references cannot be resolved
+  ansible.builtin.set_fact:
+    antigravity_mcp_skip_op_servers: true
+    antigravity_mcp_needs_op: false
   when:
     - antigravity_mcp_needs_op | bool
     - antigravity_op_check.rc != 0

--- a/roles/antigravity/templates/mcp_config.json.j2
+++ b/roles/antigravity/templates/mcp_config.json.j2
@@ -17,7 +17,13 @@
 {%   set _ = servers.update({name: spec}) %}
 {% endfor %}
 {% for srv in antigravity_mcp_servers %}
-{%   if srv.state | default('present') != 'absent' %}
+{#   antigravity_mcp_skip_op_servers is set when the 1Password CLI is missing: the spec
+     cannot be resolved, so it is dropped rather than written with a literal op:// value.
+     Matching on the serialized spec catches a reference anywhere in it, and covers the
+     OP_LOOKUP: prefix too since that form still contains op://. #}
+{%   if srv.state | default('present') != 'absent'
+       and not (antigravity_mcp_skip_op_servers | default(false)
+                and 'op://' in (srv | to_json)) %}
 {#     Normalize the claude_code role's OP_LOOKUP: prefix down to a bare op:// ref so a
        server spec can be copied between the two roles unchanged. #}
 {%     set env = {} %}


### PR DESCRIPTION
**Key Changes:**

- Make missing 1Password CLI non-fatal by default and warn/skip op:// servers
- Add antigravity_mcp_op_required to optionally enforce a hard failure
- Prevent writing literal op:// values by filtering unresolved servers in the template
- Extend molecule tests to assert skipped servers while preserving others

**Added:**

- Optional enforcement toggle - Introduce antigravity_mcp_op_required (default: false) to control whether absence of the 1Password CLI is fatal - defaults/main.yml, documented in README
- Graceful handling when op is missing - Add a warning step and a skip path that sets antigravity_mcp_skip_op_servers and disables resolution to avoid unusable configurations - tasks/manage-mcp-servers.yml
- Test coverage for missing op - Add a scenario with an unresolvable op:// reference and assertions that only non-op servers are written - molecule/default/converge.yml

**Changed:**

- Failure behavior - Gate the “fail with guidance” step on antigravity_mcp_op_required so plays only fail when explicitly required; update task wording to clarify intent - tasks/manage-mcp-servers.yml
- MCP config rendering - Update template logic to omit any server whose spec contains op:// when skipping is active, preventing literal op:// values from being written - templates/mcp_config.json.j2
- Documentation - Document the new variable and clarify task behavior around required vs. skipped op:// references - roles/antigravity/README.md