### PR TITLE
feat: switch commit and PR workflows to squad-first with fabric fallback

### DIFF
--- a/roles/antigravity/defaults/main.yml
+++ b/roles/antigravity/defaults/main.yml
@@ -124,9 +124,9 @@ antigravity_hooks_default:
       if triggered and op:
           reason = (
               f'BLOCKED: forbidden content {triggered!r} in {op!r} command.\\n\\n'
-              'Use ONLY fabric output:\\n'
-              '  Commits: fabric_commit  (or: git diff --staged | fabric --pattern commit)\\n'
-              '  PRs:     fabric_pr      (or: git diff main...HEAD | fabric --pattern pr)'
+              'Use ONLY squad output:\\n'
+              '  Commits: squad_commit  (or: git diff --staged | squad_gen commit)\\n'
+              '  PRs:     squad_pr      (or: git diff main...HEAD | squad_gen pr)'
           )
           print(json.dumps({'decision': 'deny', 'reason': reason}))
       else:
@@ -166,7 +166,7 @@ antigravity_hooks_default:
 
   # post_commit_check: Safety net for forbidden content that slipped past `forbidden_content`.
   # The PreToolUse hook only sees the literal command string, so it misses messages passed
-  # via `-F file`, stdin pipes (`fabric_commit` uses `git commit -F -`), $variables, editor
+  # via `-F file`, stdin pipes (`squad_commit` uses `git commit -F -`), $variables, editor
   # commits, and squash-merges.
   #
   # This runs on Stop rather than PostToolUse: PostToolUse hooks must emit `{}` and have no

--- a/roles/antigravity/files/GEMINI.md
+++ b/roles/antigravity/files/GEMINI.md
@@ -31,10 +31,12 @@ from the team.
 
 ### Commits
 
-Always use `fabric_commit` for commit messages:
+Always use `squad_commit` for commit messages (billed to the Claude
+subscription via squad's claude-code provider). If it fails, fall back to
+`fabric_commit` (API-billed):
 
 ```bash
-fabric_commit
+squad_commit
 ```
 
 **NEVER EVER use --no-verify when committing or there will be dire consequences!**
@@ -46,27 +48,24 @@ fabric_commit
 
 ### Pull Requests
 
-Always use the `fabric_pr` function to create pull requests:
+Always use `squad_pr` for pull requests — both to **open** them and to **update** them (billed to the Claude subscription; fall back to `fabric_pr` if it fails). `squad_pr` regenerates the title/body from the current `git diff main`, then creates the PR or, if one already exists for the branch, updates that PR in place.
 
 ```bash
-fabric_pr
+squad_pr
 ```
 
-**CRITICAL POST-CREATION VERIFICATION**:
+**The PR title and body must ALWAYS be `squad_pr`'s generated output. NEVER hand-write or hand-edit them.**
 
-After `fabric_pr` creates the PR, you MUST verify and fix if needed:
+- Any time the branch changes — after a **rebase, amend, new commits, or force-push** — the existing body is stale. Re-run `squad_pr`; it regenerates from the new diff and updates the existing PR. This is the ONLY correct way to refresh a PR body.
+- Do **not** run `gh pr edit --body "..."` (or `--title`) with text you wrote yourself, and do not "clean up", "correct", or "just fix" the body by hand. Substituting your own writing for the generated output breaks this rule no matter how small the change. If the body needs to change, re-run `squad_pr`.
 
-1. **Check the created PR** using `gh pr view` to see the title and body
-2. **Verify requirements**:
-   - **No code fences (```)** in the title or body
-   - **No duplicate title** - the title text must NOT appear in the body
-3. **If violations found**, update the PR immediately using `gh pr edit`:
+**Format verification — after every `squad_pr`:**
 
-   ```bash
-   gh pr edit --body "corrected body without code fences or duplicate title"
-   ```
+1. Check the PR with `gh pr view`.
+2. Confirm the generated output is clean: **no code fences (```)** in the title or body, and the **title is not duplicated** in the body.
+3. If the output is malformed, the bug is in the `pr` pattern or the filter — both live in `~/cowdogmoo/fabric-patterns-hub` (`patterns/pr/system.md`, `scripts/filter.py`) — fix it at the source and re-run `squad_pr`. Never patch the symptom by hand-editing the PR.
 
-The `fabric_pr` function should handle these automatically, but you must verify and correct any issues in the created PR.
+Both `squad_pr` and `fabric_pr` share the same patterns and filters from `~/cowdogmoo/fabric-patterns-hub`, so a source fix applies to both.
 
 ## Modern CLI Tools
 

--- a/roles/claude_code/defaults/main.yml
+++ b/roles/claude_code/defaults/main.yml
@@ -79,9 +79,9 @@ claude_code_advanced_hooks_default:
       if triggered and op:
           msg = (
               f'❌ BLOCKED: forbidden content {triggered!r} in {op!r} command.\\n\\n'
-              '✅ Use ONLY fabric output:\\n'
-              '  Commits: fabric_commit  (or: git diff --staged | fabric --pattern commit)\\n'
-              '  PRs:     fabric_pr      (or: git diff main...HEAD | fabric --pattern pr)'
+              '✅ Use ONLY squad output:\\n'
+              '  Commits: squad_commit  (or: git diff --staged | squad_gen commit)\\n'
+              '  PRs:     squad_pr      (or: git diff main...HEAD | squad_gen pr)'
           )
           sys.stderr.write(msg + '\\n')
           sys.exit(2)
@@ -120,7 +120,7 @@ claude_code_advanced_hooks_default:
 
   # post_commit_check: Post-commit safety net — catches forbidden content that slipped past
   # `forbidden_content`. The PreToolUse hook only sees the literal command string, so it misses
-  # messages passed via `-F file`, stdin pipes (`fabric_commit` uses `git commit -F -`),
+  # messages passed via `-F file`, stdin pipes (`squad_commit` uses `git commit -F -`),
   # $variables, editor commits, and squash-merges. This PostToolUse hook runs after any
   # commit-creating command and inspects the resulting commit message; if forbidden content
   # landed, it tells Claude to amend before pushing.
@@ -143,6 +143,7 @@ claude_code_advanced_hooks_default:
           r'\bgit\s+cherry-pick\b',
           r'\bgit\s+rebase\b',
           r'\bgit\s+merge\b',
+          r'\bsquad_commit\b',
           r'\bfabric_commit\b',
       ]
       if not any(re.search(p, cmd) for p in commit_patterns):

--- a/roles/claude_code/files/CLAUDE.md
+++ b/roles/claude_code/files/CLAUDE.md
@@ -30,10 +30,12 @@ since that hides shared agents, skills, and settings from the team.
 
 ### Commits
 
-Always use `fabric_commit` for commit messages:
+Always use `squad_commit` for commit messages (billed to the Claude
+subscription via squad's claude-code provider). If it fails, fall back to
+`fabric_commit` (API-billed):
 
 ```bash
-fabric_commit
+squad_commit
 ```
 
 **NEVER EVER use --no-verify when committing or there will be dire consequences!**
@@ -45,22 +47,24 @@ fabric_commit
 
 ### Pull Requests
 
-Always use `fabric_pr` for pull requests — both to **open** them and to **update** them. `fabric_pr` regenerates the title/body from the current `git diff main`, then creates the PR or, if one already exists for the branch, updates that PR in place.
+Always use `squad_pr` for pull requests — both to **open** them and to **update** them (billed to the Claude subscription; fall back to `fabric_pr` if it fails). `squad_pr` regenerates the title/body from the current `git diff main`, then creates the PR or, if one already exists for the branch, updates that PR in place.
 
 ```bash
-fabric_pr
+squad_pr
 ```
 
-**The PR title and body must ALWAYS be `fabric_pr`'s generated output. NEVER hand-write or hand-edit them.**
+**The PR title and body must ALWAYS be `squad_pr`'s generated output. NEVER hand-write or hand-edit them.**
 
-- Any time the branch changes — after a **rebase, amend, new commits, or force-push** — the existing body is stale. Re-run `fabric_pr`; it regenerates from the new diff and updates the existing PR. This is the ONLY correct way to refresh a PR body.
-- Do **not** run `gh pr edit --body "..."` (or `--title`) with text you wrote yourself, and do not "clean up", "correct", or "just fix" the body by hand. Substituting your own writing for fabric's output breaks this rule no matter how small the change. If the body needs to change, re-run `fabric_pr`.
+- Any time the branch changes — after a **rebase, amend, new commits, or force-push** — the existing body is stale. Re-run `squad_pr`; it regenerates from the new diff and updates the existing PR. This is the ONLY correct way to refresh a PR body.
+- Do **not** run `gh pr edit --body "..."` (or `--title`) with text you wrote yourself, and do not "clean up", "correct", or "just fix" the body by hand. Substituting your own writing for the generated output breaks this rule no matter how small the change. If the body needs to change, re-run `squad_pr`.
 
-**Format verification — after every `fabric_pr`:**
+**Format verification — after every `squad_pr`:**
 
 1. Check the PR with `gh pr view`.
-2. Confirm the fabric output is clean: **no code fences (```)** in the title or body, and the **title is not duplicated** in the body.
-3. If the output is malformed, the bug is in the fabric `pr` pattern or its `filter.sh` (`~/.config/fabric/patterns/pr/filter.sh`) — fix it at the source and re-run `fabric_pr`. Never patch the symptom by hand-editing the PR.
+2. Confirm the generated output is clean: **no code fences (```)** in the title or body, and the **title is not duplicated** in the body.
+3. If the output is malformed, the bug is in the `pr` pattern or the filter — both live in `~/cowdogmoo/fabric-patterns-hub` (`patterns/pr/system.md`, `scripts/filter.py`) — fix it at the source and re-run `squad_pr`. Never patch the symptom by hand-editing the PR.
+
+Both `squad_pr` and `fabric_pr` share the same patterns and filters from `~/cowdogmoo/fabric-patterns-hub`, so a source fix applies to both.
 
 ## Modern CLI Tools
 

--- a/roles/claude_code/molecule/default/verify.yml
+++ b/roles/claude_code/molecule/default/verify.yml
@@ -120,7 +120,7 @@
           - "'.claude Directory and Version Control' in (claude_code_claude_md_content['content'] | b64decode)"
           - "'settings.local.json' in (claude_code_claude_md_content['content'] | b64decode)"
           - "'Git Workflow' in (claude_code_claude_md_content['content'] | b64decode)"
-          - "'fabric' in (claude_code_claude_md_content['content'] | b64decode)"
+          - "'squad_commit' in (claude_code_claude_md_content['content'] | b64decode)"
           - "'--no-verify' in (claude_code_claude_md_content['content'] | b64decode)"
         fail_msg: "CLAUDE.md does not contain expected instructions"
         success_msg: "CLAUDE.md contains all expected global instructions"


### PR DESCRIPTION
**Key Changes:**

- Promoted `squad_commit` and `squad_pr` as the primary commit/PR tooling (Claude-subscription billed), with `fabric_commit`/`fabric_pr` as API-billed fallbacks
- Updated hook forbidden-content messages across `antigravity` and `claude_code` roles to steer users toward `squad_gen` output
- Repointed the fabric pattern/filter source of truth to `~/cowdogmoo/fabric-patterns-hub` (`patterns/pr/system.md`, `scripts/filter.py`) and hardened the post-commit check to also match `squad_commit`

**Changed:**

- Commit/PR guidance in `roles/claude_code/files/CLAUDE.md` and `roles/antigravity/files/GEMINI.md` now leads with `squad_commit`/`squad_pr`, explains billing, and preserves the "never hand-edit generated output" rule while noting that both squad and fabric share the same patterns
- Forbidden-content hook denial messages in `roles/antigravity/defaults/main.yml` and `roles/claude_code/defaults/main.yml` reference the squad workflow (`squad_commit`, `squad_pr`, `squad_gen commit`, `squad_gen pr`) instead of the fabric CLI
- Post-commit safety-net comments and pattern list in `roles/claude_code/defaults/main.yml` now include `\bsquad_commit\b` so stdin-piped squad commits are also inspected for forbidden content
- Molecule assertion in `roles/claude_code/molecule/default/verify.yml` tightened from the generic `'fabric'` substring to `'squad_commit'`, matching the new primary workflow in the deployed CLAUDE.md