### PR TITLE
docs: clarify version control rules for agent config directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ changelogs/.plugin-cache.yaml
 .tool-versions
 .backups
 playbooks/workstation/inventory
+.claude/settings.local.json

--- a/roles/antigravity/files/GEMINI.md
+++ b/roles/antigravity/files/GEMINI.md
@@ -1,13 +1,31 @@
 # Global Antigravity Instructions
 
-## CRITICAL: .gemini Directory
+## .gemini Directory and Version Control
 
-**NEVER EVER commit the .gemini directory or any of its contents to git!**
+Project-level agent configuration is team-shared and belongs in git; personal
+state and credentials never do.
 
-- The `.gemini/` directory and its contents are personal/local configuration
-- Always ensure `.gemini/` is in `.gitignore`
-- Never add, stage, or commit any files from `.gemini/`
-- If `.gemini/` appears in git status as staged, immediately run `git restore --staged .gemini/`
+**Commit these** (team-shared configuration):
+
+- `.gemini/settings.json` — project-scoped Gemini CLI settings (use `$VAR_NAME`
+  env-var syntax so secrets stay out of the file)
+- `.gemini/commands/` — project custom commands
+- `.agent/rules/` and `.agent/workflows/` — Antigravity workspace rules and
+  workflows
+- `GEMINI.md` / `AGENTS.md` at the repo root — project context and rules
+
+**NEVER commit these** (personal/local state and credentials):
+
+- The global `~/.gemini/` directory — it holds OAuth credentials
+  (`oauth_creds.json`, `google_accounts.json`) and belongs to the user, never
+  to a repo
+- `.env` files or anything else containing API keys
+- Session/cache state such as `.gemini/tmp/`
+
+If a local-only file shows up staged, run `git restore --staged <path>` and add
+it to `.gitignore` — but never blanket-ignore the whole `.gemini/` or `.agent/`
+directory, since that hides shared settings, commands, rules, and workflows
+from the team.
 
 ## Git Workflow
 

--- a/roles/antigravity/molecule/default/verify.yml
+++ b/roles/antigravity/molecule/default/verify.yml
@@ -121,7 +121,8 @@
       ansible.builtin.assert:
         that:
           - "'Global Antigravity Instructions' in (antigravity_agy_md_content['content'] | b64decode)"
-          - "'CRITICAL: .gemini' in (antigravity_agy_md_content['content'] | b64decode)"
+          - "'.gemini Directory and Version Control' in (antigravity_agy_md_content['content'] | b64decode)"
+          - "'oauth_creds.json' in (antigravity_agy_md_content['content'] | b64decode)"
         fail_msg: "GEMINI.md does not contain expected instructions"
         success_msg: "GEMINI.md contains all expected global instructions"
 

--- a/roles/claude_code/files/CLAUDE.md
+++ b/roles/claude_code/files/CLAUDE.md
@@ -1,13 +1,30 @@
 # Global Claude Code Instructions
 
-## CRITICAL: .claude Directory
+## .claude Directory and Version Control
 
-**NEVER EVER commit the .claude directory or any of its contents to git!**
+A project's `.claude/` directory mixes team-shared configuration with personal
+state. Commit the shared parts; keep the personal parts out of git.
 
-- The `.claude/` directory and its contents are personal/local configuration
-- Always ensure `.claude/` is in `.gitignore`
-- Never add, stage, or commit any files from `.claude/`
-- If `.claude/` appears in git status as staged, immediately run `git restore --staged .claude/`
+**Commit these** (team-shared configuration):
+
+- `.claude/settings.json` — shared permissions, hooks, and MCP configuration
+- `.claude/agents/` — project subagents
+- `.claude/skills/` — project skills
+- `.claude/commands/` — project slash commands
+- `.claude/rules/` — topic-scoped instruction files
+- `CLAUDE.md` (repo root or `.claude/CLAUDE.md`) — project instructions
+
+**NEVER commit these** (personal/local state):
+
+- `.claude/settings.local.json` — personal overrides (Claude Code auto-adds it
+  to the global git excludes)
+- `.claude/worktrees/`, `.claude/agent-memory-local/`, and any other
+  session/cache state
+- The global `~/.claude/` directory — it belongs to the user, never to a repo
+
+If a local-only file shows up staged, run `git restore --staged <path>` and add
+it to `.gitignore` — but never blanket-ignore the whole `.claude/` directory,
+since that hides shared agents, skills, and settings from the team.
 
 ## Git Workflow
 

--- a/roles/claude_code/molecule/default/verify.yml
+++ b/roles/claude_code/molecule/default/verify.yml
@@ -117,7 +117,8 @@
       ansible.builtin.assert:
         that:
           - "'Global Claude Code Instructions' in (claude_code_claude_md_content['content'] | b64decode)"
-          - "'CRITICAL: .claude Directory' in (claude_code_claude_md_content['content'] | b64decode)"
+          - "'.claude Directory and Version Control' in (claude_code_claude_md_content['content'] | b64decode)"
+          - "'settings.local.json' in (claude_code_claude_md_content['content'] | b64decode)"
           - "'Git Workflow' in (claude_code_claude_md_content['content'] | b64decode)"
           - "'fabric' in (claude_code_claude_md_content['content'] | b64decode)"
           - "'--no-verify' in (claude_code_claude_md_content['content'] | b64decode)"


### PR DESCRIPTION
**Key Changes:**

- Replaced blanket "never commit" rules with nuanced guidance distinguishing team-shared config from personal/local state for both Claude and Gemini
- Updated molecule verification tests to assert the new instruction content
- Added `.claude/settings.local.json` to `.gitignore` to keep personal overrides out of git

**Added:**

- Personal state ignore entry - Added `.claude/settings.local.json` to `.gitignore` so personal Claude Code overrides are not tracked

**Changed:**

- Claude version control guidance - Rewrote the `.claude` directory section in `roles/claude_code/files/CLAUDE.md` to explicitly list committable team-shared config (`settings.json`, `agents/`, `skills/`, `commands/`, `rules/`, `CLAUDE.md`) versus personal state that must stay out of git (`settings.local.json`, `worktrees/`, `agent-memory-local/`, global `~/.claude/`), replacing the previous blanket prohibition
- Gemini version control guidance - Rewrote the `.gemini` directory section in `roles/antigravity/files/GEMINI.md` with the same commit-vs-ignore breakdown, noting the global `~/.gemini/` holds OAuth credentials and warning against blanket-ignoring the whole directory
- Claude verification assertions - Updated `roles/claude_code/molecule/default/verify.yml` to check for the new heading (`.claude Directory and Version Control`) and `settings.local.json` reference
- Gemini verification assertions - Updated `roles/antigravity/molecule/default/verify.yml` to check for the new heading (`.gemini Directory and Version Control`) and `oauth_creds.json` reference