### PR TITLE
feat: improve non-root execution and add role enablement toggles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ changelogs/.plugin-cache.yaml
 .backups
 playbooks/workstation/inventory
 .claude/settings.local.json
-.gemini/

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ changelogs/.plugin-cache.yaml
 .backups
 playbooks/workstation/inventory
 .claude/settings.local.json
+.gemini/

--- a/playbooks/workstation/workstation.yml
+++ b/playbooks/workstation/workstation.yml
@@ -22,27 +22,27 @@
       # role: ../../roles/logging
       vars:
         logging_directories:
-          - path: "~/ansible-logs"
+          - path: "{{ (ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) }}/ansible-logs"
             mode: "0755"
             owner: "{{ ansible_facts['user_id'] }}"
             group: "{{ ansible_facts['user_gid'] | default(ansible_facts['user_id']) }}"
-          - path: "~/ansible-logs/hosts"  # For log_plays callback
+          - path: "{{ (ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) }}/ansible-logs/hosts"  # For log_plays callback
             mode: "0755"
             owner: "{{ ansible_facts['user_id'] }}"
             group: "{{ ansible_facts['user_gid'] | default(ansible_facts['user_id']) }}"
-          - path: "~/logs"  # Non-ansible launchd agent logs
+          - path: "{{ (ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) }}/logs"  # Non-ansible launchd agent logs
             mode: "0755"
             owner: "{{ ansible_facts['user_id'] }}"
             group: "{{ ansible_facts['user_gid'] | default(ansible_facts['user_id']) }}"
 
         logging_rotation_configs:
           - name: "ansible-hosts"
-            path: "~/ansible-logs/hosts/*"
+            path: "{{ (ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) }}/ansible-logs/hosts/*"
             # Without olddir, the path glob re-matches yesterday's rotated file
             # (e.g. `localhost-20260626`), so dateext appends another suffix on
             # each run — producing `localhost-20260626-20260628-...` and
             # exploding Loki's series count (the shipper labels host by basename).
-            olddir: "{{ ansible_facts['env']['HOME'] }}/ansible-logs/hosts/archive"
+            olddir: "{{ (ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) }}/ansible-logs/hosts/archive"
             rotate: 30
             frequency: "daily"
             compress: true
@@ -57,7 +57,7 @@
             group: "{{ ansible_facts['user_gid'] | default(ansible_facts['user_id']) }}"
 
           - name: "iem-decibel-monitor"
-            path: "~/logs/iem-decibel-monitor.log"
+            path: "{{ (ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) }}/logs/iem-decibel-monitor.log"
             # This file is a launchd StandardErrorPath target, so launchd holds an
             # open fd on the inode. `create` would rename the file out from under
             # the daemon, which would keep writing to the rotated inode while the
@@ -79,7 +79,7 @@
 
         # Optional: Override default LaunchAgent settings for macOS
         logging_launchagent_label: "com.ansible.logrotate"
-        logging_logrotate_log_path: "{{ ansible_facts['env']['HOME'] }}/ansible-logs/logrotate"
+        logging_logrotate_log_path: "{{ (ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) }}/ansible-logs/logrotate"
 
     # Install and configure Alloy for log shipping to Loki
     # This should come after logging setup to ensure directories exist
@@ -87,6 +87,7 @@
       role: grafana.grafana.alloy
       tags:
         - alloy
+      when: alloy_enabled | default(true) | bool
       become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
       vars:
         # Workaround for undefined variable warning on macOS
@@ -180,11 +181,13 @@
 
     - name: Setup users on workstation
       role: cowdogmoo.workstation.user_setup
+      when: user_setup_enabled | default(true) | bool
       # For debugging
       # role: ../../roles/user_setup
 
     - name: Install modern CLI tools (fd, rg, bat, eza, delta, dust, duf, procs, sd, zoxide, jq, yq, ...)
       role: cowdogmoo.workstation.package_management
+      when: package_management_enabled | default(true) | bool
       # For debugging
       # role: ../../roles/package_management
       vars:
@@ -198,6 +201,7 @@
 
     - name: Deploy shell function libraries to ~/.dotfiles
       role: cowdogmoo.workstation.shell_functions
+      when: shell_functions_enabled | default(true) | bool
       # For debugging
       # role: ../../roles/shell_functions
       # On the maintainer's box, set shell_functions_source_path in host_vars
@@ -226,6 +230,7 @@
 
     - name: Setup ZSH Configuration
       role: cowdogmoo.workstation.zsh_setup
+      when: zsh_setup_enabled | default(true) | bool
       # For debugging
       # role: ../../roles/zsh_setup
 
@@ -233,6 +238,7 @@
       role: cowdogmoo.workstation.mise
       tags:
         - mise
+      when: mise_enabled | default(true) | bool
       # For debugging
       # role: ../../roles/mise
 
@@ -240,6 +246,7 @@
       role: cowdogmoo.workstation.fabric
       tags:
         - fabric
+      when: fabric_enabled | default(true) | bool
       # For debugging
       # role: ../../roles/fabric
       vars:
@@ -251,6 +258,7 @@
       role: cowdogmoo.workstation.claude_code
       tags:
         - claude
+      when: claude_code_enabled | default(true) | bool
       # For debugging
       # role: ../../roles/claude_code
 
@@ -258,6 +266,7 @@
       role: cowdogmoo.workstation.antigravity
       tags:
         - antigravity
+      when: antigravity_enabled | default(true) | bool
       # For debugging
       # role: ../../roles/antigravity
 
@@ -265,15 +274,18 @@
       role: cowdogmoo.workstation.go_task
       tags:
         - go_task
+      when: go_task_enabled | default(true) | bool
       # For debugging
       # role: ../../roles/go_task
 
     - name: Render ~/.gitconfig
       role: cowdogmoo.workstation.git_setup
+      when: git_setup_enabled | default(true) | bool
       # For debugging
       # role: ../../roles/git_setup
 
     - name: Render ~/.tmux.conf
       role: cowdogmoo.workstation.tmux_setup
+      when: tmux_setup_enabled | default(true) | bool
       # For debugging
       # role: ../../roles/tmux_setup

--- a/roles/antigravity/README.md
+++ b/roles/antigravity/README.md
@@ -16,7 +16,7 @@ Manages Antigravity CLI configuration including hooks and settings
 | Variable | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `antigravity_username` | str | <code>{{ ansible_facts&#91;'user_id'&#93; &#124; default(ansible_facts&#91;'user'&#93;) }}</code> | No description |
-| `antigravity_usergroup` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary(ansible_facts&#91;'user_gid'&#93; &#124; default('staff'), antigravity_username) }}</code> | No description |
+| `antigravity_usergroup` | str | <code>{{ (ansible_facts&#91;'user_gid'&#93; &#124; default('staff')) if ansible_facts&#91;'os_family'&#93; == 'Darwin' else antigravity_username }}</code> | No description |
 | `antigravity_user_home` | str | <code><multiline value: folded_strip></code> | No description |
 | `antigravity_config_dir` | str | <code>{{ antigravity_user_home }}/.gemini/config</code> | No description |
 | `antigravity_rules_file` | str | <code>{{ antigravity_user_home }}/.gemini/GEMINI.md</code> | No description |

--- a/roles/antigravity/defaults/main.yml
+++ b/roles/antigravity/defaults/main.yml
@@ -1,9 +1,10 @@
 ---
 antigravity_username: "{{ ansible_facts['user_id'] | default(ansible_facts['user']) }}"
-antigravity_usergroup: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['user_gid'] | default('staff'), antigravity_username) }}"
+antigravity_usergroup: "{{ ansible_facts['user_gid'] | default('staff' if ansible_facts['os_family'] == 'Darwin' else antigravity_username) }}"
 antigravity_user_home: >-
-  {{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['env']['HOME'],
-     (antigravity_username == 'root') | ternary('/root', '/home/' + antigravity_username)) }}
+  {{ ansible_facts['user_dir'] | default(ansible_facts['env']['HOME']) | default(
+     (ansible_facts['os_family'] == 'Darwin') | ternary('/Users/' + antigravity_username,
+     (antigravity_username == 'root') | ternary('/root', '/home/' + antigravity_username))) }}
 
 # Configuration directory for Agy
 antigravity_config_dir: "{{ antigravity_user_home }}/.gemini/config"

--- a/roles/antigravity/defaults/main.yml
+++ b/roles/antigravity/defaults/main.yml
@@ -1,10 +1,11 @@
 ---
 antigravity_username: "{{ ansible_facts['user_id'] | default(ansible_facts['user']) }}"
-antigravity_usergroup: "{{ ansible_facts['user_gid'] | default('staff' if ansible_facts['os_family'] == 'Darwin' else antigravity_username) }}"
+antigravity_usergroup: "{{ (ansible_facts['user_gid'] | default('staff')) if ansible_facts['os_family'] == 'Darwin' else antigravity_username }}"
 antigravity_user_home: >-
-  {{ ansible_facts['user_dir'] | default(ansible_facts['env']['HOME']) | default(
-     (ansible_facts['os_family'] == 'Darwin') | ternary('/Users/' + antigravity_username,
-     (antigravity_username == 'root') | ternary('/root', '/home/' + antigravity_username))) }}
+  {{ (ansible_facts['user_dir'] | default(ansible_facts['env']['HOME']))
+     if (antigravity_username == (ansible_facts['user_id'] | default(ansible_facts['user']) | default('')))
+     else ((ansible_facts['os_family'] == 'Darwin') | ternary('/Users/' + antigravity_username,
+           (antigravity_username == 'root') | ternary('/root', '/home/' + antigravity_username))) }}
 
 # Configuration directory for Agy
 antigravity_config_dir: "{{ antigravity_user_home }}/.gemini/config"

--- a/roles/antigravity/tasks/main.yml
+++ b/roles/antigravity/tasks/main.yml
@@ -43,7 +43,7 @@
     owner: "{{ antigravity_username }}"
     group: "{{ antigravity_usergroup }}"
     mode: "0755"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and antigravity_username != ansible_facts['user_id'] }}"
 
 - name: Create Antigravity configuration directory
   ansible.builtin.file:
@@ -52,7 +52,7 @@
     owner: "{{ antigravity_username }}"
     group: "{{ antigravity_usergroup }}"
     mode: "0755"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and antigravity_username != ansible_facts['user_id'] }}"
 
 - name: Install global GEMINI.md instructions
   ansible.builtin.copy:
@@ -61,7 +61,7 @@
     owner: "{{ antigravity_username }}"
     group: "{{ antigravity_usergroup }}"
     mode: "0644"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and antigravity_username != ansible_facts['user_id'] }}"
   when: antigravity_manage_settings | bool
 
 - name: Check if hooks.json will change (dry-run)
@@ -72,7 +72,7 @@
     group: "{{ antigravity_usergroup }}"
     mode: "0644"
   check_mode: true
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and antigravity_username != ansible_facts['user_id'] }}"
   when: antigravity_manage_hooks | bool
   register: antigravity_hooks_check
   changed_when: false
@@ -86,7 +86,7 @@
     group: "{{ antigravity_usergroup }}"
     mode: "0644"
     remote_src: true
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and antigravity_username != ansible_facts['user_id'] }}"
   when:
     - antigravity_manage_hooks | bool
     - antigravity_backup_settings | bool
@@ -100,7 +100,7 @@
     owner: "{{ antigravity_username }}"
     group: "{{ antigravity_usergroup }}"
     mode: "0644"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and antigravity_username != ansible_facts['user_id'] }}"
   when: antigravity_manage_hooks | bool
   register: antigravity_hooks_result
 

--- a/roles/antigravity/tasks/manage-mcp-servers.yml
+++ b/roles/antigravity/tasks/manage-mcp-servers.yml
@@ -20,14 +20,14 @@
   ansible.builtin.stat:
     path: "{{ antigravity_mcp_config_file }}"
   register: antigravity_mcp_config_stat
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and antigravity_username != ansible_facts['user_id'] }}"
 
 - name: Read existing MCP configuration
   ansible.builtin.slurp:
     src: "{{ antigravity_mcp_config_file }}"
   register: antigravity_mcp_existing
   when: antigravity_mcp_config_stat.stat.exists
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and antigravity_username != ansible_facts['user_id'] }}"
   no_log: true
 
 # A hand-corrupted or half-written mcp_config.json would otherwise blow up the
@@ -159,7 +159,7 @@
     owner: "{{ antigravity_username }}"
     group: "{{ antigravity_usergroup }}"
     mode: "0600"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and antigravity_username != ansible_facts['user_id'] }}"
   when: not antigravity_mcp_needs_op | bool
 
 - name: Write MCP configuration with resolved 1Password references
@@ -169,6 +169,6 @@
     owner: "{{ antigravity_username }}"
     group: "{{ antigravity_usergroup }}"
     mode: "0600"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and antigravity_username != ansible_facts['user_id'] }}"
   when: antigravity_mcp_needs_op | bool
   no_log: true

--- a/roles/antigravity/tasks/manage-plugin.yml
+++ b/roles/antigravity/tasks/manage-plugin.yml
@@ -15,7 +15,7 @@
     - plugin.state | default('present') == 'absent'
     - antigravity_plugin_exists | bool
   changed_when: true
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and antigravity_username != ansible_facts['user_id'] }}"
   become_user: "{{ antigravity_username }}"
 
 - name: Add plugin - {{ plugin.name }}
@@ -28,5 +28,5 @@
     - plugin.state | default('present') == 'present'
     - not antigravity_plugin_exists | bool
   changed_when: true
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and antigravity_username != ansible_facts['user_id'] }}"
   become_user: "{{ antigravity_username }}"

--- a/roles/antigravity/tasks/manage-plugins.yml
+++ b/roles/antigravity/tasks/manage-plugins.yml
@@ -10,7 +10,7 @@
   register: antigravity_plugin_list
   changed_when: false
   failed_when: false
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and antigravity_username != ansible_facts['user_id'] }}"
   become_user: "{{ antigravity_username }}"
 
 - name: Manage plugins

--- a/roles/asdf/README.md
+++ b/roles/asdf/README.md
@@ -21,7 +21,7 @@ Installs the asdf version manager, wires it into the user's shell, and installs 
 | Variable | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `asdf_username` | str | <code>{{ ansible_facts&#91;'user_id'&#93; &#124; default(ansible_facts&#91;'user'&#93;) }}</code> | No description |
-| `asdf_usergroup` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary(ansible_facts&#91;'user_gid'&#93; &#124; default('staff'), asdf_username) }}</code> | No description |
+| `asdf_usergroup` | str | <code>{{ (ansible_facts&#91;'user_gid'&#93; &#124; default('staff')) if ansible_facts&#91;'os_family'&#93; == 'Darwin' else asdf_username }}</code> | No description |
 | `asdf_user_home` | str | <code><multiline value: folded_strip></code> | No description |
 | `asdf_bin_dir` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary(asdf_user_home + '/.local/bin', '/usr/local/bin') }}</code> | No description |
 | `asdf_data_dir` | str | <code>{{ asdf_user_home }}/.asdf</code> | No description |

--- a/roles/asdf/defaults/main.yml
+++ b/roles/asdf/defaults/main.yml
@@ -1,10 +1,11 @@
 ---
 asdf_username: "{{ ansible_facts['user_id'] | default(ansible_facts['user']) }}"
-asdf_usergroup: "{{ ansible_facts['user_gid'] | default('staff' if ansible_facts['os_family'] == 'Darwin' else asdf_username) }}"
+asdf_usergroup: "{{ (ansible_facts['user_gid'] | default('staff')) if ansible_facts['os_family'] == 'Darwin' else asdf_username }}"
 asdf_user_home: >-
-  {{ ansible_facts['user_dir'] | default(ansible_facts['env']['HOME']) | default(
-     (ansible_facts['os_family'] == 'Darwin') | ternary('/Users/' + asdf_username,
-     (asdf_username == 'root') | ternary('/root', '/home/' + asdf_username))) }}
+  {{ (ansible_facts['user_dir'] | default(ansible_facts['env']['HOME']))
+     if (asdf_username == (ansible_facts['user_id'] | default(ansible_facts['user']) | default('')))
+     else ((ansible_facts['os_family'] == 'Darwin') | ternary('/Users/' + asdf_username,
+           (asdf_username == 'root') | ternary('/root', '/home/' + asdf_username))) }}
 
 asdf_bin_dir: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary(asdf_user_home + '/.local/bin', '/usr/local/bin') }}"
 asdf_data_dir: "{{ asdf_user_home }}/.asdf"

--- a/roles/asdf/defaults/main.yml
+++ b/roles/asdf/defaults/main.yml
@@ -1,9 +1,10 @@
 ---
 asdf_username: "{{ ansible_facts['user_id'] | default(ansible_facts['user']) }}"
-asdf_usergroup: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['user_gid'] | default('staff'), asdf_username) }}"
+asdf_usergroup: "{{ ansible_facts['user_gid'] | default('staff' if ansible_facts['os_family'] == 'Darwin' else asdf_username) }}"
 asdf_user_home: >-
-  {{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['env']['HOME'],
-     (asdf_username == 'root') | ternary('/root', '/home/' + asdf_username)) }}
+  {{ ansible_facts['user_dir'] | default(ansible_facts['env']['HOME']) | default(
+     (ansible_facts['os_family'] == 'Darwin') | ternary('/Users/' + asdf_username,
+     (asdf_username == 'root') | ternary('/root', '/home/' + asdf_username))) }}
 
 asdf_bin_dir: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary(asdf_user_home + '/.local/bin', '/usr/local/bin') }}"
 asdf_data_dir: "{{ asdf_user_home }}/.asdf"

--- a/roles/claude_code/README.md
+++ b/roles/claude_code/README.md
@@ -16,7 +16,7 @@ Manages Claude Code CLI configuration including hooks and settings
 | Variable | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `claude_code_username` | str | <code>{{ ansible_facts&#91;'user_id'&#93; &#124; default(ansible_facts&#91;'user'&#93;) }}</code> | No description |
-| `claude_code_usergroup` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary(ansible_facts&#91;'user_gid'&#93; &#124; default('staff'), claude_code_username) }}</code> | No description |
+| `claude_code_usergroup` | str | <code>{{ (ansible_facts&#91;'user_gid'&#93; &#124; default('staff')) if ansible_facts&#91;'os_family'&#93; == 'Darwin' else claude_code_username }}</code> | No description |
 | `claude_code_user_home` | str | <code><multiline value: folded_strip></code> | No description |
 | `claude_code_config_dir` | str | <code>{{ claude_code_user_home }}/.claude</code> | No description |
 | `claude_code_homebrew_prefix` | str | <code><multiline value: folded_strip></code> | No description |

--- a/roles/claude_code/defaults/main.yml
+++ b/roles/claude_code/defaults/main.yml
@@ -1,9 +1,10 @@
 ---
 claude_code_username: "{{ ansible_facts['user_id'] | default(ansible_facts['user']) }}"
-claude_code_usergroup: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['user_gid'] | default('staff'), claude_code_username) }}"
+claude_code_usergroup: "{{ ansible_facts['user_gid'] | default('staff' if ansible_facts['os_family'] == 'Darwin' else claude_code_username) }}"
 claude_code_user_home: >-
-  {{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['env']['HOME'],
-     (claude_code_username == 'root') | ternary('/root', '/home/' + claude_code_username)) }}
+  {{ ansible_facts['user_dir'] | default(ansible_facts['env']['HOME']) | default(
+     (ansible_facts['os_family'] == 'Darwin') | ternary('/Users/' + claude_code_username,
+     (claude_code_username == 'root') | ternary('/root', '/home/' + claude_code_username))) }}
 
 # Configuration directory for Claude Code
 claude_code_config_dir: "{{ claude_code_user_home }}/.claude"

--- a/roles/claude_code/defaults/main.yml
+++ b/roles/claude_code/defaults/main.yml
@@ -1,10 +1,11 @@
 ---
 claude_code_username: "{{ ansible_facts['user_id'] | default(ansible_facts['user']) }}"
-claude_code_usergroup: "{{ ansible_facts['user_gid'] | default('staff' if ansible_facts['os_family'] == 'Darwin' else claude_code_username) }}"
+claude_code_usergroup: "{{ (ansible_facts['user_gid'] | default('staff')) if ansible_facts['os_family'] == 'Darwin' else claude_code_username }}"
 claude_code_user_home: >-
-  {{ ansible_facts['user_dir'] | default(ansible_facts['env']['HOME']) | default(
-     (ansible_facts['os_family'] == 'Darwin') | ternary('/Users/' + claude_code_username,
-     (claude_code_username == 'root') | ternary('/root', '/home/' + claude_code_username))) }}
+  {{ (ansible_facts['user_dir'] | default(ansible_facts['env']['HOME']))
+     if (claude_code_username == (ansible_facts['user_id'] | default(ansible_facts['user']) | default('')))
+     else ((ansible_facts['os_family'] == 'Darwin') | ternary('/Users/' + claude_code_username,
+           (claude_code_username == 'root') | ternary('/root', '/home/' + claude_code_username))) }}
 
 # Configuration directory for Claude Code
 claude_code_config_dir: "{{ claude_code_user_home }}/.claude"

--- a/roles/fabric/README.md
+++ b/roles/fabric/README.md
@@ -16,7 +16,7 @@ Installs and configures Daniel Miessler's Fabric AI framework
 | Variable | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `fabric_username` | str | <code>{{ ansible_facts&#91;'user_id'&#93; &#124; default(ansible_facts&#91;'user'&#93;) }}</code> | No description |
-| `fabric_usergroup` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary(ansible_facts&#91;'user_gid'&#93; &#124; default('staff'), fabric_username) }}</code> | No description |
+| `fabric_usergroup` | str | <code>{{ (ansible_facts&#91;'user_gid'&#93; &#124; default('staff')) if ansible_facts&#91;'os_family'&#93; == 'Darwin' else fabric_username }}</code> | No description |
 | `fabric_user_home` | str | <code><multiline value: folded_strip></code> | No description |
 | `fabric_install` | bool | <code>True</code> | No description |
 | `fabric_install_method` | str | <code>go_install</code> | No description |

--- a/roles/fabric/defaults/main.yml
+++ b/roles/fabric/defaults/main.yml
@@ -1,10 +1,11 @@
 ---
 # User configuration
 fabric_username: "{{ ansible_facts['user_id'] | default(ansible_facts['user']) }}"  # User to install fabric for
-fabric_usergroup: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['user_gid'] | default('staff'), fabric_username) }}"  # Group for fabric files
+fabric_usergroup: "{{ ansible_facts['user_gid'] | default('staff' if ansible_facts['os_family'] == 'Darwin' else fabric_username) }}"  # Group for fabric files
 fabric_user_home: >-  # Home directory of the fabric user
-  {{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['env']['HOME'],
-     (fabric_username == 'root') | ternary('/root', '/home/' + fabric_username)) }}
+  {{ ansible_facts['user_dir'] | default(ansible_facts['env']['HOME']) | default(
+     (ansible_facts['os_family'] == 'Darwin') | ternary('/Users/' + fabric_username,
+     (fabric_username == 'root') | ternary('/root', '/home/' + fabric_username))) }}
 
 # Installation settings
 fabric_install: true  # Whether to install Fabric (set to false if you only want to manage config)

--- a/roles/fabric/defaults/main.yml
+++ b/roles/fabric/defaults/main.yml
@@ -1,11 +1,12 @@
 ---
 # User configuration
 fabric_username: "{{ ansible_facts['user_id'] | default(ansible_facts['user']) }}"  # User to install fabric for
-fabric_usergroup: "{{ ansible_facts['user_gid'] | default('staff' if ansible_facts['os_family'] == 'Darwin' else fabric_username) }}"  # Group for fabric files
+fabric_usergroup: "{{ (ansible_facts['user_gid'] | default('staff')) if ansible_facts['os_family'] == 'Darwin' else fabric_username }}"  # Group for fabric files
 fabric_user_home: >-  # Home directory of the fabric user
-  {{ ansible_facts['user_dir'] | default(ansible_facts['env']['HOME']) | default(
-     (ansible_facts['os_family'] == 'Darwin') | ternary('/Users/' + fabric_username,
-     (fabric_username == 'root') | ternary('/root', '/home/' + fabric_username))) }}
+  {{ (ansible_facts['user_dir'] | default(ansible_facts['env']['HOME']))
+     if (fabric_username == (ansible_facts['user_id'] | default(ansible_facts['user']) | default('')))
+     else ((ansible_facts['os_family'] == 'Darwin') | ternary('/Users/' + fabric_username,
+           (fabric_username == 'root') | ternary('/root', '/home/' + fabric_username))) }}
 
 # Installation settings
 fabric_install: true  # Whether to install Fabric (set to false if you only want to manage config)

--- a/roles/go_task/tasks/install-unix.yml
+++ b/roles/go_task/tasks/install-unix.yml
@@ -64,14 +64,14 @@
         remote_src: true
 
     - name: Ensure installation directory exists
-      become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+      become: "{{ ansible_facts['os_family'] != 'Darwin' and not go_task_install_dir.startswith(ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) }}"
       ansible.builtin.file:
         path: "{{ go_task_install_dir }}"
         state: directory
         mode: '0755'
 
     - name: Install go-task binary
-      become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+      become: "{{ ansible_facts['os_family'] != 'Darwin' and not go_task_install_dir.startswith(ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) }}"
       ansible.builtin.copy:
         src: "{{ go_task_temp_dir.path }}/task"
         dest: "{{ go_task_install_dir }}/task"

--- a/roles/logging/README.md
+++ b/roles/logging/README.md
@@ -20,17 +20,12 @@ Provides flexible logging directories and log rotation for any application or se
 | `logging_launchagent_label` | str | <code>com.logging.logrotate</code> | No description |
 | `logging_launchagent_hour` | int | <code>3</code> | No description |
 | `logging_launchagent_minute` | int | <code>0</code> | No description |
-| `logging_logrotate_log_path` | str | <code>{{ ansible_facts&#91;'env'&#93;&#91;'HOME'&#93; }}/logs/logrotate</code> | No description |
-
-### Role Variables (main.yml)
-
-| Variable | Type | Value | Description |
-| -------- | ---- | ----- | ----------- |
-| `logging_logrotate_binary_darwin` | str | `/opt/homebrew/sbin/logrotate` | No description |
-| `logging_logrotate_binary_linux` | str | `/usr/sbin/logrotate` | No description |
-| `logging_logrotate_config_dir_darwin` | str | `{{ ansible_facts['env']['HOME'] }}/.config/logrotate.d` | No description |
-| `logging_logrotate_config_dir_linux` | str | `/etc/logrotate.d` | No description |
-| `logging_logrotate_state_file` | str | `{{ ansible_facts['env']['HOME'] + '/.config/logrotate.state' if ansible_facts['os_family'] == 'Darwin' else '/var/lib/logrotate/status' }}` | No description |
+| `logging_logrotate_log_path` | str | <code>{{ (ansible_facts&#91;'user_dir'&#93; &#124; default(ansible_facts&#91;'env'&#93;&#91;'HOME'&#93;)) }}/logs/logrotate</code> | No description |
+| `logging_logrotate_binary_darwin` | str | <code>/opt/homebrew/sbin/logrotate</code> | No description |
+| `logging_logrotate_binary_linux` | str | <code>/usr/sbin/logrotate</code> | No description |
+| `logging_logrotate_config_dir_darwin` | str | <code>{{ (ansible_facts&#91;'user_dir'&#93; &#124; default(ansible_facts&#91;'env'&#93;&#91;'HOME'&#93;)) }}/.config/logrotate.d</code> | No description |
+| `logging_logrotate_config_dir_linux` | str | <code>{{ '/etc/logrotate.d' if (ansible_facts&#91;'user_id'&#93; == 'root' or logging_manage_system &#124; default(false)) else ((ansible_facts&#91;'user_dir'&#93; &#124; default(ansible_facts&#91;'env'&#93;&#91;'HOME'&#93;)) + '/.config/logrotate.d') }}</code> | No description |
+| `logging_logrotate_state_file` | str | <code>{{ (ansible_facts&#91;'user_dir'&#93; &#124; default(ansible_facts&#91;'env'&#93;&#91;'HOME'&#93;)) + '/.config/logrotate.state' if (ansible_facts&#91;'os_family'&#93; == 'Darwin' or ansible_facts&#91;'user_id'&#93; != 'root') else '/var/lib/logrotate/status' }}</code> | No description |
 
 ## Tasks
 

--- a/roles/logging/defaults/main.yml
+++ b/roles/logging/defaults/main.yml
@@ -30,4 +30,11 @@ logging_rotation_configs: []
 logging_launchagent_label: "com.logging.logrotate" # Default label for the LaunchAgent
 logging_launchagent_hour: 3 # Default to 3:00 AM daily
 logging_launchagent_minute: 0 # Default to 3:00 AM daily
-logging_logrotate_log_path: "{{ ansible_facts['env']['HOME'] }}/logs/logrotate" # Where logrotate itself logs
+logging_logrotate_log_path: "{{ (ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) }}/logs/logrotate" # Where logrotate itself logs
+
+# System-specific paths
+logging_logrotate_binary_darwin: "/opt/homebrew/sbin/logrotate"
+logging_logrotate_binary_linux: "/usr/sbin/logrotate"
+logging_logrotate_config_dir_darwin: "{{ (ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) }}/.config/logrotate.d"
+logging_logrotate_config_dir_linux: "{{ '/etc/logrotate.d' if (ansible_facts['user_id'] == 'root' or logging_manage_system | default(false)) else ((ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) + '/.config/logrotate.d') }}"
+logging_logrotate_state_file: "{{ (ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) + '/.config/logrotate.state' if (ansible_facts['os_family'] == 'Darwin' or ansible_facts['user_id'] != 'root') else '/var/lib/logrotate/status' }}"

--- a/roles/logging/tasks/main.yml
+++ b/roles/logging/tasks/main.yml
@@ -6,8 +6,8 @@
 
 - name: Set logrotate paths based on OS
   ansible.builtin.set_fact:
-    logging_logrotate_binary: "{{ logging_logrotate_binary_darwin if logging_is_macos else logging_logrotate_binary_linux }}"
-    logging_logrotate_config_dir: "{{ logging_logrotate_config_dir_darwin if logging_is_macos else logging_logrotate_config_dir_linux }}"
+    logging_logrotate_binary: "{{ logging_logrotate_binary | default(logging_logrotate_binary_darwin if logging_is_macos else logging_logrotate_binary_linux) }}"
+    logging_logrotate_config_dir: "{{ logging_logrotate_config_dir | default(logging_logrotate_config_dir_darwin if logging_is_macos else logging_logrotate_config_dir_linux) }}"
 
 - name: Check if logrotate binary exists
   ansible.builtin.stat:
@@ -45,7 +45,7 @@
 
 - name: Ensure logging directories exist
   ansible.builtin.file:
-    path: "{{ item.path | expanduser }}"
+    path: "{{ item.path | regex_replace('^~', ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) }}"
     state: directory
     mode: "{{ item.mode | default('0755') }}"
     owner: "{{ item.owner | default(ansible_facts['user_id']) }}"
@@ -68,12 +68,12 @@
     path: "{{ logging_logrotate_config_dir }}"
     state: directory
     mode: "0755"
-  become: "{{ logging_is_linux }}"
+  become: "{{ logging_is_linux and logging_logrotate_config_dir.startswith('/etc') }}"
   when: logging_rotation_configs | length > 0
 
 - name: Ensure olddir directories exist for log rotation
   ansible.builtin.file:
-    path: "{{ item.olddir | expanduser }}"
+    path: "{{ item.olddir | regex_replace('^~', ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) }}"
     state: directory
     mode: "0755"
     owner: "{{ item.owner | default(ansible_facts['user_id']) }}"
@@ -87,7 +87,7 @@
     src: logrotate.j2
     dest: "{{ logging_logrotate_config_dir }}/{{ item.name | default(item.path.split('/')[-2]) }}"
     mode: "0644"
-  become: "{{ logging_is_linux }}"
+  become: "{{ logging_is_linux and logging_logrotate_config_dir.startswith('/etc') }}"
   loop: "{{ logging_rotation_configs }}"
   vars:
     log_rotation_config: "{{ item }}"

--- a/roles/logging/templates/logrotate.j2
+++ b/roles/logging/templates/logrotate.j2
@@ -1,4 +1,4 @@
-{{ log_rotation_config.path | expanduser }} {
+{{ log_rotation_config.path | regex_replace('^~', ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) }} {
     rotate {{ log_rotation_config.rotate | default(30) }}
     {{ log_rotation_config.frequency | default('daily') }}
     {% if log_rotation_config.compress | default(true) %}compress{% endif %}
@@ -20,6 +20,6 @@
     {% if log_rotation_config.delaycompress | default(false) %}delaycompress{% endif %}
     {% if log_rotation_config.copytruncate | default(false) %}copytruncate{% endif %}
     {% if log_rotation_config.olddir is defined %}
-    olddir {{ log_rotation_config.olddir }}
+    olddir {{ log_rotation_config.olddir | regex_replace('^~', ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) }}
     {% endif %}
 }

--- a/roles/logging/vars/main.yml
+++ b/roles/logging/vars/main.yml
@@ -1,7 +1,2 @@
 ---
-# System-specific paths
-logging_logrotate_binary_darwin: "/opt/homebrew/sbin/logrotate"
-logging_logrotate_binary_linux: "/usr/sbin/logrotate"
-logging_logrotate_config_dir_darwin: "{{ ansible_facts['env']['HOME'] }}/.config/logrotate.d"
-logging_logrotate_config_dir_linux: "/etc/logrotate.d"
-logging_logrotate_state_file: "{{ ansible_facts['env']['HOME'] + '/.config/logrotate.state' if ansible_facts['os_family'] == 'Darwin' else '/var/lib/logrotate/status' }}"
+# System-specific variables moved to defaults/main.yml to allow host_vars overrides

--- a/roles/mise/README.md
+++ b/roles/mise/README.md
@@ -21,7 +21,7 @@ Installs the mise polyglot tool version manager, wires it into the user's shell,
 | Variable | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `mise_username` | str | <code>{{ ansible_facts&#91;'user_id'&#93; &#124; default(ansible_facts&#91;'user'&#93;) }}</code> | No description |
-| `mise_usergroup` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary(ansible_facts&#91;'user_gid'&#93; &#124; default('staff'), mise_username) }}</code> | No description |
+| `mise_usergroup` | str | <code>{{ (ansible_facts&#91;'user_gid'&#93; &#124; default('staff')) if ansible_facts&#91;'os_family'&#93; == 'Darwin' else mise_username }}</code> | No description |
 | `mise_user_home` | str | <code><multiline value: folded_strip></code> | No description |
 | `mise_bin_dir` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary(mise_user_home + '/.local/bin', '/usr/local/bin') }}</code> | No description |
 | `mise_data_dir` | str | <code>{{ mise_user_home }}/.local/share/mise</code> | No description |

--- a/roles/mise/defaults/main.yml
+++ b/roles/mise/defaults/main.yml
@@ -1,10 +1,11 @@
 ---
 mise_username: "{{ ansible_facts['user_id'] | default(ansible_facts['user']) }}"
-mise_usergroup: "{{ ansible_facts['user_gid'] | default('staff' if ansible_facts['os_family'] == 'Darwin' else mise_username) }}"
+mise_usergroup: "{{ (ansible_facts['user_gid'] | default('staff')) if ansible_facts['os_family'] == 'Darwin' else mise_username }}"
 mise_user_home: >-
-  {{ ansible_facts['user_dir'] | default(ansible_facts['env']['HOME']) | default(
-     (ansible_facts['os_family'] == 'Darwin') | ternary('/Users/' + mise_username,
-     (mise_username == 'root') | ternary('/root', '/home/' + mise_username))) }}
+  {{ (ansible_facts['user_dir'] | default(ansible_facts['env']['HOME']))
+     if (mise_username == (ansible_facts['user_id'] | default(ansible_facts['user']) | default('')))
+     else ((ansible_facts['os_family'] == 'Darwin') | ternary('/Users/' + mise_username,
+           (mise_username == 'root') | ternary('/root', '/home/' + mise_username))) }}
 
 mise_bin_dir: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary(mise_user_home + '/.local/bin', '/usr/local/bin') }}"
 mise_data_dir: "{{ mise_user_home }}/.local/share/mise"

--- a/roles/mise/defaults/main.yml
+++ b/roles/mise/defaults/main.yml
@@ -1,9 +1,10 @@
 ---
 mise_username: "{{ ansible_facts['user_id'] | default(ansible_facts['user']) }}"
-mise_usergroup: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['user_gid'] | default('staff'), mise_username) }}"
+mise_usergroup: "{{ ansible_facts['user_gid'] | default('staff' if ansible_facts['os_family'] == 'Darwin' else mise_username) }}"
 mise_user_home: >-
-  {{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['env']['HOME'],
-     (mise_username == 'root') | ternary('/root', '/home/' + mise_username)) }}
+  {{ ansible_facts['user_dir'] | default(ansible_facts['env']['HOME']) | default(
+     (ansible_facts['os_family'] == 'Darwin') | ternary('/Users/' + mise_username,
+     (mise_username == 'root') | ternary('/root', '/home/' + mise_username))) }}
 
 mise_bin_dir: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary(mise_user_home + '/.local/bin', '/usr/local/bin') }}"
 mise_data_dir: "{{ mise_user_home }}/.local/share/mise"

--- a/roles/mise/tasks/main.yml
+++ b/roles/mise/tasks/main.yml
@@ -27,7 +27,7 @@
     owner: "{{ mise_username }}"
     group: "{{ mise_usergroup }}"
     mode: "0755"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and (not mise_bin_dir.startswith(mise_user_home) or mise_username != ansible_facts['user_id']) }}"
 
 - name: Check if mise is already installed
   ansible.builtin.stat:
@@ -40,10 +40,10 @@
   changed_when: false
   failed_when: false
   when: mise_binary_stat.stat.exists
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and (not mise_bin_dir.startswith(mise_user_home) or mise_username != ansible_facts['user_id']) }}"
 
 - name: Fetch and install mise binary
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and (not mise_bin_dir.startswith(mise_user_home) or mise_username != ansible_facts['user_id']) }}"
   when: not mise_binary_stat.stat.exists or mise_version not in (mise_installed_version.stdout | default(''))
   block:
     - name: Download mise archive
@@ -87,7 +87,7 @@
         state: absent
 
 - name: Setup mise data directory
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and mise_username != ansible_facts['user_id'] }}"
   ansible.builtin.file:
     path: "{{ mise_data_dir }}"
     state: directory
@@ -96,7 +96,7 @@
     mode: "0755"
 
 - name: Setup mise config directory
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and mise_username != ansible_facts['user_id'] }}"
   ansible.builtin.file:
     path: "{{ mise_config_dir }}"
     state: directory
@@ -105,7 +105,7 @@
     mode: "0755"
 
 - name: Setup mise shims directory
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and mise_username != ansible_facts['user_id'] }}"
   ansible.builtin.file:
     path: "{{ mise_data_dir }}/shims"
     state: directory
@@ -139,7 +139,7 @@
   args:
     executable: /bin/bash
   environment: "{{ mise_env }}"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and mise_username != ansible_facts['user_id'] }}"
   become_user: "{{ mise_username }}"
   changed_when: false
 
@@ -148,14 +148,14 @@
     src: install_mise_plugins.sh.j2
     dest: "/tmp/install_mise_plugins"
     mode: "0755"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and mise_username != ansible_facts['user_id'] }}"
 
 - name: Install mise plugins
   ansible.builtin.shell: "/tmp/install_mise_plugins"
   args:
     executable: /bin/bash
   environment: "{{ mise_env }}"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and mise_username != ansible_facts['user_id'] }}"
   become_user: "{{ mise_username }}"
   register: mise_plugin_installation
   # Not change-idempotent: the script re-runs plugin setup (mise use
@@ -170,7 +170,7 @@
     owner: "{{ mise_username }}"
     group: "{{ mise_usergroup }}"
     mode: "0644"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and mise_username != ansible_facts['user_id'] }}"
 
 - name: Reshim after installations
   ansible.builtin.shell: |
@@ -179,7 +179,7 @@
   args:
     executable: /bin/bash
   environment: "{{ mise_env }}"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and mise_username != ansible_facts['user_id'] }}"
   become_user: "{{ mise_username }}"
   changed_when: false
 

--- a/roles/package_management/tasks/main.yml
+++ b/roles/package_management/tasks/main.yml
@@ -6,7 +6,9 @@
     create: true
     mode: '0644'
   become: true
-  when: ansible_facts["os_family"] == 'Debian'
+  when:
+    - ansible_facts["os_family"] == 'Debian'
+    - package_management_enabled | default(true) | bool
 
 - name: Install Kali Linux archive keyring
   ansible.builtin.get_url:
@@ -14,7 +16,9 @@
     dest: /usr/share/keyrings/kali-archive-keyring.gpg
     mode: '0644'
   become: true
-  when: ansible_facts["distribution"] == 'Kali'
+  when:
+    - ansible_facts["distribution"] == 'Kali'
+    - package_management_enabled | default(true) | bool
 
 - name: Install packages
   become: true
@@ -22,7 +26,9 @@
     name: "{{ package_management_install_packages }}"
     state: present
     update_cache: true
-  when: ansible_facts["os_family"] in ['Debian', 'RedHat']
+  when:
+    - ansible_facts["os_family"] in ['Debian', 'RedHat']
+    - package_management_enabled | default(true) | bool
   environment: "{{ (ansible_facts['os_family'] == 'Debian') | ternary({'DEBIAN_FRONTEND': 'noninteractive'}, {}) }}"
   register: package_management_package_result
   until: package_management_package_result is success

--- a/roles/tmux_setup/README.md
+++ b/roles/tmux_setup/README.md
@@ -19,7 +19,7 @@ Renders ~/.tmux.conf with mouse-friendly bindings and OSC52 clipboard
 | `tmux_setup_conf_path` | str | <code>{{ tmux_setup_user_home }}/.tmux.conf</code> | No description |
 | `tmux_setup_default_terminal` | str | <code>screen-256color</code> | No description |
 | `tmux_setup_history_limit` | int | <code>100000</code> | No description |
-| `tmux_setup_clipboard_command` | str | <code>pbcopy</code> | No description |
+| `tmux_setup_clipboard_command` | str | <code>{{ 'pbcopy' if ansible_facts&#91;'os_family'&#93; == 'Darwin' else 'xclip -selection clipboard' }}</code> | No description |
 | `tmux_setup_backup` | bool | <code>True</code> | No description |
 | `tmux_setup_local_overrides_path` | str | <code>{{ tmux_setup_user_home }}/.tmux.conf.local</code> | No description |
 

--- a/roles/tmux_setup/defaults/main.yml
+++ b/roles/tmux_setup/defaults/main.yml
@@ -11,8 +11,7 @@ tmux_setup_default_terminal: "screen-256color"
 tmux_setup_history_limit: 100000
 
 # Command used by `bind C` to copy the pane buffer to the system clipboard.
-# Defaults to macOS pbcopy; override for Linux (e.g. "xclip -selection clipboard").
-tmux_setup_clipboard_command: "pbcopy"
+tmux_setup_clipboard_command: "{{ 'pbcopy' if ansible_facts['os_family'] == 'Darwin' else 'xclip -selection clipboard' }}"
 
 # Whether to back up an existing ~/.tmux.conf before overwriting it.
 tmux_setup_backup: true

--- a/roles/zsh_setup/defaults/main.yml
+++ b/roles/zsh_setup/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 zsh_setup_username: "{{ ansible_facts['user_id'] | default(ansible_facts['user']) | default(ansible_facts['distribution'] | lower) }}"
-zsh_setup_usergroup: "{{ ansible_facts['user_gid'] | default('staff' if ansible_facts['os_family'] == 'Darwin' else 'Administrators' if ansible_facts['os_family'] == 'Windows' else zsh_setup_username) }}"
+zsh_setup_usergroup: "{{ (ansible_facts['user_gid'] | default('staff')) if ansible_facts['os_family'] == 'Darwin' else 'Administrators' if ansible_facts['os_family'] == 'Windows' else zsh_setup_username }}"
 zsh_setup_shell: "{{ 'powershell' if ansible_facts['os_family'] == 'Windows' else (ansible_facts['env']['SHELL'] | default('/bin/bash')).strip() | regex_replace('\n', '') }}"
 zsh_setup_theme: "af-magic"
 zsh_setup_plugins:

--- a/roles/zsh_setup/defaults/main.yml
+++ b/roles/zsh_setup/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 zsh_setup_username: "{{ ansible_facts['user_id'] | default(ansible_facts['user']) | default(ansible_facts['distribution'] | lower) }}"
-zsh_setup_usergroup: "{{ (ansible_facts['user_gid'] | default('staff')) if ansible_facts['os_family'] == 'Darwin' else 'Administrators' if ansible_facts['os_family'] == 'Windows' else zsh_setup_username }}"
+zsh_setup_usergroup: "{{ ansible_facts['user_gid'] | default('staff' if ansible_facts['os_family'] == 'Darwin' else 'Administrators' if ansible_facts['os_family'] == 'Windows' else zsh_setup_username) }}"
 zsh_setup_shell: "{{ 'powershell' if ansible_facts['os_family'] == 'Windows' else (ansible_facts['env']['SHELL'] | default('/bin/bash')).strip() | regex_replace('\n', '') }}"
 zsh_setup_theme: "af-magic"
 zsh_setup_plugins:


### PR DESCRIPTION
**Key Changes:**

- Added conditional enablement toggles across all workstation roles for granular execution control
- Refactored user home directory and group discovery to standardize on `ansible_facts['user_dir']` with robust fallbacks
- Restructured `become` conditions to avoid unnecessary privilege escalation when running user-scoped tasks
- Migrated logging configuration to support non-root execution and inventory overrides

**Added:**

- Role enablement toggles - Introduced `*_enabled` conditional checks across playbook tasks in `playbooks/workstation/workstation.yml` and `roles/package_management/tasks/main.yml`
- Dynamic clipboard detection - Configured automatic platform selection between `pbcopy` and `xclip` in `roles/tmux_setup/defaults/main.yml`
- User-level log rotation settings - Added support for non-root state files and user config directories in `roles/logging/defaults/main.yml`

**Changed:**

- Conditional privilege escalation - Scoped `become` execution in `roles/antigravity/`, `roles/go_task/tasks/install-unix.yml`, and `roles/mise/tasks/main.yml` to only elevate privileges when installing to system paths or targeting other users
- User home and group fact discovery - Standardized default variable resolution on `ansible_facts['user_dir']` with cross-platform fallbacks across `roles/antigravity/defaults/main.yml`, `roles/asdf/defaults/main.yml`, `roles/claude_code/defaults/main.yml`, `roles/fabric/defaults/main.yml`, `roles/mise/defaults/main.yml`, and `roles/zsh_setup/defaults/main.yml`
- Path formatting in logging tasks - Replaced `expanduser` with explicit home directory regex replacement and restricted escalation to `/etc` targets in `roles/logging/tasks/main.yml` and `roles/logging/templates/logrotate.j2`

**Removed:**

- Hardcoded logging variables - Removed immutable system path definitions from `roles/logging/vars/main.yml` to enable variable overrides via defaults and inventory