### PR TITLE
fix: rescue unparseable antigravity MCP config with block/rescue

### DIFF
--- a/roles/antigravity/README.md
+++ b/roles/antigravity/README.md
@@ -92,7 +92,8 @@ Manages Antigravity CLI configuration including hooks and settings
 
 - **Check for existing MCP configuration** (ansible.builtin.stat)
 - **Read existing MCP configuration** (ansible.builtin.slurp) - Conditional
-- **Parse existing MCP servers** (ansible.builtin.set_fact)
+- **Parse existing MCP servers** (block)
+- **Extract mcpServers from the existing configuration** (ansible.builtin.set_fact)
 - **Determine whether 1Password resolution is needed** (ansible.builtin.set_fact)
 - **Check for the 1Password CLI** (ansible.builtin.command) - Conditional
 - **Fail with guidance when op:// references are required but unresolvable** (ansible.builtin.fail) - Conditional

--- a/roles/antigravity/tasks/manage-mcp-servers.yml
+++ b/roles/antigravity/tasks/manage-mcp-servers.yml
@@ -30,16 +30,30 @@
   become: "{{ ansible_facts['os_family'] != 'Darwin' and antigravity_username != ansible_facts['user_id'] }}"
   no_log: true
 
-# A hand-corrupted or half-written mcp_config.json would otherwise blow up the
-# from_json below with an unhelpful template error, so fall back to an empty map
-# and let the write task rebuild the file from scratch.
+# A hand-corrupted or half-written mcp_config.json blows up the from_json below,
+# and `failed_when` cannot rescue that: the expression fails while templating the
+# task's own argument, before a result exists for `failed_when` to judge. Only
+# block/rescue catches it — fall back to an empty map and let the write task
+# rebuild the file from scratch.
 - name: Parse existing MCP servers
-  ansible.builtin.set_fact:
-    antigravity_mcp_existing_servers: >-
-      {{ (antigravity_mcp_existing['content'] | b64decode | from_json).get('mcpServers', {})
-         if antigravity_mcp_config_stat.stat.exists else {} }}
-  failed_when: false
-  no_log: true
+  block:
+    - name: Extract mcpServers from the existing configuration
+      ansible.builtin.set_fact:
+        antigravity_mcp_existing_servers: >-
+          {{ (antigravity_mcp_existing['content'] | b64decode | from_json).get('mcpServers', {})
+             if antigravity_mcp_config_stat.stat.exists else {} }}
+      no_log: true
+  rescue:
+    - name: Warn that the existing MCP configuration is unreadable
+      ansible.builtin.debug:
+        msg: >-
+          {{ antigravity_mcp_config_file }} exists but does not parse as a JSON object;
+          rebuilding it from antigravity_mcp_servers. Servers added by hand to the old
+          file are not preserved this run.
+
+    - name: Fall back to an empty MCP server map
+      ansible.builtin.set_fact:
+        antigravity_mcp_existing_servers: {}
 
 # Detected from the source vars rather than the rendered document. Existing on-disk
 # servers are included so references left behind by an interrupted run still get resolved.


### PR DESCRIPTION
**Key Changes:**

- Replaced the ineffective `failed_when: false` guard on MCP config parsing with a proper block/rescue structure that actually catches template-time JSON parse failures
- Added an explicit fallback path that warns the operator and rebuilds the config from scratch when the existing `mcp_config.json` is corrupted or malformed
- Updated role documentation to reflect the new task structure

**Changed:**

- MCP server parsing logic in `roles/antigravity/tasks/manage-mcp-servers.yml` — restructured the `Parse existing MCP servers` task into a block that extracts `mcpServers` from the existing configuration, with a rescue clause that emits a debug warning about hand-added servers not being preserved and falls back to an empty map
- Inline comment rewritten to explain *why* block/rescue is required: `failed_when` cannot rescue a failure that occurs while templating the task's own argument, before a result exists to judge
- Role README task listing in `roles/antigravity/README.md` — updated to show the new block wrapper and the nested `Extract mcpServers from the existing configuration` set_fact task