### PR TITLE
fix: harden CI molecule retries and make claude_code install idempotent

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -545,7 +545,10 @@ jobs:
           molecule list
 
           # Retry up to 3 times when failures look like transient network issues
-          # (github.com flakes downloading release assets, etc.).
+          # (github.com flakes downloading release assets, curl connection
+          # resets) or container-boot races (systemd-tmpfiles wiping /tmp while
+          # the first fact-gathering module is still importing its payload,
+          # which surfaces as "Module result deserialization failed").
           max_attempts=3
           attempt=1
           run_log=$(mktemp)
@@ -561,7 +564,7 @@ jobs:
             if [[ ${rc} -eq 0 ]]; then
               break
             fi
-            if [[ ${attempt} -ge ${max_attempts} ]] || ! grep -qE "Connection failure|Gateway Time-out|read operation timed out|HTTP Error 5[0-9][0-9]|Could not resolve host|Temporary failure in name resolution" "${run_log}"; then
+            if [[ ${attempt} -ge ${max_attempts} ]] || ! grep -qE "Connection failure|Gateway Time-out|read operation timed out|HTTP Error 5[0-9][0-9]|Could not resolve host|Temporary failure in name resolution|Connection reset by peer|Recv failure|Module result deserialization failed" "${run_log}"; then
               echo "Molecule test failed. Collecting debug information..."
 
               echo "Docker containers:"
@@ -583,7 +586,7 @@ jobs:
 
               exit 1
             fi
-            echo "Transient network failure detected; retrying in 30s..."
+            echo "Transient failure detected; retrying in 30s..."
             sleep 30
             attempt=$((attempt + 1))
           done

--- a/roles/claude_code/README.md
+++ b/roles/claude_code/README.md
@@ -46,6 +46,7 @@ Manages Claude Code CLI configuration including hooks and settings
 
 
 - **Check if already installed** (ansible.builtin.command)
+- **Check for user-local install** (ansible.builtin.stat)
 - **Check if npm is available** (ansible.builtin.command) - Conditional
 - **Install via npm** (community.general.npm) - Conditional
 - **Install via script (fallback)** (ansible.builtin.shell) - Conditional

--- a/roles/claude_code/tasks/install-linux.yml
+++ b/roles/claude_code/tasks/install-linux.yml
@@ -5,12 +5,22 @@
   changed_when: false
   failed_when: false
 
+# The install script drops the binary in the target user's ~/.local/bin, which
+# is not on the PATH `which` searches above — without this check every rerun
+# re-downloads the installer.
+- name: Check for user-local install
+  ansible.builtin.stat:
+    path: "{{ claude_code_user_home }}/.local/bin/claude"
+  register: claude_code_local_install
+
 - name: Check if npm is available
   ansible.builtin.command: which npm
   register: claude_code_npm_check
   changed_when: false
   failed_when: false
-  when: claude_code_check.rc != 0
+  when:
+    - claude_code_check.rc != 0
+    - not claude_code_local_install.stat.exists
 
 - name: Install via npm
   community.general.npm:
@@ -20,6 +30,7 @@
   become: true
   when:
     - claude_code_check.rc != 0
+    - not claude_code_local_install.stat.exists
     - claude_code_npm_check.rc == 0
 
 - name: Install via script (fallback)
@@ -34,8 +45,12 @@
   become_user: "{{ claude_code_username }}"
   when:
     - claude_code_check.rc != 0
+    - not claude_code_local_install.stat.exists
     - claude_code_npm_check.rc != 0
   register: claude_code_script_install
+  retries: 3
+  delay: 10
+  until: claude_code_script_install.rc == 0
   changed_when: "'Successfully installed' in claude_code_script_install.stdout"
 
 - name: Verify installation


### PR DESCRIPTION
**Key Changes:**

- Broadened the molecule CI retry matcher to cover connection resets and container-boot deserialization races, so runs that fail for non-deterministic reasons get another attempt instead of failing the job
- Made the Linux claude_code install detect a pre-existing `~/.local/bin/claude` binary, eliminating a redundant installer download on every rerun
- Added retry-with-backoff around the claude_code install-script fallback to absorb transient download failures

**Added:**

- User-local install detection — a `stat` check on `{{ claude_code_user_home }}/.local/bin/claude` gates the npm check, npm install, and script-fallback tasks, since the install script drops the binary outside the PATH that `which` searches (`roles/claude_code/tasks/install-linux.yml`, documented in the role README)
- Retry loop on the install-script fallback — 3 attempts with a 10s delay, gated on `rc == 0`

**Changed:**

- Retry-eligible failure patterns in the molecule workflow now include `Connection reset by peer`, `Recv failure`, and `Module result deserialization failed`, the last covering systemd-tmpfiles wiping `/tmp` while the first fact-gathering module is still importing its payload (`.github/workflows/molecule.yaml`)
- Retry messaging and the surrounding comment reworded from "transient network failure" to "transient failure" to reflect that boot races, not just network flakes, now trigger a retry