### PR TITLE
feat: enhance tmux status bar formatting and session name display

### DIFF
--- a/roles/tmux_setup/molecule/default/verify.yml
+++ b/roles/tmux_setup/molecule/default/verify.yml
@@ -32,6 +32,9 @@
           - "\"bind -n WheelUpPane if -Ft= '#{||:#{pane_in_mode},#{mouse_any_flag}}' 'send-keys -M' 'copy-mode -e'\" in cfg"
           - "'set -g set-clipboard on' in cfg"
           - "'setw -g mode-keys vi' in cfg"
+          - "'set -g status-left-length 80' in cfg"
+          - "'Session: #{=/32/…:session_name}' in cfg"
+          - "'Pane: #P #[fg=yellow]|#[default] ' in cfg"
           - "'xclip -selection clipboard' in cfg"
           - "'source-file -q ' + tmux_setup_local_overrides_path in cfg"
         quiet: true

--- a/roles/tmux_setup/templates/tmux.conf.j2
+++ b/roles/tmux_setup/templates/tmux.conf.j2
@@ -67,8 +67,11 @@ set -g mode-style "bg=colour78,fg=colour232"
 # Set status bar
 set -g status-bg black
 set -g status-fg white
-set -g status-left-length 60
-set -g status-left "#[fg=green]Session: #S #[fg=yellow]| #[fg=cyan]Window: #I #[fg=yellow]| #[fg=magenta]Pane: #P "
+# Cap the displayed session name and give status-left enough room that it can
+# never be hard-truncated; the trailing "| " keeps the window list from
+# rendering flush against (clobbering) the status-left text.
+set -g status-left-length 80
+set -g status-left "#[fg=green]Session: #{=/32/…:session_name} #[fg=yellow]| #[fg=cyan]Window: #I #[fg=yellow]| #[fg=magenta]Pane: #P #[fg=yellow]|#[default] "
 set -g status-right "#{?pane_in_mode,#[fg=yellow][#{pane_mode}]#[default] ,}%Y-%m-%d %H:%M"
 
 # Enable vi keybindings

--- a/roles/tmux_setup/templates/tmux.conf.j2
+++ b/roles/tmux_setup/templates/tmux.conf.j2
@@ -68,7 +68,7 @@ set -g mode-style "bg=colour78,fg=colour232"
 set -g status-bg black
 set -g status-fg white
 set -g status-left-length 60
-set -g status-left "#[fg=green]Session: #S #[fg=yellow]| #[fg=cyan]Window: #I #[fg=yellow]| #[fg=magenta]Pane: #P"
+set -g status-left "#[fg=green]Session: #S #[fg=yellow]| #[fg=cyan]Window: #I #[fg=yellow]| #[fg=magenta]Pane: #P "
 set -g status-right "#{?pane_in_mode,#[fg=yellow][#{pane_mode}]#[default] ,}%Y-%m-%d %H:%M"
 
 # Enable vi keybindings


### PR DESCRIPTION
**Key Changes:**

- Increased the maximum length of the left status bar to prevent hard truncation
- Implemented smart truncation for long session names at 32 characters
- Added a trailing separator to prevent text overlap between the left status bar and the window list

**Changed:**

- Status bar layout - Updated tmux.conf.j2 to expand the left status length to 80, introduce a formatting directive for capping the session name length, and append a trailing pipe separator for better visual spacing
- Configuration verification - Added new string matching assertions in verify.yml to ensure the updated status bar length and formatting rules are correctly generated