### PR TITLE
fix: restore pre-3.6 tmux wheel-scroll behavior and harden home path resolution

### DIFF
--- a/roles/ansible_bootstrap/README.md
+++ b/roles/ansible_bootstrap/README.md
@@ -15,7 +15,7 @@ Templates ~/.ansible.cfg and creates the ~/.ansible directory tree (collections,
 
 | Variable | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
-| `ansible_bootstrap_user_home` | str | <code>{{ ansible_facts&#91;'env'&#93;&#91;'HOME'&#93; }}</code> | No description |
+| `ansible_bootstrap_user_home` | str | <code>{{ ansible_facts&#91;'user_dir'&#93; &#124; default(ansible_facts&#91;'env'&#93;&#91;'HOME'&#93;) }}</code> | No description |
 | `ansible_bootstrap_dir` | str | <code>{{ ansible_bootstrap_user_home }}/.ansible</code> | No description |
 | `ansible_bootstrap_collections_path` | str | <code>{{ ansible_bootstrap_dir }}/collections</code> | No description |
 | `ansible_bootstrap_roles_path` | str | <code>{{ ansible_bootstrap_dir }}/roles</code> | No description |

--- a/roles/ansible_bootstrap/defaults/main.yml
+++ b/roles/ansible_bootstrap/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-ansible_bootstrap_user_home: "{{ ansible_facts['env']['HOME'] }}"
+ansible_bootstrap_user_home: "{{ ansible_facts['user_dir'] | default(ansible_facts['env']['HOME']) }}"
 
 # Where ansible's user-level state lives.
 ansible_bootstrap_dir: "{{ ansible_bootstrap_user_home }}/.ansible"

--- a/roles/git_setup/README.md
+++ b/roles/git_setup/README.md
@@ -15,7 +15,7 @@ Renders ~/.gitconfig with aliases and sane defaults
 
 | Variable | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
-| `git_setup_user_home` | str | <code>{{ ansible_facts&#91;'env'&#93;&#91;'HOME'&#93; }}</code> | No description |
+| `git_setup_user_home` | str | <code>{{ ansible_facts&#91;'user_dir'&#93; &#124; default(ansible_facts&#91;'env'&#93;&#91;'HOME'&#93;) }}</code> | No description |
 | `git_setup_gitconfig_path` | str | <code>{{ git_setup_user_home }}/.gitconfig</code> | No description |
 | `git_setup_userparams_path` | str | <code>{{ git_setup_user_home }}/.gitconfig.userparams</code> | No description |
 | `git_setup_editor` | str | <code>code --wait</code> | No description |

--- a/roles/git_setup/defaults/main.yml
+++ b/roles/git_setup/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-git_setup_user_home: "{{ ansible_facts['env']['HOME'] }}"
+git_setup_user_home: "{{ ansible_facts['user_dir'] | default(ansible_facts['env']['HOME']) }}"
 
 # Where ~/.gitconfig is written.
 git_setup_gitconfig_path: "{{ git_setup_user_home }}/.gitconfig"

--- a/roles/go_task/README.md
+++ b/roles/go_task/README.md
@@ -16,7 +16,7 @@ Installs go-task (Task runner) on Unix-like and Windows systems
 | Variable | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `go_task_version` | str | <code>latest</code> | No description |
-| `go_task_install_dir` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary(ansible_facts&#91;'env'&#93;&#91;'HOME'&#93; + '/.local/bin', '/usr/local/bin') }}</code> | No description |
+| `go_task_install_dir` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary((ansible_facts&#91;'user_dir'&#93; &#124; default(ansible_facts&#91;'env'&#93;&#91;'HOME'&#93;)) + '/.local/bin', '/usr/local/bin') }}</code> | No description |
 | `go_task_windows_install_dir` | str | <code>C:\\Program Files\\task</code> | No description |
 | `go_task_windows_add_to_path` | bool | <code>True</code> | No description |
 | `go_task_github_token` | str | <code>{{ lookup('env', 'GITHUB_TOKEN') &#124; default('') }}</code> | No description |

--- a/roles/go_task/defaults/main.yml
+++ b/roles/go_task/defaults/main.yml
@@ -3,7 +3,7 @@
 go_task_version: latest
 
 # Installation directory for Unix-like systems
-go_task_install_dir: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary(ansible_facts['env']['HOME'] + '/.local/bin', '/usr/local/bin') }}"
+go_task_install_dir: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary((ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) + '/.local/bin', '/usr/local/bin') }}"
 
 # Installation directory for Windows systems
 go_task_windows_install_dir: C:\\Program Files\\task

--- a/roles/package_management/README.md
+++ b/roles/package_management/README.md
@@ -71,7 +71,7 @@ Manage package installations and cleanups on Debian-based and Red Hat-based syst
 | `package_management_install_modern_cli` | bool | <code>False</code> | No description |
 | `package_management_manage_brewfile` | bool | <code>False</code> | No description |
 | `package_management_brewfile_src` | str | <code></code> | No description |
-| `package_management_brewfile_dest` | str | <code>{{ ansible_facts&#91;'env'&#93;&#91;'HOME'&#93; }}/.config/brewfile/Brewfile</code> | No description |
+| `package_management_brewfile_dest` | str | <code>{{ (ansible_facts&#91;'user_dir'&#93; &#124; default(ansible_facts&#91;'env'&#93;&#91;'HOME'&#93;)) }}/.config/brewfile/Brewfile</code> | No description |
 | `package_management_brewfile_apply` | bool | <code>False</code> | No description |
 | `package_management_modern_cli_brew_packages` | list | <code>&#91;&#93;</code> | No description |
 | `package_management_modern_cli_brew_packages.0` | str | <code>bat</code> | No description |

--- a/roles/package_management/defaults/main.yml
+++ b/roles/package_management/defaults/main.yml
@@ -76,7 +76,7 @@ package_management_install_modern_cli: false
 # Set package_management_brewfile_apply to also run `brew bundle --file=...`.
 package_management_manage_brewfile: false
 package_management_brewfile_src: ""
-package_management_brewfile_dest: "{{ ansible_facts['env']['HOME'] }}/.config/brewfile/Brewfile"
+package_management_brewfile_dest: "{{ (ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) }}/.config/brewfile/Brewfile"
 package_management_brewfile_apply: false
 
 # macOS Homebrew package names — Homebrew carries every tool we want.

--- a/roles/shell_functions/README.md
+++ b/roles/shell_functions/README.md
@@ -15,7 +15,7 @@ Deploys the user's dotfiles shell-function library to ~/.dotfiles
 
 | Variable | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
-| `shell_functions_user_home` | str | <code>{{ ansible_facts&#91;'env'&#93;&#91;'HOME'&#93; }}</code> | No description |
+| `shell_functions_user_home` | str | <code>{{ ansible_facts&#91;'user_dir'&#93; &#124; default(ansible_facts&#91;'env'&#93;&#91;'HOME'&#93;) }}</code> | No description |
 | `shell_functions_dest` | str | <code>{{ shell_functions_user_home }}/.dotfiles</code> | No description |
 | `shell_functions_source_path` | str | <code></code> | No description |
 | `shell_functions_repo_url` | str | <code></code> | No description |

--- a/roles/shell_functions/defaults/main.yml
+++ b/roles/shell_functions/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-shell_functions_user_home: "{{ ansible_facts['env']['HOME'] }}"
+shell_functions_user_home: "{{ ansible_facts['user_dir'] | default(ansible_facts['env']['HOME']) }}"
 
 # Destination the dotfiles content is materialized into. The zsh_setup template
 # sources every *.sh/*.zsh under this path.

--- a/roles/tmux_setup/README.md
+++ b/roles/tmux_setup/README.md
@@ -15,7 +15,7 @@ Renders ~/.tmux.conf with mouse-friendly bindings and OSC52 clipboard
 
 | Variable | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
-| `tmux_setup_user_home` | str | <code>{{ ansible_facts&#91;'env'&#93;&#91;'HOME'&#93; }}</code> | No description |
+| `tmux_setup_user_home` | str | <code>{{ ansible_facts&#91;'user_dir'&#93; &#124; default(ansible_facts&#91;'env'&#93;&#91;'HOME'&#93;) }}</code> | No description |
 | `tmux_setup_conf_path` | str | <code>{{ tmux_setup_user_home }}/.tmux.conf</code> | No description |
 | `tmux_setup_default_terminal` | str | <code>screen-256color</code> | No description |
 | `tmux_setup_history_limit` | int | <code>100000</code> | No description |

--- a/roles/tmux_setup/defaults/main.yml
+++ b/roles/tmux_setup/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
-tmux_setup_user_home: "{{ ansible_facts['env']['HOME'] }}"
+# user_dir comes from /etc/passwd for the connecting user, so it stays correct
+# under become; env HOME is only a fallback for when user_dir is not gathered.
+tmux_setup_user_home: "{{ ansible_facts['user_dir'] | default(ansible_facts['env']['HOME']) }}"
 
 # Where ~/.tmux.conf is written.
 tmux_setup_conf_path: "{{ tmux_setup_user_home }}/.tmux.conf"

--- a/roles/tmux_setup/molecule/default/verify.yml
+++ b/roles/tmux_setup/molecule/default/verify.yml
@@ -29,6 +29,7 @@
           - "'set -g default-terminal \"screen-256color\"' in cfg"
           - "'set -g history-limit 100000' in cfg"
           - "'setw -g mouse on' in cfg"
+          - "\"bind -n WheelUpPane if -Ft= '#{||:#{pane_in_mode},#{mouse_any_flag}}' 'send-keys -M' 'copy-mode -e'\" in cfg"
           - "'set -g set-clipboard on' in cfg"
           - "'setw -g mode-keys vi' in cfg"
           - "'xclip -selection clipboard' in cfg"

--- a/roles/tmux_setup/templates/tmux.conf.j2
+++ b/roles/tmux_setup/templates/tmux.conf.j2
@@ -8,6 +8,12 @@ set -g history-limit {{ tmux_setup_history_limit }}
 # Enable mouse support
 setw -g mouse on
 
+# tmux >= 3.6 adds #{alternate_on} to the default WheelUpPane binding, which
+# forwards wheel events to full-screen apps instead of scrolling tmux history.
+# Pin the pre-3.6 behavior: the wheel always scrolls tmux scrollback unless
+# the app itself enables mouse reporting.
+bind -n WheelUpPane if -Ft= '#{||:#{pane_in_mode},#{mouse_any_flag}}' 'send-keys -M' 'copy-mode -e'
+
 # Prevent mouse selection from crossing pane boundaries
 unbind -n MouseDrag1Pane
 unbind -n MouseDragEnd1Pane


### PR DESCRIPTION
**Key Changes:**

- Restored pre-3.6 tmux wheel-scroll behavior via an explicit WheelUpPane binding so mouse-wheel scrolling continues to page through scrollback instead of being forwarded to full-screen apps
- Hardened `_user_home` / brewfile / install-dir defaults across roles to prefer `ansible_facts['user_dir']` (from `/etc/passwd`) and fall back to `ansible_facts['env']['HOME']`, keeping paths correct under `become`
- Extended `tmux_setup` Molecule verify to assert the new WheelUpPane binding is rendered into `~/.tmux.conf`

**Added:**

- Explicit pre-3.6 wheel binding in the tmux template — `bind -n WheelUpPane if -Ft= '#{||:#{pane_in_mode},#{mouse_any_flag}}' 'send-keys -M' 'copy-mode -e'` in `roles/tmux_setup/templates/tmux.conf.j2`, with a comment explaining the tmux 3.6 `#{alternate_on}` regression it works around
- Molecule assertion for the new WheelUpPane binding in `roles/tmux_setup/molecule/default/verify.yml`

**Changed:**

- Home-directory resolution now prefers `ansible_facts['user_dir']` with an `env.HOME` fallback across `ansible_bootstrap`, `git_setup`, `go_task` (macOS branch of `go_task_install_dir`), `package_management` (`brewfile_dest`), `shell_functions`, and `tmux_setup` defaults, so paths stay pointed at the target user even when running under `become`
- Regenerated role READMEs to reflect the updated default expressions