### PR TITLE
ci: remove hardcoded ansible python interpreter from molecule config

### DIFF
--- a/roles/vnc_setup/molecule/default/molecule.yml
+++ b/roles/vnc_setup/molecule/default/molecule.yml
@@ -21,8 +21,6 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
     privileged: true
-    environment:
-      ANSIBLE_PYTHON_INTERPRETER: /usr/bin/python3
 
   - name: kali-vnc-setup
     image: cisagov/docker-kali-ansible:latest
@@ -33,8 +31,6 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
     privileged: true
-    environment:
-      ANSIBLE_PYTHON_INTERPRETER: /usr/bin/python3
 
 provisioner:
   name: ansible


### PR DESCRIPTION
**Key Changes:**

- Removed explicit ANSIBLE_PYTHON_INTERPRETER to rely on Ansible discovery
- Simplified Molecule configuration by dropping redundant environment blocks
- Reduced maintenance risk from pinned interpreter paths across images

**Removed:**

- Interpreter environment overrides for ubuntu-vnc-setup and kali-vnc-setup platforms to use cisagov/docker-ansible defaults and Ansible’s auto-discovery instead of hardcoding /usr/bin/python3 - roles/vnc_setup/molecule/default/molecule.yml