### PR TITLE
chore: remove chrome devtools mcp server configuration

### DIFF
--- a/playbooks/workstation/group_vars/all.yml
+++ b/playbooks/workstation/group_vars/all.yml
@@ -10,12 +10,6 @@
 # Split into base + extra because Ansible replaces lists rather than merging them:
 # a host that sets antigravity_mcp_servers directly would drop everything below it.
 antigravity_mcp_servers_base:
-  # Browser automation via Chrome DevTools
-  - name: chrome-devtools
-    command: npx
-    args:
-      - "-y"
-      - "chrome-devtools-mcp@latest"
 
   # Warpgate for container/AMI image building
   - name: warpgate

--- a/playbooks/workstation/host_vars/MacBook-Pro-4/main.yml
+++ b/playbooks/workstation/host_vars/MacBook-Pro-4/main.yml
@@ -7,13 +7,6 @@ fabric_update_custom_patterns: true
 
 # MCP Server configuration for Claude Code
 claude_code_mcp_servers:
-  # Browser automation via Chrome DevTools
-  - name: chrome-devtools
-    scope: user
-    command: npx
-    args:
-      - "-y"
-      - "chrome-devtools-mcp@latest"
 
   # Grafana integration for dashboards, alerts, and observability
   - name: grafana

--- a/playbooks/workstation/host_vars/ouroboros.yml
+++ b/playbooks/workstation/host_vars/ouroboros.yml
@@ -7,13 +7,6 @@ fabric_update_custom_patterns: true
 
 # MCP Server configuration for Claude Code
 claude_code_mcp_servers:
-  # Browser automation via Chrome DevTools
-  - name: chrome-devtools
-    scope: user
-    command: npx
-    args:
-      - "-y"
-      - "chrome-devtools-mcp@latest"
 
   # Grafana integration for dashboards, alerts, and observability.
   # Both the instance URL and the token resolve from 1Password via a single `op inject`


### PR DESCRIPTION
**Key Changes:**

- Removed Chrome DevTools MCP server integration across all environments
- Cleaned up Antigravity base server configurations
- Removed Claude Code server configuration for specific hosts

**Removed:**

- Global Chrome DevTools MCP server configuration - Removed from the global Ansible group variables
- Host-specific Claude Code configurations - Removed the integration from both the MacBook-Pro-4 and ouroboros host variables