### PR TITLE
test: remove molecule host_vars override and clarify 1password comments

### DIFF
--- a/playbooks/workstation/molecule/default/molecule.yml
+++ b/playbooks/workstation/molecule/default/molecule.yml
@@ -25,17 +25,6 @@ provisioner:
   name: ansible
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}
-  inventory:
-    host_vars:
-      ubuntu-workstation:
-        # group_vars/all.yml points the Grafana MCP server at 1Password. This container
-        # has no `op` binary and no vault access, and the role fails fast on unresolvable
-        # op:// references by design, so substitute a literal server that still exercises
-        # the merge-and-write path. Inventory host_vars outrank playbook group_vars, which
-        # is why this override takes effect at all.
-        antigravity_mcp_servers:
-          - name: molecule-probe
-            command: /bin/true
 
 verifier:
   name: ansible

--- a/roles/antigravity/molecule/default/converge.yml
+++ b/roles/antigravity/molecule/default/converge.yml
@@ -14,8 +14,7 @@
       - name: doomed
         command: /bin/true
         state: present
-    # Nothing installs the 1Password CLI in the container, so this reference is
-    # deliberately unresolvable — see the third role invocation below.
+    # The container has no `op`, so this reference cannot be resolved.
     test_mcp_op_servers:
       - name: needs-op
         command: /bin/true
@@ -70,9 +69,7 @@
         fail_msg: "Second run should not report changes (idempotency failed)"
         success_msg: "Role is idempotent"
 
-    # A missing 1Password CLI used to abort the play, which broke every host that does not
-    # use 1Password rather than just the servers needing it. Run last so the unresolvable
-    # server cannot disturb the idempotency check above.
+    # Run last so the unresolvable server cannot disturb the idempotency check above.
     - name: Include role under test (unresolvable op:// reference)
       ansible.builtin.include_role:
         name: cowdogmoo.workstation.antigravity


### PR DESCRIPTION
**Key Changes:**

- Remove Molecule inventory host_vars override to avoid masking missing 1Password CLI
- Rely on default group_vars to exercise the real merge-and-write path in tests
- Clarify comments about unresolvable op references and test run order in converge play

**Changed:**

- Clarified wording around the container lacking the 1Password CLI (`op`) and why the unresolvable reference is executed after the idempotency check to prevent false failures - roles/antigravity/molecule/default/converge.yml

**Removed:**

- Inventory host_vars override that injected a dummy MCP server, simplifying the scenario to reflect real defaults and intentional unresolved `op://` references - playbooks/workstation/molecule/default/molecule.yml