### PR TITLE
feat: skip become when target user matches and refine tmux clipboard flow

### DIFF
--- a/playbooks/workstation/workstation.yml
+++ b/playbooks/workstation/workstation.yml
@@ -280,12 +280,16 @@
 
     - name: Render ~/.gitconfig
       role: cowdogmoo.workstation.git_setup
+      tags:
+        - git
       when: git_setup_enabled | default(true) | bool
       # For debugging
       # role: ../../roles/git_setup
 
     - name: Render ~/.tmux.conf
       role: cowdogmoo.workstation.tmux_setup
+      tags:
+        - tmux
       when: tmux_setup_enabled | default(true) | bool
       # For debugging
       # role: ../../roles/tmux_setup

--- a/roles/claude_code/tasks/install-linux.yml
+++ b/roles/claude_code/tasks/install-linux.yml
@@ -30,7 +30,7 @@
     executable: /bin/bash
   environment:
     HOME: "{{ claude_code_user_home }}"
-  become: true
+  become: "{{ claude_code_username != ansible_facts['user_id'] }}"
   become_user: "{{ claude_code_username }}"
   when:
     - claude_code_check.rc != 0
@@ -43,7 +43,7 @@
   register: claude_code_version
   changed_when: false
   failed_when: false
-  become: true
+  become: "{{ claude_code_username != ansible_facts['user_id'] }}"
   become_user: "{{ claude_code_username }}"
 
 - name: Display version

--- a/roles/claude_code/tasks/main.yml
+++ b/roles/claude_code/tasks/main.yml
@@ -41,7 +41,7 @@
     owner: "{{ claude_code_username }}"
     group: "{{ claude_code_usergroup }}"
     mode: "0755"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and claude_code_username != ansible_facts['user_id'] }}"
 
 - name: Install global CLAUDE.md instructions
   ansible.builtin.copy:
@@ -50,7 +50,7 @@
     owner: "{{ claude_code_username }}"
     group: "{{ claude_code_usergroup }}"
     mode: "0644"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and claude_code_username != ansible_facts['user_id'] }}"
 
 - name: Check if settings.json will change (dry-run)
   ansible.builtin.template:
@@ -60,7 +60,7 @@
     group: "{{ claude_code_usergroup }}"
     mode: "0644"
   check_mode: true
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and claude_code_username != ansible_facts['user_id'] }}"
   when: claude_code_manage_settings | bool
   register: claude_code_settings_check
   changed_when: false
@@ -74,7 +74,7 @@
     group: "{{ claude_code_usergroup }}"
     mode: "0644"
     remote_src: true
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and claude_code_username != ansible_facts['user_id'] }}"
   when:
     - claude_code_manage_settings | bool
     - claude_code_backup_settings | bool
@@ -88,7 +88,7 @@
     owner: "{{ claude_code_username }}"
     group: "{{ claude_code_usergroup }}"
     mode: "0644"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and claude_code_username != ansible_facts['user_id'] }}"
   when: claude_code_manage_settings | bool
   register: claude_code_settings_result
 

--- a/roles/claude_code/tasks/manage-mcp-server.yml
+++ b/roles/claude_code/tasks/manage-mcp-server.yml
@@ -19,7 +19,7 @@
     - mcp_server.state | default('present') == 'absent'
     - claude_code_mcp_server_exists | bool
   changed_when: true
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and claude_code_username != ansible_facts['user_id'] }}"
   become_user: "{{ claude_code_username }}"
 
 - name: Build MCP add command - {{ mcp_server.name }}
@@ -47,6 +47,6 @@
     - mcp_server.state | default('present') == 'present'
     - not claude_code_mcp_server_exists | bool
   changed_when: true
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and claude_code_username != ansible_facts['user_id'] }}"
   become_user: "{{ claude_code_username }}"
   no_log: true

--- a/roles/claude_code/tasks/manage-mcp-servers.yml
+++ b/roles/claude_code/tasks/manage-mcp-servers.yml
@@ -19,7 +19,7 @@
   register: claude_code_mcp_list
   changed_when: false
   failed_when: false
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and claude_code_username != ansible_facts['user_id'] }}"
   become_user: "{{ claude_code_username }}"
 
 # The serialized list is deliberately never stored in a fact: set_fact coerces a value

--- a/roles/fabric/tasks/install-go.yml
+++ b/roles/fabric/tasks/install-go.yml
@@ -24,7 +24,7 @@
     go install {{ fabric_go_package }}
   environment:
     HOME: "{{ fabric_user_home }}"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and fabric_username != ansible_facts['user_id'] }}"
   become_user: "{{ fabric_username }}"
   when: fabric_check.rc != 0
   register: fabric_go_install
@@ -35,7 +35,7 @@
   register: fabric_version_check
   changed_when: false
   failed_when: false
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and fabric_username != ansible_facts['user_id'] }}"
   become_user: "{{ fabric_username }}"
 
 - name: Display installed version

--- a/roles/fabric/tasks/install-script.yml
+++ b/roles/fabric/tasks/install-script.yml
@@ -3,7 +3,7 @@
   ansible.builtin.stat:
     path: "{{ fabric_user_home }}/.local/bin/fabric"
   register: fabric_check_script
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and fabric_username != ansible_facts['user_id'] }}"
   become_user: "{{ fabric_username }}"
 
 - name: Install Fabric via official install script
@@ -14,7 +14,7 @@
     executable: /bin/bash
   environment:
     HOME: "{{ fabric_user_home }}"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and fabric_username != ansible_facts['user_id'] }}"
   become_user: "{{ fabric_username }}"
   when: not fabric_check_script.stat.exists
   register: fabric_script_install
@@ -25,7 +25,7 @@
   register: fabric_version_check_script
   changed_when: false
   failed_when: false
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and fabric_username != ansible_facts['user_id'] }}"
   become_user: "{{ fabric_username }}"
   environment:
     HOME: "{{ fabric_user_home }}"

--- a/roles/fabric/tasks/main.yml
+++ b/roles/fabric/tasks/main.yml
@@ -41,7 +41,7 @@
     owner: "{{ fabric_username }}"
     group: "{{ fabric_usergroup }}"
     mode: "0755"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and fabric_username != ansible_facts['user_id'] }}"
   when: fabric_init_directories | bool
 
 - name: Create fabric patterns directory
@@ -51,7 +51,7 @@
     owner: "{{ fabric_username }}"
     group: "{{ fabric_usergroup }}"
     mode: "0755"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and fabric_username != ansible_facts['user_id'] }}"
   when: fabric_init_directories | bool
 
 - name: Manage custom patterns from git repository

--- a/roles/fabric/tasks/manage-custom-patterns.yml
+++ b/roles/fabric/tasks/manage-custom-patterns.yml
@@ -33,7 +33,7 @@
       ansible.builtin.package:
         name: git
         state: present
-      become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+      become: "{{ ansible_facts['os_family'] != 'Darwin' and fabric_username != ansible_facts['user_id'] }}"
       when: not fabric_patterns_is_local | bool
 
     - name: Create temporary directory for custom patterns repository
@@ -89,7 +89,7 @@
         group: "{{ fabric_usergroup }}"
         force: true
       loop: "{{ fabric_custom_pattern_dirs.files }}"
-      become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+      become: "{{ ansible_facts['os_family'] != 'Darwin' and fabric_username != ansible_facts['user_id'] }}"
       when: fabric_custom_patterns_symlink | bool
 
     - name: Copy custom patterns to fabric patterns directory
@@ -101,7 +101,7 @@
         mode: "0755"
         remote_src: true
       loop: "{{ fabric_custom_pattern_dirs.files }}"
-      become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+      become: "{{ ansible_facts['os_family'] != 'Darwin' and fabric_username != ansible_facts['user_id'] }}"
       when: not fabric_custom_patterns_symlink | bool
 
     - name: Check if shared scripts directory exists
@@ -117,7 +117,7 @@
         owner: "{{ fabric_username }}"
         group: "{{ fabric_usergroup }}"
         force: true
-      become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+      become: "{{ ansible_facts['os_family'] != 'Darwin' and fabric_username != ansible_facts['user_id'] }}"
       when:
         - fabric_scripts_source_stat.stat.exists
         - fabric_custom_patterns_symlink | bool
@@ -141,7 +141,7 @@
             owner: "{{ fabric_username }}"
             group: "{{ fabric_usergroup }}"
             mode: "0755"
-          become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+          become: "{{ ansible_facts['os_family'] != 'Darwin' and fabric_username != ansible_facts['user_id'] }}"
 
         - name: Copy shared script files to fabric config directory
           ansible.builtin.copy:
@@ -152,7 +152,7 @@
             mode: "0755"
             remote_src: true
           loop: "{{ fabric_script_files.files }}"
-          become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+          become: "{{ ansible_facts['os_family'] != 'Darwin' and fabric_username != ansible_facts['user_id'] }}"
 
     - name: Create marker file to track installation
       ansible.builtin.copy:
@@ -165,7 +165,7 @@
         owner: "{{ fabric_username }}"
         group: "{{ fabric_usergroup }}"
         mode: "0644"
-      become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+      become: "{{ ansible_facts['os_family'] != 'Darwin' and fabric_username != ansible_facts['user_id'] }}"
 
     - name: Clean up temporary directory
       ansible.builtin.file:

--- a/roles/go_task/README.md
+++ b/roles/go_task/README.md
@@ -16,7 +16,7 @@ Installs go-task (Task runner) on Unix-like and Windows systems
 | Variable | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `go_task_version` | str | <code>latest</code> | No description |
-| `go_task_install_dir` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin') &#124; ternary((ansible_facts&#91;'user_dir'&#93; &#124; default(ansible_facts&#91;'env'&#93;&#91;'HOME'&#93;)) + '/.local/bin', '/usr/local/bin') }}</code> | No description |
+| `go_task_install_dir` | str | <code>{{ (ansible_facts&#91;'os_family'&#93; == 'Darwin' or ansible_facts&#91;'user_id'&#93; != 'root') &#124; ternary((ansible_facts&#91;'user_dir'&#93; &#124; default(ansible_facts&#91;'env'&#93;&#91;'HOME'&#93;)) + '/.local/bin', '/usr/local/bin') }}</code> | No description |
 | `go_task_windows_install_dir` | str | <code>C:\\Program Files\\task</code> | No description |
 | `go_task_windows_add_to_path` | bool | <code>True</code> | No description |
 | `go_task_github_token` | str | <code>{{ lookup('env', 'GITHUB_TOKEN') &#124; default('') }}</code> | No description |

--- a/roles/go_task/defaults/main.yml
+++ b/roles/go_task/defaults/main.yml
@@ -3,7 +3,7 @@
 go_task_version: latest
 
 # Installation directory for Unix-like systems
-go_task_install_dir: "{{ (ansible_facts['os_family'] == 'Darwin') | ternary((ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) + '/.local/bin', '/usr/local/bin') }}"
+go_task_install_dir: "{{ (ansible_facts['os_family'] == 'Darwin' or ansible_facts['user_id'] != 'root') | ternary((ansible_facts['user_dir'] | default(ansible_facts['env']['HOME'])) + '/.local/bin', '/usr/local/bin') }}"
 
 # Installation directory for Windows systems
 go_task_windows_install_dir: C:\\Program Files\\task

--- a/roles/mise/tasks/install_default_pkg_files.yml
+++ b/roles/mise/tasks/install_default_pkg_files.yml
@@ -7,4 +7,4 @@
     group: "{{ mise_usergroup }}"
     mode: "0644"
   loop: "{{ mise_default_pkg_files }}"
-  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' and mise_username != ansible_facts['user_id'] }}"

--- a/roles/tmux_setup/README.md
+++ b/roles/tmux_setup/README.md
@@ -19,7 +19,7 @@ Renders ~/.tmux.conf with mouse-friendly bindings and OSC52 clipboard
 | `tmux_setup_conf_path` | str | <code>{{ tmux_setup_user_home }}/.tmux.conf</code> | No description |
 | `tmux_setup_default_terminal` | str | <code>screen-256color</code> | No description |
 | `tmux_setup_history_limit` | int | <code>100000</code> | No description |
-| `tmux_setup_clipboard_command` | str | <code>{{ 'pbcopy' if ansible_facts&#91;'os_family'&#93; == 'Darwin' else 'xclip -selection clipboard' }}</code> | No description |
+| `tmux_setup_clipboard_command` | str | <code>{{ 'pbcopy' if ansible_facts&#91;'os_family'&#93; == 'Darwin' else '(xclip -selection clipboard 2>/dev/null &#124;&#124; true)' }}</code> | No description |
 | `tmux_setup_backup` | bool | <code>True</code> | No description |
 | `tmux_setup_local_overrides_path` | str | <code>{{ tmux_setup_user_home }}/.tmux.conf.local</code> | No description |
 

--- a/roles/tmux_setup/defaults/main.yml
+++ b/roles/tmux_setup/defaults/main.yml
@@ -13,7 +13,7 @@ tmux_setup_default_terminal: "screen-256color"
 tmux_setup_history_limit: 100000
 
 # Command used by `bind C` to copy the pane buffer to the system clipboard.
-tmux_setup_clipboard_command: "{{ 'pbcopy' if ansible_facts['os_family'] == 'Darwin' else 'xclip -selection clipboard' }}"
+tmux_setup_clipboard_command: "{{ 'pbcopy' if ansible_facts['os_family'] == 'Darwin' else '(xclip -selection clipboard 2>/dev/null || true)' }}"
 
 # Whether to back up an existing ~/.tmux.conf before overwriting it.
 tmux_setup_backup: true

--- a/roles/tmux_setup/templates/tmux.conf.j2
+++ b/roles/tmux_setup/templates/tmux.conf.j2
@@ -19,10 +19,10 @@ unbind -n MouseDrag1Pane
 unbind -n MouseDragEnd1Pane
 bind -n MouseDrag1Pane if -Ft= '#{mouse_any_flag}' 'if -Ft= "#{pane_in_mode}" "copy-mode -M" "send-keys -M"' 'copy-mode -M'
 
-# Copy to clipboard on mouse drag end without leaving copy-mode,
-# so the scroll position and selection are preserved
-bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "{{ tmux_setup_clipboard_command }}"
-bind-key -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "{{ tmux_setup_clipboard_command }}"
+# Releasing the mouse keeps the selection highlighted without copying;
+# nothing reaches the clipboard until 'y' (or Enter) is pressed
+bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X stop-selection
+bind-key -T copy-mode MouseDragEnd1Pane send-keys -X stop-selection
 
 # Customize word separators to include paths and special chars
 set-option -gs word-separators " \t\"'`@"
@@ -47,7 +47,7 @@ bind - split-window -v -c "#{pane_current_path}"
 bind P command-prompt -p "Pane Title:" "select-pane -T '%%'"
 
 # Keybinding to copy entire pane content to clipboard
-bind C run-shell "tmux capture-pane -pS - | {{ tmux_setup_clipboard_command }}" \; display-message "Pane copied to clipboard"
+bind C run-shell "tmux capture-pane -pS - | tmux load-buffer -w -" \; display-message "Pane copied to clipboard"
 
 # Pane borders - make them highly visible
 set -g pane-border-style fg=colour240,bg=colour235
@@ -92,6 +92,8 @@ bind r source-file ~/.tmux.conf
 
 # Enable OSC 52 clipboard for copying over SSH
 set -g set-clipboard on
+set -as terminal-features ',*:clipboard'
+set -as terminal-overrides ',*:Ms=\E]52;%p1%s;%p2%s\007'
 
 # Bind keys 'y' and Enter to copy to system clipboard
 bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "{{ tmux_setup_clipboard_command }}"


### PR DESCRIPTION
**Key Changes:**

- Conditionally skip privilege escalation across claude_code, fabric, mise, and go_task roles when the running user already matches the target user, enabling non-root workstation provisioning
- Reworked tmux clipboard bindings to preserve selections on mouse release and rely on OSC 52 for cross-terminal copy support
- Added `git` and `tmux` tags to the workstation playbook for targeted role invocation

**Added:**

- Tag selectors for git and tmux setup roles in the workstation playbook - `playbooks/workstation/workstation.yml`
- OSC 52 terminal-features and terminal-overrides declarations in the tmux config to broaden clipboard support across terminals - `roles/tmux_setup/templates/tmux.conf.j2`

**Changed:**

- Standardized the `become` conditional on all privileged tasks in `roles/claude_code/`, `roles/fabric/`, and `roles/mise/` to also short-circuit when `*_username` equals `ansible_facts['user_id']`, avoiding unnecessary sudo when the play is already running as the target user
- Updated `go_task_install_dir` default to target the user's `~/.local/bin` whenever the caller is non-root, not just on macOS - `roles/go_task/defaults/main.yml`
- Reworked tmux mouse-drag copy bindings to `stop-selection` so releasing the mouse preserves the highlight without copying, deferring the actual clipboard write to explicit `y`/Enter - `roles/tmux_setup/templates/tmux.conf.j2`
- Switched the `bind C` full-pane copy to `tmux load-buffer -w -` so the buffer flows through the OSC 52 path instead of a local clipboard binary - `roles/tmux_setup/templates/tmux.conf.j2`
- Hardened the default Linux `tmux_setup_clipboard_command` to swallow missing-xclip errors with `(xclip -selection clipboard 2>/dev/null || true)` - `roles/tmux_setup/defaults/main.yml`