### PR TITLE
fix: use dynamic user gid and macos-friendly install paths

### DIFF
--- a/roles/antigravity/README.md
+++ b/roles/antigravity/README.md
@@ -16,7 +16,7 @@ Manages Antigravity CLI configuration including hooks and settings
 | Variable | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `antigravity_username` | str | <code>{{ ansible_facts&#91;'user_id'&#93; &#124; default(ansible_facts&#91;'user'&#93;) }}</code> | No description |
-| `antigravity_usergroup` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary('staff', antigravity_username) }}</code> | No description |
+| `antigravity_usergroup` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary(ansible_facts&#91;'user_gid'&#93; &#124; default('staff'), antigravity_username) }}</code> | No description |
 | `antigravity_user_home` | str | <code><multiline value: folded_strip></code> | No description |
 | `antigravity_config_dir` | str | <code>{{ antigravity_user_home }}/.gemini/config</code> | No description |
 | `antigravity_rules_file` | str | <code>{{ antigravity_user_home }}/.gemini/GEMINI.md</code> | No description |

--- a/roles/antigravity/defaults/main.yml
+++ b/roles/antigravity/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 antigravity_username: "{{ ansible_facts['user_id'] | default(ansible_facts['user']) }}"
-antigravity_usergroup: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary('staff', antigravity_username) }}"
+antigravity_usergroup: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['user_gid'] | default('staff'), antigravity_username) }}"
 antigravity_user_home: >-
   {{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['env']['HOME'],
      (antigravity_username == 'root') | ternary('/root', '/home/' + antigravity_username)) }}

--- a/roles/asdf/README.md
+++ b/roles/asdf/README.md
@@ -21,9 +21,9 @@ Installs the asdf version manager, wires it into the user's shell, and installs 
 | Variable | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `asdf_username` | str | <code>{{ ansible_facts&#91;'user_id'&#93; &#124; default(ansible_facts&#91;'user'&#93;) }}</code> | No description |
-| `asdf_usergroup` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary('staff', asdf_username) }}</code> | No description |
+| `asdf_usergroup` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary(ansible_facts&#91;'user_gid'&#93; &#124; default('staff'), asdf_username) }}</code> | No description |
 | `asdf_user_home` | str | <code><multiline value: folded_strip></code> | No description |
-| `asdf_bin_dir` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary('/usr/local/bin', '/usr/local/bin') }}</code> | No description |
+| `asdf_bin_dir` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary(asdf_user_home + '/.local/bin', '/usr/local/bin') }}</code> | No description |
 | `asdf_data_dir` | str | <code>{{ asdf_user_home }}/.asdf</code> | No description |
 | `asdf_shells` | list | <code>&#91;&#93;</code> | No description |
 | `asdf_shells.0` | str | <code>/usr/bin/zsh</code> | No description |

--- a/roles/asdf/defaults/main.yml
+++ b/roles/asdf/defaults/main.yml
@@ -1,11 +1,11 @@
 ---
 asdf_username: "{{ ansible_facts['user_id'] | default(ansible_facts['user']) }}"
-asdf_usergroup: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary('staff', asdf_username) }}"
+asdf_usergroup: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['user_gid'] | default('staff'), asdf_username) }}"
 asdf_user_home: >-
   {{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['env']['HOME'],
      (asdf_username == 'root') | ternary('/root', '/home/' + asdf_username)) }}
 
-asdf_bin_dir: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary('/usr/local/bin', '/usr/local/bin') }}"
+asdf_bin_dir: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary(asdf_user_home + '/.local/bin', '/usr/local/bin') }}"
 asdf_data_dir: "{{ asdf_user_home }}/.asdf"
 
 asdf_shells:

--- a/roles/claude_code/README.md
+++ b/roles/claude_code/README.md
@@ -16,7 +16,7 @@ Manages Claude Code CLI configuration including hooks and settings
 | Variable | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `claude_code_username` | str | <code>{{ ansible_facts&#91;'user_id'&#93; &#124; default(ansible_facts&#91;'user'&#93;) }}</code> | No description |
-| `claude_code_usergroup` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary('staff', claude_code_username) }}</code> | No description |
+| `claude_code_usergroup` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary(ansible_facts&#91;'user_gid'&#93; &#124; default('staff'), claude_code_username) }}</code> | No description |
 | `claude_code_user_home` | str | <code><multiline value: folded_strip></code> | No description |
 | `claude_code_config_dir` | str | <code>{{ claude_code_user_home }}/.claude</code> | No description |
 | `claude_code_homebrew_prefix` | str | <code><multiline value: folded_strip></code> | No description |

--- a/roles/claude_code/defaults/main.yml
+++ b/roles/claude_code/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 claude_code_username: "{{ ansible_facts['user_id'] | default(ansible_facts['user']) }}"
-claude_code_usergroup: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary('staff', claude_code_username) }}"
+claude_code_usergroup: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['user_gid'] | default('staff'), claude_code_username) }}"
 claude_code_user_home: >-
   {{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['env']['HOME'],
      (claude_code_username == 'root') | ternary('/root', '/home/' + claude_code_username)) }}

--- a/roles/fabric/README.md
+++ b/roles/fabric/README.md
@@ -16,7 +16,7 @@ Installs and configures Daniel Miessler's Fabric AI framework
 | Variable | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `fabric_username` | str | <code>{{ ansible_facts&#91;'user_id'&#93; &#124; default(ansible_facts&#91;'user'&#93;) }}</code> | No description |
-| `fabric_usergroup` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary('staff', fabric_username) }}</code> | No description |
+| `fabric_usergroup` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary(ansible_facts&#91;'user_gid'&#93; &#124; default('staff'), fabric_username) }}</code> | No description |
 | `fabric_user_home` | str | <code><multiline value: folded_strip></code> | No description |
 | `fabric_install` | bool | <code>True</code> | No description |
 | `fabric_install_method` | str | <code>go_install</code> | No description |

--- a/roles/fabric/defaults/main.yml
+++ b/roles/fabric/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # User configuration
 fabric_username: "{{ ansible_facts['user_id'] | default(ansible_facts['user']) }}"  # User to install fabric for
-fabric_usergroup: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary('staff', fabric_username) }}"  # Group for fabric files
+fabric_usergroup: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['user_gid'] | default('staff'), fabric_username) }}"  # Group for fabric files
 fabric_user_home: >-  # Home directory of the fabric user
   {{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['env']['HOME'],
      (fabric_username == 'root') | ternary('/root', '/home/' + fabric_username)) }}

--- a/roles/go_task/README.md
+++ b/roles/go_task/README.md
@@ -16,7 +16,7 @@ Installs go-task (Task runner) on Unix-like and Windows systems
 | Variable | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `go_task_version` | str | <code>latest</code> | No description |
-| `go_task_install_dir` | str | <code>/usr/local/bin</code> | No description |
+| `go_task_install_dir` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary(ansible_facts&#91;'env'&#93;&#91;'HOME'&#93; + '/.local/bin', '/usr/local/bin') }}</code> | No description |
 | `go_task_windows_install_dir` | str | <code>C:\\Program Files\\task</code> | No description |
 | `go_task_windows_add_to_path` | bool | <code>True</code> | No description |
 | `go_task_github_token` | str | <code>{{ lookup('env', 'GITHUB_TOKEN') &#124; default('') }}</code> | No description |
@@ -54,7 +54,7 @@ Installs go-task (Task runner) on Unix-like and Windows systems
 - **Extract checksum for specific file** (ansible.builtin.shell)
 - **Download go-task archive** (ansible.builtin.get_url)
 - **Extract go-task archive** (ansible.builtin.unarchive)
-- **Ensure installation directory exists** (ansible.builtin.file) - Conditional
+- **Ensure installation directory exists** (ansible.builtin.file)
 - **Install go-task binary** (ansible.builtin.copy)
 
 ### install-windows.yml

--- a/roles/go_task/defaults/main.yml
+++ b/roles/go_task/defaults/main.yml
@@ -3,7 +3,7 @@
 go_task_version: latest
 
 # Installation directory for Unix-like systems
-go_task_install_dir: /usr/local/bin
+go_task_install_dir: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['env']['HOME'] + '/.local/bin', '/usr/local/bin') }}"
 
 # Installation directory for Windows systems
 go_task_windows_install_dir: C:\\Program Files\\task

--- a/roles/go_task/tasks/install-unix.yml
+++ b/roles/go_task/tasks/install-unix.yml
@@ -64,12 +64,11 @@
         remote_src: true
 
     - name: Ensure installation directory exists
-      become: true
+      become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
       ansible.builtin.file:
         path: "{{ go_task_install_dir }}"
         state: directory
         mode: '0755'
-      when: ansible_facts['os_family'] != 'Darwin'
 
     - name: Install go-task binary
       become: "{{ ansible_facts['os_family'] != 'Darwin' }}"

--- a/roles/mise/README.md
+++ b/roles/mise/README.md
@@ -21,9 +21,9 @@ Installs the mise polyglot tool version manager, wires it into the user's shell,
 | Variable | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `mise_username` | str | <code>{{ ansible_facts&#91;'user_id'&#93; &#124; default(ansible_facts&#91;'user'&#93;) }}</code> | No description |
-| `mise_usergroup` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary('staff', mise_username) }}</code> | No description |
+| `mise_usergroup` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary(ansible_facts&#91;'user_gid'&#93; &#124; default('staff'), mise_username) }}</code> | No description |
 | `mise_user_home` | str | <code><multiline value: folded_strip></code> | No description |
-| `mise_bin_dir` | str | <code>/usr/local/bin</code> | No description |
+| `mise_bin_dir` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary(mise_user_home + '/.local/bin', '/usr/local/bin') }}</code> | No description |
 | `mise_data_dir` | str | <code>{{ mise_user_home }}/.local/share/mise</code> | No description |
 | `mise_config_dir` | str | <code>{{ mise_user_home }}/.config/mise</code> | No description |
 | `mise_shells` | list | <code>&#91;&#93;</code> | No description |

--- a/roles/mise/defaults/main.yml
+++ b/roles/mise/defaults/main.yml
@@ -1,11 +1,11 @@
 ---
 mise_username: "{{ ansible_facts['user_id'] | default(ansible_facts['user']) }}"
-mise_usergroup: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary('staff', mise_username) }}"
+mise_usergroup: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['user_gid'] | default('staff'), mise_username) }}"
 mise_user_home: >-
   {{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['env']['HOME'],
      (mise_username == 'root') | ternary('/root', '/home/' + mise_username)) }}
 
-mise_bin_dir: "/usr/local/bin"
+mise_bin_dir: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary(mise_user_home + '/.local/bin', '/usr/local/bin') }}"
 mise_data_dir: "{{ mise_user_home }}/.local/share/mise"
 mise_config_dir: "{{ mise_user_home }}/.config/mise"
 

--- a/roles/tmux_setup/templates/tmux.conf.j2
+++ b/roles/tmux_setup/templates/tmux.conf.j2
@@ -13,20 +13,21 @@ unbind -n MouseDrag1Pane
 unbind -n MouseDragEnd1Pane
 bind -n MouseDrag1Pane if -Ft= '#{mouse_any_flag}' 'if -Ft= "#{pane_in_mode}" "copy-mode -M" "send-keys -M"' 'copy-mode -M'
 
-# Copy to clipboard on mouse drag end
-bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "{{ tmux_setup_clipboard_command }}"
-bind-key -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "{{ tmux_setup_clipboard_command }}"
+# Copy to clipboard on mouse drag end without leaving copy-mode,
+# so the scroll position and selection are preserved
+bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "{{ tmux_setup_clipboard_command }}"
+bind-key -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "{{ tmux_setup_clipboard_command }}"
 
 # Customize word separators to include paths and special chars
 set-option -gs word-separators " \t\"'`@"
 
 # Enable double-click to select and copy word
 bind -n DoubleClick1Pane select-pane \; copy-mode -M \; send-keys -X select-word \; send-keys -X copy-pipe-and-cancel "{{ tmux_setup_clipboard_command }}"
-bind -T copy-mode-vi DoubleClick1Pane select-pane \; send-keys -X select-word \; send-keys -X copy-pipe-and-cancel "{{ tmux_setup_clipboard_command }}"
+bind -T copy-mode-vi DoubleClick1Pane select-pane \; send-keys -X select-word \; send-keys -X copy-pipe-no-clear "{{ tmux_setup_clipboard_command }}"
 
 # Enable triple-click to select and copy line
 bind -n TripleClick1Pane select-pane \; copy-mode -M \; send-keys -X select-line \; send-keys -X copy-pipe-and-cancel "{{ tmux_setup_clipboard_command }}"
-bind -T copy-mode-vi TripleClick1Pane select-pane \; send-keys -X select-line \; send-keys -X copy-pipe-and-cancel "{{ tmux_setup_clipboard_command }}"
+bind -T copy-mode-vi TripleClick1Pane select-pane \; send-keys -X select-line \; send-keys -X copy-pipe-no-clear "{{ tmux_setup_clipboard_command }}"
 
 bind m set -g mouse \; display "Mouse: #{?mouse,ON,OFF}"
 

--- a/roles/tmux_setup/templates/tmux.conf.j2
+++ b/roles/tmux_setup/templates/tmux.conf.j2
@@ -13,20 +13,20 @@ unbind -n MouseDrag1Pane
 unbind -n MouseDragEnd1Pane
 bind -n MouseDrag1Pane if -Ft= '#{mouse_any_flag}' 'if -Ft= "#{pane_in_mode}" "copy-mode -M" "send-keys -M"' 'copy-mode -M'
 
-# Don't auto-copy on drag end
-unbind -T copy-mode-vi MouseDragEnd1Pane
-unbind -T copy-mode MouseDragEnd1Pane
+# Copy to clipboard on mouse drag end
+bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "{{ tmux_setup_clipboard_command }}"
+bind-key -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "{{ tmux_setup_clipboard_command }}"
 
 # Customize word separators to include paths and special chars
 set-option -gs word-separators " \t\"'`@"
 
-# Enable double-click to select word
-bind -n DoubleClick1Pane select-pane \; copy-mode -M \; send-keys -X select-word
-bind -T copy-mode-vi DoubleClick1Pane select-pane \; send-keys -X select-word
+# Enable double-click to select and copy word
+bind -n DoubleClick1Pane select-pane \; copy-mode -M \; send-keys -X select-word \; send-keys -X copy-pipe-and-cancel "{{ tmux_setup_clipboard_command }}"
+bind -T copy-mode-vi DoubleClick1Pane select-pane \; send-keys -X select-word \; send-keys -X copy-pipe-and-cancel "{{ tmux_setup_clipboard_command }}"
 
-# Enable triple-click to select line
-bind -n TripleClick1Pane select-pane \; copy-mode -M \; send-keys -X select-line
-bind -T copy-mode-vi TripleClick1Pane select-pane \; send-keys -X select-line
+# Enable triple-click to select and copy line
+bind -n TripleClick1Pane select-pane \; copy-mode -M \; send-keys -X select-line \; send-keys -X copy-pipe-and-cancel "{{ tmux_setup_clipboard_command }}"
+bind -T copy-mode-vi TripleClick1Pane select-pane \; send-keys -X select-line \; send-keys -X copy-pipe-and-cancel "{{ tmux_setup_clipboard_command }}"
 
 bind m set -g mouse \; display "Mouse: #{?mouse,ON,OFF}"
 
@@ -66,6 +66,10 @@ set -g status-right "#{?pane_in_mode,#[fg=yellow][#{pane_mode}]#[default] ,}%Y-%
 # Enable vi keybindings
 setw -g mode-keys vi
 
+# Vi mode visual selection
+bind-key -T copy-mode-vi v send-keys -X begin-selection
+bind-key -T copy-mode-vi C-v send-keys -X rectangle-toggle
+
 # Enable the use of arrows for pane navigation
 set -g status-keys vi
 
@@ -81,8 +85,9 @@ bind r source-file ~/.tmux.conf
 # Enable OSC 52 clipboard for copying over SSH
 set -g set-clipboard on
 
-# Bind key 'y' to copy to system clipboard (works locally and over SSH via OSC 52)
-bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel 'printf "\033]52;c;$(base64 | tr -d "\n")\a"'
+# Bind keys 'y' and Enter to copy to system clipboard
+bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "{{ tmux_setup_clipboard_command }}"
+bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "{{ tmux_setup_clipboard_command }}"
 
 # Bind key 'p' to paste the copied text - Ctrl b p
 unbind p

--- a/roles/user_setup/defaults/main.yml
+++ b/roles/user_setup/defaults/main.yml
@@ -3,6 +3,6 @@ user_setup_default_username: "{{ ansible_facts['distribution'] | lower }}"
 user_setup_default_group: "{{ ansible_facts['distribution'] | lower }}"
 user_setup_default_users:
   - username: "{{ ansible_facts['env']['USER'] if ansible_facts['os_family'] == 'Darwin' else 'Administrator' if ansible_facts['os_family'] == 'Windows' else user_setup_default_username }}"
-    usergroup: "{{ 'staff' if ansible_facts['os_family'] == 'Darwin' else 'Administrators' if ansible_facts['os_family'] == 'Windows' else user_setup_default_group }}"
+    usergroup: "{{ (ansible_facts['user_gid'] | default('staff')) if ansible_facts['os_family'] == 'Darwin' else 'Administrators' if ansible_facts['os_family'] == 'Windows' else user_setup_default_group }}"
     sudo: true
     shell: "{{ 'powershell' if ansible_facts['os_family'] == 'Windows' else (ansible_facts['env']['SHELL'] | default('/bin/bash')).strip() | regex_replace('\\n', '') }}"

--- a/roles/zsh_setup/README.md
+++ b/roles/zsh_setup/README.md
@@ -16,7 +16,7 @@ Installs and configures zsh with oh-my-zsh.
 | Variable | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `zsh_setup_username` | str | <code>{{ ansible_facts&#91;'user_id'&#93; &#124; default(ansible_facts&#91;'user'&#93;) &#124; default(ansible_facts&#91;'distribution'&#93; &#124; lower) }}</code> | No description |
-| `zsh_setup_usergroup` | str | <code>{{ 'staff' if ansible_facts&#91;'os_family'&#93; == 'Darwin' else 'Administrators' if ansible_facts&#91;'os_family'&#93; == 'Windows' else zsh_setup_username }}</code> | No description |
+| `zsh_setup_usergroup` | str | <code>{{ (ansible_facts&#91;'user_gid'&#93; &#124; default('staff')) if ansible_facts&#91;'os_family'&#93; == 'Darwin' else 'Administrators' if ansible_facts&#91;'os_family'&#93; == 'Windows' else zsh_setup_username }}</code> | No description |
 | `zsh_setup_shell` | str | <code>{{ 'powershell' if ansible_facts&#91;'os_family'&#93; == 'Windows' else (ansible_facts&#91;'env'&#93;&#91;'SHELL'&#93; &#124; default('/bin/bash')).strip() &#124; regex_replace('\n', '') }}</code> | No description |
 | `zsh_setup_theme` | str | <code>af-magic</code> | No description |
 | `zsh_setup_plugins` | list | <code>&#91;&#93;</code> | No description |

--- a/roles/zsh_setup/defaults/main.yml
+++ b/roles/zsh_setup/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 zsh_setup_username: "{{ ansible_facts['user_id'] | default(ansible_facts['user']) | default(ansible_facts['distribution'] | lower) }}"
-zsh_setup_usergroup: "{{ 'staff' if ansible_facts['os_family'] == 'Darwin' else 'Administrators' if ansible_facts['os_family'] == 'Windows' else zsh_setup_username }}"
+zsh_setup_usergroup: "{{ (ansible_facts['user_gid'] | default('staff')) if ansible_facts['os_family'] == 'Darwin' else 'Administrators' if ansible_facts['os_family'] == 'Windows' else zsh_setup_username }}"
 zsh_setup_shell: "{{ 'powershell' if ansible_facts['os_family'] == 'Windows' else (ansible_facts['env']['SHELL'] | default('/bin/bash')).strip() | regex_replace('\n', '') }}"
 zsh_setup_theme: "af-magic"
 zsh_setup_plugins:

--- a/roles/zsh_setup/tasks/main.yml
+++ b/roles/zsh_setup/tasks/main.yml
@@ -9,11 +9,15 @@
     package_management_common_install_packages: "{{ zsh_setup_common_install_packages }}"
   when: zsh_setup_install_packages | default(true) | bool
 
+# Skipped on macOS: zsh_setup_usergroup resolves to a numeric GID there,
+# which the group module would treat as a group name to create
 - name: Ensure user group exists
   ansible.builtin.group:
     name: "{{ zsh_setup_usergroup }}"
     state: present
-  when: zsh_setup_getent_passwd.failed | default(false)
+  when:
+    - zsh_setup_getent_passwd.failed | default(false)
+    - ansible_facts['os_family'] != 'Darwin'
 
 - name: Ensure user exists
   ansible.builtin.user:


### PR DESCRIPTION
**Key Changes:**

- Replaced hardcoded `staff` group on macOS with the dynamic `user_gid` fact across all roles for accurate file ownership
- Switched macOS install directories from system paths to user-writable `~/.local/bin` for go-task, asdf, and mise to avoid requiring elevated privileges
- Overhauled tmux copy/paste behavior to reliably copy selections to the system clipboard and preserve scroll position

**Changed:**

- User group resolution - Updated `usergroup` defaults across the antigravity, asdf, claude_code, fabric, mise, user_setup, and zsh_setup roles to use `ansible_facts['user_gid'] | default('staff')` on macOS instead of the static `staff` value, ensuring correct group ownership
- macOS installation directories - Pointed `asdf_bin_dir`, `mise_bin_dir`, and `go_task_install_dir` at the user's `~/.local/bin` on macOS while retaining `/usr/local/bin` for Linux, removing the need for root when installing tools
- go-task directory creation - Consolidated the `become` and `when` logic in `install-unix.yml` so privilege escalation is only used on non-Darwin systems when ensuring the install directory exists
- zsh group creation - Added a guard to skip the `Ensure user group exists` task on macOS, since `user_gid` resolves to a numeric GID that the group module would otherwise misinterpret as a group name to create
- tmux clipboard integration - Reworked mouse drag-end, double-click, and triple-click bindings to copy selections via the configurable `tmux_setup_clipboard_command`, using `copy-pipe-no-clear` to preserve scroll position and selection
- tmux copy keybindings - Bound both `y` and `Enter` to copy to the system clipboard and added vi-style visual selection (`v`) and rectangle-toggle (`C-v`) bindings in copy mode