### PR TITLE
feat: allow custom rule sources and content for agent configurations

### DIFF
--- a/roles/antigravity/README.md
+++ b/roles/antigravity/README.md
@@ -20,6 +20,8 @@ Manages Antigravity CLI configuration including hooks and settings
 | `antigravity_user_home` | str | <code><multiline value: folded_strip></code> | No description |
 | `antigravity_config_dir` | str | <code>{{ antigravity_user_home }}/.gemini/config</code> | No description |
 | `antigravity_rules_file` | str | <code>{{ antigravity_user_home }}/.gemini/GEMINI.md</code> | No description |
+| `antigravity_rules_src` | str | <code>GEMINI.md</code> | No description |
+| `antigravity_rules_content` | str | <code></code> | No description |
 | `antigravity_hooks_file` | str | <code>{{ antigravity_config_dir }}/hooks.json</code> | No description |
 | `antigravity_mcp_config_file` | str | <code>{{ antigravity_config_dir }}/mcp_config.json</code> | No description |
 | `antigravity_homebrew_prefix` | str | <code><multiline value: folded_strip></code> | No description |

--- a/roles/antigravity/defaults/main.yml
+++ b/roles/antigravity/defaults/main.yml
@@ -14,6 +14,16 @@ antigravity_config_dir: "{{ antigravity_user_home }}/.gemini/config"
 # the only globally-scoped rules path Google documents.
 antigravity_rules_file: "{{ antigravity_user_home }}/.gemini/GEMINI.md"
 
+# Source file for global GEMINI.md instructions.
+# Defaults to GEMINI.md from the role's files/ directory.
+# Point to a custom path (e.g. `{{ playbook_dir }}/files/GEMINI.md`) or set
+# `antigravity_rules_content` to supply custom instructions per-host or from a private playbook.
+antigravity_rules_src: "GEMINI.md"
+
+# Optional raw content for global GEMINI.md instructions.
+# If non-empty, this takes precedence over antigravity_rules_src.
+antigravity_rules_content: ""
+
 # Unlike Claude Code — which nests hooks inside ~/.claude/settings.json — Antigravity
 # reads hooks from a dedicated file in the customization root. Versions of agy before
 # 1.0.8 wrote this to ~/.gemini/antigravity-cli/hooks.json via the /hooks command;

--- a/roles/antigravity/tasks/main.yml
+++ b/roles/antigravity/tasks/main.yml
@@ -56,13 +56,16 @@
 
 - name: Install global GEMINI.md instructions
   ansible.builtin.copy:
-    src: GEMINI.md
+    src: "{{ antigravity_rules_src if (antigravity_rules_content | default('') | length == 0) else omit }}"
+    content: "{{ antigravity_rules_content if (antigravity_rules_content | default('') | length > 0) else omit }}"
     dest: "{{ antigravity_rules_file }}"
     owner: "{{ antigravity_username }}"
     group: "{{ antigravity_usergroup }}"
     mode: "0644"
   become: "{{ ansible_facts['os_family'] != 'Darwin' and antigravity_username != ansible_facts['user_id'] }}"
-  when: antigravity_manage_settings | bool
+  when:
+    - antigravity_manage_settings | bool
+    - (antigravity_rules_src | default('') | length > 0) or (antigravity_rules_content | default('') | length > 0)
 
 - name: Check if hooks.json will change (dry-run)
   ansible.builtin.template:

--- a/roles/claude_code/README.md
+++ b/roles/claude_code/README.md
@@ -19,6 +19,9 @@ Manages Claude Code CLI configuration including hooks and settings
 | `claude_code_usergroup` | str | <code>{{ (ansible_facts&#91;'user_gid'&#93; &#124; default('staff')) if ansible_facts&#91;'os_family'&#93; == 'Darwin' else claude_code_username }}</code> | No description |
 | `claude_code_user_home` | str | <code><multiline value: folded_strip></code> | No description |
 | `claude_code_config_dir` | str | <code>{{ claude_code_user_home }}/.claude</code> | No description |
+| `claude_code_rules_file` | str | <code>{{ claude_code_config_dir }}/CLAUDE.md</code> | No description |
+| `claude_code_rules_src` | str | <code>CLAUDE.md</code> | No description |
+| `claude_code_rules_content` | str | <code></code> | No description |
 | `claude_code_homebrew_prefix` | str | <code><multiline value: folded_strip></code> | No description |
 | `claude_code_path` | str | <code>{{ claude_code_homebrew_prefix }}/bin:{{ claude_code_user_home }}/.local/bin:/usr/local/bin:/usr/bin:/bin</code> | No description |
 | `claude_code_install` | bool | <code>True</code> | No description |

--- a/roles/claude_code/README.md
+++ b/roles/claude_code/README.md
@@ -80,7 +80,7 @@ Manages Claude Code CLI configuration including hooks and settings
 - **Install Claude Code on Linux** (ansible.builtin.include_tasks) - Conditional
 - **Install Claude Code on Windows** (ansible.builtin.include_tasks) - Conditional
 - **Create Claude Code configuration directory** (ansible.builtin.file)
-- **Install global CLAUDE.md instructions** (ansible.builtin.copy)
+- **Install global CLAUDE.md instructions** (ansible.builtin.copy) - Conditional
 - **Check if settings.json will change (dry-run)** (ansible.builtin.template) - Conditional
 - **Create backup of existing settings.json in /tmp** (ansible.builtin.copy) - Conditional
 - **Generate Claude Code settings.json** (ansible.builtin.template) - Conditional

--- a/roles/claude_code/defaults/main.yml
+++ b/roles/claude_code/defaults/main.yml
@@ -10,6 +10,19 @@ claude_code_user_home: >-
 # Configuration directory for Claude Code
 claude_code_config_dir: "{{ claude_code_user_home }}/.claude"
 
+# Global rules file for Claude Code instructions.
+claude_code_rules_file: "{{ claude_code_config_dir }}/CLAUDE.md"
+
+# Source file for global CLAUDE.md instructions.
+# Defaults to CLAUDE.md from the role's files/ directory.
+# Point to a custom path (e.g. `{{ playbook_dir }}/files/CLAUDE.md`) or set
+# `claude_code_rules_content` to supply custom instructions per-host or from a private playbook.
+claude_code_rules_src: "CLAUDE.md"
+
+# Optional raw content for global CLAUDE.md instructions.
+# If non-empty, this takes precedence over claude_code_rules_src.
+claude_code_rules_content: ""
+
 # Homebrew prefix (varies by OS/architecture)
 # macOS ARM: /opt/homebrew, macOS Intel: /usr/local, Linux: /home/linuxbrew/.linuxbrew
 claude_code_homebrew_prefix: >-

--- a/roles/claude_code/tasks/main.yml
+++ b/roles/claude_code/tasks/main.yml
@@ -45,12 +45,16 @@
 
 - name: Install global CLAUDE.md instructions
   ansible.builtin.copy:
-    src: CLAUDE.md
-    dest: "{{ claude_code_config_dir }}/CLAUDE.md"
+    src: "{{ claude_code_rules_src if (claude_code_rules_content | default('') | length == 0) else omit }}"
+    content: "{{ claude_code_rules_content if (claude_code_rules_content | default('') | length > 0) else omit }}"
+    dest: "{{ claude_code_rules_file }}"
     owner: "{{ claude_code_username }}"
     group: "{{ claude_code_usergroup }}"
     mode: "0644"
   become: "{{ ansible_facts['os_family'] != 'Darwin' and claude_code_username != ansible_facts['user_id'] }}"
+  when:
+    - claude_code_manage_settings | bool
+    - (claude_code_rules_src | default('') | length > 0) or (claude_code_rules_content | default('') | length > 0)
 
 - name: Check if settings.json will change (dry-run)
   ansible.builtin.template:


### PR DESCRIPTION
**Key Changes:**

- Introduced support for customizing global instruction files for both Antigravity (`GEMINI.md`) and Claude Code (`CLAUDE.md`)
- Enabled defining rules from either custom source paths or raw inline content strings
- Updated installation tasks to conditionally apply rules based on variable presence

**Added:**

- Custom rule source configuration - Added `_rules_src` and `_rules_content` variables to both roles to allow users to specify external files or inline text for agent instructions
- Claude Code rules file path - Added `claude_code_rules_file` variable to parameterize the destination path of `CLAUDE.md`

**Changed:**

- Rule installation logic - Modified `tasks/main.yml` in both roles to dynamically use either the source file path or raw content, replacing hardcoded source values
- Task execution conditions - Updated `when` clauses on rule installation tasks to ensure they only run when a source file or content is explicitly defined alongside the settings management flag