### PR TITLE
fix: prevent redundant logrotate installation if already present

### DIFF
--- a/roles/logging/tasks/main.yml
+++ b/roles/logging/tasks/main.yml
@@ -31,6 +31,7 @@
   when:
     - logging_is_linux
     - ansible_facts['os_family'] == "Debian"
+    - not (logging_logrotate_check.stat.exists | default(false))
 
 - name: Install logrotate on Linux (RedHat-based)
   ansible.builtin.dnf:
@@ -40,6 +41,7 @@
   when:
     - logging_is_linux
     - ansible_facts['os_family'] == "RedHat"
+    - not (logging_logrotate_check.stat.exists | default(false))
 
 - name: Ensure logging directories exist
   ansible.builtin.file:


### PR DESCRIPTION
**Key Changes:**

- Added conditional checks to verify if logrotate is already installed on the system
- Prevented redundant package manager operations for Debian-based distributions
- Prevented redundant package manager operations for RedHat-based distributions

**Changed:**

- Logrotate installation execution rules - Updated the when conditions for installing logrotate on Linux systems to verify the stat check variable, ensuring the task is skipped if the tool is already present to speed up playbook execution