### PR TITLE
feat: harden non-root logging with systemd user timer and gating

### DIFF
--- a/roles/logging/README.md
+++ b/roles/logging/README.md
@@ -21,11 +21,15 @@ Provides flexible logging directories and log rotation for any application or se
 | `logging_launchagent_hour` | int | <code>3</code> | No description |
 | `logging_launchagent_minute` | int | <code>0</code> | No description |
 | `logging_logrotate_log_path` | str | <code>{{ (ansible_facts&#91;'user_dir'&#93; &#124; default(ansible_facts&#91;'env'&#93;&#91;'HOME'&#93;)) }}/logs/logrotate</code> | No description |
+| `logging_manage_system` | bool | <code>False</code> | No description |
+| `logging_systemd_timer_on_calendar` | str | <code>*-*-* 03:00:00</code> | No description |
 | `logging_logrotate_binary_darwin` | str | <code>/opt/homebrew/sbin/logrotate</code> | No description |
 | `logging_logrotate_binary_linux` | str | <code>/usr/sbin/logrotate</code> | No description |
 | `logging_logrotate_config_dir_darwin` | str | <code>{{ (ansible_facts&#91;'user_dir'&#93; &#124; default(ansible_facts&#91;'env'&#93;&#91;'HOME'&#93;)) }}/.config/logrotate.d</code> | No description |
-| `logging_logrotate_config_dir_linux` | str | <code>{{ '/etc/logrotate.d' if (ansible_facts&#91;'user_id'&#93; == 'root' or logging_manage_system &#124; default(false)) else ((ansible_facts&#91;'user_dir'&#93; &#124; default(ansible_facts&#91;'env'&#93;&#91;'HOME'&#93;)) + '/.config/logrotate.d') }}</code> | No description |
+| `logging_logrotate_config_dir_linux` | str | <code>{{ '/etc/logrotate.d' if (ansible_facts&#91;'user_id'&#93; == 'root' or logging_manage_system &#124; bool) else ((ansible_facts&#91;'user_dir'&#93; &#124; default(ansible_facts&#91;'env'&#93;&#91;'HOME'&#93;)) + '/.config/logrotate.d') }}</code> | No description |
 | `logging_logrotate_state_file` | str | <code>{{ (ansible_facts&#91;'user_dir'&#93; &#124; default(ansible_facts&#91;'env'&#93;&#91;'HOME'&#93;)) + '/.config/logrotate.state' if (ansible_facts&#91;'os_family'&#93; == 'Darwin' or ansible_facts&#91;'user_id'&#93; != 'root') else '/var/lib/logrotate/status' }}</code> | No description |
+| `logging_logrotate_binary` | str | <code>{{ logging_logrotate_binary_darwin if ansible_facts&#91;'os_family'&#93; == 'Darwin' else logging_logrotate_binary_linux }}</code> | No description |
+| `logging_logrotate_config_dir` | str | <code>{{ logging_logrotate_config_dir_darwin if ansible_facts&#91;'os_family'&#93; == 'Darwin' else logging_logrotate_config_dir_linux }}</code> | No description |
 
 ## Tasks
 
@@ -33,7 +37,6 @@ Provides flexible logging directories and log rotation for any application or se
 
 
 - **Set OS-specific facts** (ansible.builtin.set_fact)
-- **Set logrotate paths based on OS** (ansible.builtin.set_fact)
 - **Check if logrotate binary exists** (ansible.builtin.stat)
 - **Install logrotate on macOS** (community.general.homebrew) - Conditional
 - **Install logrotate on Linux (Debian-based)** (ansible.builtin.apt) - Conditional
@@ -50,6 +53,10 @@ Provides flexible logging directories and log rotation for any application or se
 - **Unload existing LaunchAgent if present** (ansible.builtin.command) - Conditional
 - **Load LaunchAgent for logrotate on macOS** (ansible.builtin.command) - Conditional
 - **Ensure logrotate's own log directory exists** (ansible.builtin.file) - Conditional
+- **Ensure systemd user unit directory exists** (ansible.builtin.file) - Conditional
+- **Install systemd user units for logrotate** (ansible.builtin.template) - Conditional
+- **Check for a reachable systemd user session** (ansible.builtin.command) - Conditional
+- **Enable and start the logrotate user timer** (ansible.builtin.systemd_service) - Conditional
 
 ## Example Playbook
 

--- a/roles/logging/defaults/main.yml
+++ b/roles/logging/defaults/main.yml
@@ -32,9 +32,23 @@ logging_launchagent_hour: 3 # Default to 3:00 AM daily
 logging_launchagent_minute: 0 # Default to 3:00 AM daily
 logging_logrotate_log_path: "{{ (ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) }}/logs/logrotate" # Where logrotate itself logs
 
+# On Linux, force rotation configs into /etc/logrotate.d (requires become)
+# even when the play runs as a non-root user. Leave false to keep non-root
+# runs privilege-free: configs land in ~/.config/logrotate.d and are run by
+# the systemd user timer this role installs.
+logging_manage_system: false
+
+# Schedule for the Linux systemd user timer (systemd OnCalendar syntax).
+logging_systemd_timer_on_calendar: "*-*-* 03:00:00"
+
 # System-specific paths
 logging_logrotate_binary_darwin: "/opt/homebrew/sbin/logrotate"
 logging_logrotate_binary_linux: "/usr/sbin/logrotate"
 logging_logrotate_config_dir_darwin: "{{ (ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) }}/.config/logrotate.d"
-logging_logrotate_config_dir_linux: "{{ '/etc/logrotate.d' if (ansible_facts['user_id'] == 'root' or logging_manage_system | default(false)) else ((ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) + '/.config/logrotate.d') }}"
+logging_logrotate_config_dir_linux: "{{ '/etc/logrotate.d' if (ansible_facts['user_id'] == 'root' or logging_manage_system | bool) else ((ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) + '/.config/logrotate.d') }}"
 logging_logrotate_state_file: "{{ (ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) + '/.config/logrotate.state' if (ansible_facts['os_family'] == 'Darwin' or ansible_facts['user_id'] != 'root') else '/var/lib/logrotate/status' }}"
+
+# Resolved per-OS paths. Overridable from inventory; the *_darwin/*_linux
+# variants above only feed these defaults.
+logging_logrotate_binary: "{{ logging_logrotate_binary_darwin if ansible_facts['os_family'] == 'Darwin' else logging_logrotate_binary_linux }}"
+logging_logrotate_config_dir: "{{ logging_logrotate_config_dir_darwin if ansible_facts['os_family'] == 'Darwin' else logging_logrotate_config_dir_linux }}"

--- a/roles/logging/molecule/default/converge.yml
+++ b/roles/logging/molecule/default/converge.yml
@@ -26,3 +26,28 @@
             maxsize: 100M
         logging_logrotate_log_path: /var/log/logrotate
         logging_logrotate_state_file: /var/lib/logrotate.state
+
+# Exercise the user-scope Linux path: configs land under ~/.config/logrotate.d
+# and the role renders systemd user units instead of relying on system cron.
+# (Containers run as root, so the user-scope dir is forced via override; the
+# timer enable step is skipped because containers have no user session bus.)
+- name: Converge user-scope rotation
+  hosts: all
+  tasks:
+    - name: Include role under test with a user-scope config dir
+      ansible.builtin.include_role:
+        name: cowdogmoo.workstation.logging
+      vars:
+        logging_logrotate_config_dir: "{{ ansible_facts['user_dir'] | default('/root') }}/.config/logrotate.d"
+        logging_directories:
+          - path: "~/test-user-logs"
+            mode: "0755"
+        logging_rotation_configs:
+          - name: user-app
+            path: "~/test-user-logs/*.log"
+            rotate: 7
+            frequency: daily
+            compress: true
+            missingok: true
+            notifempty: true
+            create: true

--- a/roles/logging/molecule/default/verify.yml
+++ b/roles/logging/molecule/default/verify.yml
@@ -65,3 +65,44 @@
           - logging_logrotate_debug.rc == 0
         fail_msg: "Logrotate configuration is invalid"
         success_msg: "Logrotate configuration is valid"
+
+    # User-scope path (second converge play): config and systemd user units
+    - name: Check user-scope rotation artifacts
+      ansible.builtin.stat:
+        path: "{{ item }}"
+      loop:
+        - "{{ ansible_facts['user_dir'] }}/.config/logrotate.d/user-app"
+        - "{{ ansible_facts['user_dir'] }}/.config/systemd/user/logrotate.service"
+        - "{{ ansible_facts['user_dir'] }}/.config/systemd/user/logrotate.timer"
+      register: logging_user_scope_stats
+
+    - name: Assert user-scope rotation artifacts exist
+      ansible.builtin.assert:
+        that:
+          - item.stat.exists
+        fail_msg: "Missing user-scope artifact: {{ item.item }}"
+        quiet: true
+      loop: "{{ logging_user_scope_stats.results }}"
+
+    - name: Read user-scope rotation config
+      ansible.builtin.slurp:
+        src: "{{ ansible_facts['user_dir'] }}/.config/logrotate.d/user-app"
+      register: logging_user_scope_config
+
+    - name: Assert tilde paths were expanded to the user's home
+      ansible.builtin.assert:
+        that:
+          - "ansible_facts['user_dir'] + '/test-user-logs/*.log' in logging_user_scope_config.content | b64decode"
+        fail_msg: "User-scope config does not contain the expanded home path"
+
+    - name: Read rendered systemd user service
+      ansible.builtin.slurp:
+        src: "{{ ansible_facts['user_dir'] }}/.config/systemd/user/logrotate.service"
+      register: logging_user_scope_service
+
+    - name: Assert the service runs logrotate against the user config dir
+      ansible.builtin.assert:
+        that:
+          - "'/logrotate.d/*' in logging_user_scope_service.content | b64decode"
+          - "'logrotate -s' in logging_user_scope_service.content | b64decode"
+        fail_msg: "systemd user service does not invoke logrotate on the user config dir"

--- a/roles/logging/tasks/main.yml
+++ b/roles/logging/tasks/main.yml
@@ -3,11 +3,7 @@
   ansible.builtin.set_fact:
     logging_is_macos: "{{ ansible_facts['os_family'] == 'Darwin' }}"
     logging_is_linux: "{{ ansible_facts['os_family'] in ['Debian', 'RedHat'] }}"
-
-- name: Set logrotate paths based on OS
-  ansible.builtin.set_fact:
-    logging_logrotate_binary: "{{ logging_logrotate_binary | default(logging_logrotate_binary_darwin if logging_is_macos else logging_logrotate_binary_linux) }}"
-    logging_logrotate_config_dir: "{{ logging_logrotate_config_dir | default(logging_logrotate_config_dir_darwin if logging_is_macos else logging_logrotate_config_dir_linux) }}"
+    logging_user_scope_linux: "{{ ansible_facts['os_family'] in ['Debian', 'RedHat'] and not logging_logrotate_config_dir.startswith('/etc') }}"
 
 - name: Check if logrotate binary exists
   ansible.builtin.stat:
@@ -155,3 +151,53 @@
   when:
     - logging_is_macos
     - logging_rotation_configs | length > 0
+
+# System logrotate only reads /etc/logrotate.d, so configs written to a
+# user-scope directory on Linux need their own scheduler — a systemd user
+# timer, mirroring the LaunchAgent used on macOS.
+- name: Ensure systemd user unit directory exists
+  ansible.builtin.file:
+    path: "{{ (ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) }}/.config/systemd/user"
+    state: directory
+    mode: "0755"
+  when:
+    - logging_user_scope_linux
+    - logging_rotation_configs | length > 0
+
+- name: Install systemd user units for logrotate
+  ansible.builtin.template:
+    src: "{{ item }}.j2"
+    dest: "{{ (ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) }}/.config/systemd/user/{{ item }}"
+    mode: "0644"
+  loop:
+    - logrotate.service
+    - logrotate.timer
+  when:
+    - logging_user_scope_linux
+    - logging_rotation_configs | length > 0
+
+# `systemctl --user` needs a reachable user session bus; containers and bare
+# SSH sessions without lingering don't have one, so probe before enabling.
+# The command exercises the same bus connection the systemd_service module
+# uses, which no module can probe — hence the noqa.
+- name: Check for a reachable systemd user session # noqa: command-instead-of-module
+  ansible.builtin.command:
+    cmd: systemctl --user show-environment
+  register: logging_systemd_user_session
+  changed_when: false
+  failed_when: false
+  when:
+    - logging_user_scope_linux
+    - logging_rotation_configs | length > 0
+
+- name: Enable and start the logrotate user timer
+  ansible.builtin.systemd_service:
+    name: logrotate.timer
+    scope: user
+    daemon_reload: true
+    enabled: true
+    state: started
+  when:
+    - logging_user_scope_linux
+    - logging_rotation_configs | length > 0
+    - logging_systemd_user_session.rc | default(1) == 0

--- a/roles/logging/templates/logrotate.service.j2
+++ b/roles/logging/templates/logrotate.service.j2
@@ -1,0 +1,6 @@
+[Unit]
+Description=Rotate user-scope logs with logrotate
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c '{{ logging_logrotate_binary }} -s {{ logging_logrotate_state_file }} {{ logging_logrotate_config_dir }}/*'

--- a/roles/logging/templates/logrotate.timer.j2
+++ b/roles/logging/templates/logrotate.timer.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Daily user-scope logrotate run
+
+[Timer]
+OnCalendar={{ logging_systemd_timer_on_calendar }}
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/roles/package_management/README.md
+++ b/roles/package_management/README.md
@@ -15,6 +15,7 @@ Manage package installations and cleanups on Debian-based and Red Hat-based syst
 
 | Variable | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
+| `package_management_enabled` | bool | <code>True</code> | No description |
 | `package_management_common_install_packages` | list | <code>&#91;&#93;</code> | No description |
 | `package_management_common_install_packages.0` | str | <code>autoconf</code> | No description |
 | `package_management_common_install_packages.1` | str | <code>bash</code> | No description |

--- a/roles/package_management/defaults/main.yml
+++ b/roles/package_management/defaults/main.yml
@@ -1,4 +1,9 @@
 ---
+# Master toggle for the whole role. Checked in-task (not just at the playbook
+# level) so it also applies when other roles include package_management
+# directly, e.g. zsh_setup.
+package_management_enabled: true
+
 # Common packages to be installed on all systems
 package_management_common_install_packages:
   - autoconf

--- a/roles/package_management/tasks/main.yml
+++ b/roles/package_management/tasks/main.yml
@@ -8,7 +8,7 @@
   become: true
   when:
     - ansible_facts["os_family"] == 'Debian'
-    - package_management_enabled | default(true) | bool
+    - package_management_enabled | bool
 
 - name: Install Kali Linux archive keyring
   ansible.builtin.get_url:
@@ -18,7 +18,7 @@
   become: true
   when:
     - ansible_facts["distribution"] == 'Kali'
-    - package_management_enabled | default(true) | bool
+    - package_management_enabled | bool
 
 - name: Install packages
   become: true
@@ -28,7 +28,7 @@
     update_cache: true
   when:
     - ansible_facts["os_family"] in ['Debian', 'RedHat']
-    - package_management_enabled | default(true) | bool
+    - package_management_enabled | bool
   environment: "{{ (ansible_facts['os_family'] == 'Debian') | ternary({'DEBIAN_FRONTEND': 'noninteractive'}, {}) }}"
   register: package_management_package_result
   until: package_management_package_result is success
@@ -38,12 +38,15 @@
 
 - name: Install modern CLI tools
   ansible.builtin.include_tasks: modern_cli.yml
-  when: package_management_install_modern_cli | bool
+  when:
+    - package_management_enabled | bool
+    - package_management_install_modern_cli | bool
   tags: packages
 
 - name: Manage Brewfile (macOS)
   ansible.builtin.include_tasks: brewfile.yml
   when:
+    - package_management_enabled | bool
     - ansible_facts['os_family'] == 'Darwin'
     - package_management_manage_brewfile | bool
   tags: packages

--- a/roles/tmux_setup/molecule/default/converge.yml
+++ b/roles/tmux_setup/molecule/default/converge.yml
@@ -5,6 +5,3 @@
     - name: Include role under test
       ansible.builtin.include_role:
         name: cowdogmoo.workstation.tmux_setup
-      vars:
-        # The default uses pbcopy which doesn't exist in Linux molecule images.
-        tmux_setup_clipboard_command: "xclip -selection clipboard"


### PR DESCRIPTION
**Key Changes:**

- Added a systemd user timer path so non-root Linux runs get scheduled log rotation without requiring root, mirroring the macOS LaunchAgent pattern
- Promoted `logging_manage_system` and resolved `logging_logrotate_*` paths to first-class defaults so they can be overridden from inventory and reused across tasks
- Made `package_management_enabled` a real default and enforced it in every task so downstream roles (e.g. `zsh_setup`) that include package_management directly also honor the toggle

**Added:**

- systemd user units for logrotate — `templates/logrotate.service.j2` and `templates/logrotate.timer.j2` render into `~/.config/systemd/user/`, driven by the new `logging_systemd_timer_on_calendar` schedule variable
- User-session probing and unit installation — new tasks in `roles/logging/tasks/main.yml` create the user unit directory, install the units, probe for a reachable systemd user bus with `systemctl --user show-environment`, and enable/start `logrotate.timer` only when the bus is available (keeps container converges green)
- `logging_manage_system` default (bool, false) documenting that non-root Linux runs stay privilege-free by writing configs under `~/.config/logrotate.d`
- `package_management_enabled` default (bool, true) — a proper master toggle for the role instead of relying on `| default(true)` sprinkled through tasks
- Molecule coverage for the user-scope Linux path — a second converge play exercises `~/.config/logrotate.d`, and `verify.yml` asserts the config file, rendered service/timer units, tilde expansion, and that the service actually invokes logrotate against the user config dir

**Changed:**

- Consolidated `logging_logrotate_binary` and `logging_logrotate_config_dir` into `defaults/main.yml` as OS-resolved defaults and removed the redundant `Set logrotate paths based on OS` set_fact task; the OS-family/user-scope classification now lives in a single set_fact that also derives `logging_user_scope_linux`
- Replaced `| default(false)` with `| bool` in `logging_logrotate_config_dir_linux` now that `logging_manage_system` is a declared default
- `package_management` tasks now gate every step (including `modern_cli.yml` and `brewfile.yml` includes) on `package_management_enabled | bool` without relying on inline defaults
- Simplified `roles/tmux_setup/molecule/default/converge.yml` by dropping the Linux-only `tmux_setup_clipboard_command` override

**Removed:**

- `Set logrotate paths based on OS` set_fact task in `roles/logging/tasks/main.yml` — superseded by resolved defaults
- Inline `| default(true)` fallbacks on `package_management_enabled` across `roles/package_management/tasks/main.yml`
- `tmux_setup_clipboard_command: "xclip -selection clipboard"` override from the tmux_setup molecule converge