### PR TITLE
fix: prevent tmux status-left truncation and improve readability

### DIFF
--- a/roles/tmux_setup/templates/tmux.conf.j2
+++ b/roles/tmux_setup/templates/tmux.conf.j2
@@ -67,7 +67,8 @@ set -g mode-style "bg=colour78,fg=colour232"
 # Set status bar
 set -g status-bg black
 set -g status-fg white
-set -g status-left "#[fg=green]Session: #S #[fg=yellow]| #[fg=green]Window: #I #[fg=yellow]| #[fg=green]Pane: #P"
+set -g status-left-length 60
+set -g status-left "#[fg=green]Session: #S #[fg=yellow]| #[fg=cyan]Window: #I #[fg=yellow]| #[fg=magenta]Pane: #P"
 set -g status-right "#{?pane_in_mode,#[fg=yellow][#{pane_mode}]#[default] ,}%Y-%m-%d %H:%M"
 
 # Enable vi keybindings


### PR DESCRIPTION
**Key Changes:**

- Raised status-left character budget to prevent the session/window/pane segment from being truncated in the tmux status bar
- Recolored the Window and Pane labels to visually distinguish the three segments at a glance

**Changed:**

- tmux status bar configuration - Set `status-left-length` to 60 and reassigned `Window` to cyan and `Pane` to magenta in `roles/tmux_setup/templates/tmux.conf.j2`, keeping `Session` green so each segment is independently scannable