### PR TITLE
feat: add log rotation for iem-decibel-monitor launchd agent

### DIFF
--- a/playbooks/workstation/workstation.yml
+++ b/playbooks/workstation/workstation.yml
@@ -30,6 +30,10 @@
             mode: "0755"
             owner: "{{ ansible_facts['user_id'] }}"
             group: "{{ ansible_facts['user_gid'] | default(ansible_facts['user_id']) }}"
+          - path: "~/logs"  # Non-ansible launchd agent logs
+            mode: "0755"
+            owner: "{{ ansible_facts['user_id'] }}"
+            group: "{{ ansible_facts['user_gid'] | default(ansible_facts['user_id']) }}"
 
         logging_rotation_configs:
           - name: "ansible-hosts"
@@ -49,6 +53,27 @@
             maxsize: "100M"
             copytruncate: true
             delaycompress: true
+            owner: "{{ ansible_facts['user_id'] }}"
+            group: "{{ ansible_facts['user_gid'] | default(ansible_facts['user_id']) }}"
+
+          - name: "iem-decibel-monitor"
+            path: "~/logs/iem-decibel-monitor.log"
+            # This file is a launchd StandardErrorPath target, so launchd holds an
+            # open fd on the inode. `create` would rename the file out from under
+            # the daemon, which would keep writing to the rotated inode while the
+            # fresh file stayed empty. copytruncate is the only correct mode here,
+            # and it is mutually exclusive with create.
+            copytruncate: true
+            create: false
+            # The monitor emits a retry line every 3s whenever the Fireface is
+            # unplugged, so cap by size rather than trusting the daily cadence.
+            maxsize: "10M"
+            rotate: 3
+            frequency: "daily"
+            compress: true
+            missingok: true
+            notifempty: true
+            dateext: true
             owner: "{{ ansible_facts['user_id'] }}"
             group: "{{ ansible_facts['user_gid'] | default(ansible_facts['user_id']) }}"
 


### PR DESCRIPTION
**Key Changes:**

- Added a dedicated `~/logs` directory for non-ansible launchd agent logs
- Configured log rotation for the `iem-decibel-monitor` daemon using `copytruncate` to safely handle launchd's open file descriptor
- Set size-based rotation caps to handle high-frequency retry logging

**Added:**

- Non-ansible log directory - Created `~/logs` directory entry in `playbooks/workstation/workstation.yml` with `0755` permissions to hold launchd agent logs separate from ansible-managed logs
- Log rotation config for `iem-decibel-monitor` - Added a `logging_rotation_configs` entry targeting `~/logs/iem-decibel-monitor.log`, using `copytruncate: true` and `create: false` because the log is a launchd `StandardErrorPath` target; renaming it via `create` would leave the daemon writing to the rotated inode while the fresh file stayed empty
- Size-based rotation limits - Configured `maxsize: 10M` with `rotate: 3`, daily `frequency`, compression, and `notifempty`/`missingok`/`dateext` options to cap growth from the monitor's 3-second retry logging when the Fireface is unplugged, rather than relying on the daily cadence alone